### PR TITLE
Route53 geo conv fixes

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -90,7 +90,8 @@ class _Route53Record(object):
         elif self.geo:
             geo = self.geo
             rrset['SetIdentifier'] = geo.code
-            rrset['HealthCheckId'] = self.health_check_id
+            if self.health_check_id:
+                rrset['HealthCheckId'] = self.health_check_id
             if geo.subdivision_code:
                 rrset['GeoLocation'] = {
                     'CountryCode': geo.country_code,

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -90,8 +90,7 @@ class _Route53Record(object):
         elif self.geo:
             geo = self.geo
             rrset['SetIdentifier'] = geo.code
-            if self.health_check_id:
-                rrset['HealthCheckId'] = self.health_check_id
+            rrset['HealthCheckId'] = self.health_check_id
             if geo.subdivision_code:
                 rrset['GeoLocation'] = {
                     'CountryCode': geo.country_code,

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -699,6 +699,13 @@ class TestRoute53Provider(TestCase):
                 'AF': ['4.2.3.4'],
             }
         })
+
+        # if not allowed to create returns none
+        id = provider._get_health_check_id(record, 'AF', record.geo['AF'],
+                                           False)
+        self.assertFalse(id)
+
+        # when allowed to create we do
         id = provider._get_health_check_id(record, 'AF', record.geo['AF'],
                                            True)
         self.assertEquals('42', id)

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -500,6 +500,70 @@ class TestRoute53Provider(TestCase):
         self.assertEquals(1, provider.apply(plan))
         stubber.assert_no_pending_responses()
 
+        # Update converting to non-geo by monkey patching in a populate that
+        # modifies the A record with geos
+        def mod_add_geo_populate(existing, target):
+            for record in self.expected.records:
+                if record._type != 'A' or record.geo:
+                    existing.records.add(record)
+            record = Record.new(existing, 'simple', {
+                'ttl': 61,
+                'type': 'A',
+                'values': ['1.2.3.4', '2.2.3.4'],
+                'geo': {
+                    'OC': ['3.2.3.4', '4.2.3.4'],
+                }
+            })
+            existing.records.add(record)
+
+        provider.populate = mod_add_geo_populate
+        change_resource_record_sets_params = {
+            'ChangeBatch': {
+                'Changes': [{
+                    'Action': 'DELETE',
+                    'ResourceRecordSet': {
+                        'GeoLocation': {'ContinentCode': 'OC'},
+                        'Name': 'simple.unit.tests.',
+                        'ResourceRecords': [{'Value': '3.2.3.4'},
+                                            {'Value': '4.2.3.4'}],
+                        'SetIdentifier': 'OC',
+                        'TTL': 61,
+                        'Type': 'A'}
+                }, {
+                    'Action': 'DELETE',
+                    'ResourceRecordSet': {
+                        'GeoLocation': {'CountryCode': '*'},
+                        'Name': 'simple.unit.tests.',
+                        'ResourceRecords': [{'Value': '1.2.3.4'},
+                                            {'Value': '2.2.3.4'}],
+                        'SetIdentifier': 'default',
+                        'TTL': 61,
+                        'Type': 'A'}
+                }, {
+                    'Action': 'CREATE',
+                    'ResourceRecordSet': {
+                        'Name': 'simple.unit.tests.',
+                        'ResourceRecords': [{'Value': '1.2.3.4'},
+                                            {'Value': '2.2.3.4'}],
+                        'TTL': 60,
+                        'Type': 'A'}
+                }],
+                'Comment': ANY
+            },
+            'HostedZoneId': 'z42'
+        }
+        stubber.add_response('change_resource_record_sets',
+                             {'ChangeInfo': {
+                                 'Id': 'id',
+                                 'Status': 'PENDING',
+                                 'SubmittedAt': '2017-01-29T01:02:03Z',
+                             }}, change_resource_record_sets_params)
+        plan = provider.plan(self.expected)
+        self.assertEquals(1, len(plan.changes))
+        self.assertIsInstance(plan.changes[0], Update)
+        self.assertEquals(1, provider.apply(plan))
+        stubber.assert_no_pending_responses()
+
     def test_sync_create(self):
         provider, stubber = self._get_stubbed_provider()
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -430,6 +430,7 @@ class TestRoute53Provider(TestCase):
                     'ResourceRecordSet': {
                         'GeoLocation': {'CountryCode': 'US',
                                         'SubdivisionCode': 'KY'},
+                        'HealthCheckId': u'44',
                         'Name': 'unit.tests.',
                         'ResourceRecords': [{'Value': '7.2.3.4'}],
                         'SetIdentifier': 'NA-US-KY',
@@ -629,7 +630,8 @@ class TestRoute53Provider(TestCase):
                 'AF': ['4.2.3.4'],
             }
         })
-        id = provider._get_health_check_id(record, 'AF', record.geo['AF'])
+        id = provider._get_health_check_id(record, 'AF', record.geo['AF'],
+                                           True)
         self.assertEquals('42', id)
 
     def test_health_check_create(self):
@@ -697,7 +699,8 @@ class TestRoute53Provider(TestCase):
                 'AF': ['4.2.3.4'],
             }
         })
-        id = provider._get_health_check_id(record, 'AF', record.geo['AF'])
+        id = provider._get_health_check_id(record, 'AF', record.geo['AF'],
+                                           True)
         self.assertEquals('42', id)
         stubber.assert_no_pending_responses()
 


### PR DESCRIPTION
Fixes problems encountered sometimes when converting to or from `geo` records with Route53Provider. Main bit of this was dealing with the API's inability to `UPSERT` a non-geo record into the default geo record. Beyond that I ran into some edge cases where records couldn't be deleted without including the `HealthCheckId` with errors complaining about trying to delete a record with params that don't match.

