### PR TITLE
DynProvider Traffic Directors want lowercase province without country

### DIFF
--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -531,8 +531,7 @@ class DynProvider(BaseProvider):
         for _, geo in geos:
             if geo.subdivision_code:
                 criteria = {
-                    'country': geo.country_code,
-                    'province': geo.subdivision_code
+                    'province': geo.subdivision_code.lower()
                 }
             elif geo.country_code:
                 criteria = {


### PR DESCRIPTION
`province` is globally unique and required to be lowercase.