### PR TITLE
Alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The above command pulled the existing data out of Route53 and placed the results
 
 * ALIAS support varies a lot fromm provider to provider care should be taken to verify that your needs are met in detail.
    * Dyn's UI doesn't allow editing or view of TTL, but the API accepts and stores the value provided, this value does not appear to be used when served
-   * Dnsimple's API throws errors when TTL is modified, but it can be edited in the UI and seems to be used when served, there's also a secondary TXT record created alongside the ALIAS that octoDNS ignores
+   * Dnsimple's uses the configured TTL when serving things through the ALIAS, there's also a secondary TXT record created alongside the ALIAS that octoDNS ignores
 
 ## Custom Sources and Providers
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ The above command pulled the existing data out of Route53 and placed the results
 | [TinyDNSSource](/octodns/source/tinydns.py) | A, CNAME, MX, NS, PTR | No | read-only |
 | [YamlProvider](/octodns/provider/yaml.py) | All | Yes | config |
 
+#### Notes
+
+* ALIAS support varies a lot fromm provider to provider care should be taken to verify that your needs are met in detail.
+   * Dyn's UI doesn't allow editing or view of TTL, but the API accepts and stores the value provided, this value does not appear to be used when served
+   * Dnsimple's API throws errors when TTL is modified, but it can be edited in the UI and seems to be used when served, there's also a secondary TXT record created alongside the ALIAS that octoDNS ignores
+
 ## Custom Sources and Providers
 
 You can check out the [source](/octodns/source/) and [provider](/octodns/provider/) directory to see what's currently supported. Sources act as a source of record information. TinyDnsProvider is currently the only OSS source, though we have several others internally that are specific to our environment. These include something to pull host data from  [gPanel](https://githubengineering.com/githubs-metal-cloud/) and a similar provider that sources information about our network gear to create both `A` & `PTR` records for their interfaces. Things that might make good OSS sources might include an `ElbSource` that pulls information about [AWS Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/) and dynamically creates `CNAME`s for them, or `Ec2Source` that pulls instance information so that records can be created for hosts similar to how our `GPanelProvider` works. An `AxfrSource` could be really interesting as well. Another case where a source may make sense is if you'd like to export data from a legacy service that you have no plans to push changes back into.

--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -120,6 +120,8 @@ class DnsimpleProvider(BaseProvider):
             'value': '{}.'.format(record['content'])
         }
 
+    _data_for_ALIAS = _data_for_CNAME
+
     def _data_for_MX(self, _type, records):
         values = []
         for record in records:
@@ -238,6 +240,10 @@ class DnsimpleProvider(BaseProvider):
             _type = record['type']
             if _type == 'SOA':
                 continue
+            elif _type == 'TXT' and record['content'].startswith('ALIAS for'):
+                # ALIAS has a "ride along" TXT record with 'ALIAS for XXXX',
+                # we're ignoring it
+                continue
             values[record['name']][record['type']].append(record)
 
         before = len(zone.records)
@@ -273,6 +279,7 @@ class DnsimpleProvider(BaseProvider):
             'type': record._type
         }
 
+    _params_for_ALIAS = _params_for_single
     _params_for_CNAME = _params_for_single
     _params_for_PTR = _params_for_single
 

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -48,6 +48,7 @@ class Ns1Provider(BaseProvider):
             'value': record['short_answers'][0],
         }
 
+    _data_for_ALIAS = _data_for_CNAME
     _data_for_PTR = _data_for_CNAME
 
     def _data_for_MX(self, _type, record):
@@ -140,6 +141,7 @@ class Ns1Provider(BaseProvider):
     def _params_for_CNAME(self, record):
         return {'answers': [record.value], 'ttl': record.ttl}
 
+    _params_for_ALIAS = _params_for_CNAME
     _params_for_PTR = _params_for_CNAME
 
     def _params_for_MX(self, record):

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -64,6 +64,7 @@ class PowerDnsBaseProvider(BaseProvider):
             'ttl': rrset['ttl']
         }
 
+    _data_for_ALIAS = _data_for_single
     _data_for_CNAME = _data_for_single
     _data_for_PTR = _data_for_single
 
@@ -191,6 +192,7 @@ class PowerDnsBaseProvider(BaseProvider):
     def _records_for_single(self, record):
         return [{'content': record.value, 'disabled': False}]
 
+    _records_for_ALIAS = _records_for_single
     _records_for_CNAME = _records_for_single
     _records_for_PTR = _records_for_single
 

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -311,6 +311,16 @@ class _ValueMixin(object):
                                            self.fqdn, self.value)
 
 
+class AliasRecord(_ValueMixin, Record):
+    _type = 'ALIAS'
+
+    def _process_value(self, value):
+        if not value.endswith(self.zone.name):
+            raise Exception('Invalid record {}, value ({}) must be in '
+                            'same zone.'.format(self.fqdn, value))
+        return value.lower()
+
+
 class CnameRecord(_ValueMixin, Record):
     _type = 'CNAME'
 

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -313,29 +313,7 @@ class _ValueMixin(object):
                                            self.fqdn, self.value)
 
 
-class AliasValue(object):
-
-    def __init__(self, value):
-        self.name = value['name'].lower()
-        self._type = value['type']
-
-    @property
-    def data(self):
-        return {
-            'name': self.name,
-            'type': self._type,
-        }
-
-    def __cmp__(self, other):
-        if self.name == other.name:
-            return cmp(self._type, other._type)
-        return cmp(self.name, other.name)
-
-    def __repr__(self):
-        return "'{} {}'".format(self.name, self._type)
-
-
-class AliasRecord(_ValuesMixin, Record):
+class AliasRecord(_ValueMixin, Record):
     _type = 'ALIAS'
 
     def __init__(self, zone, name, data, source=None):
@@ -344,19 +322,11 @@ class AliasRecord(_ValuesMixin, Record):
         data['ttl'] = 0
         super(AliasRecord, self).__init__(zone, name, data, source)
 
-    def _process_values(self, values):
-        ret = []
-        for value in values:
-            try:
-                value = AliasValue(value)
-            except KeyError as e:
-                raise Exception('Invalid value in record {}, missing {}'
-                                .format(self.fqdn, e.args[0]))
-            if not value.name.endswith(self.zone.name):
-                raise Exception('Invalid value in record {}, name must be in '
-                                'same zone.'.format(self.fqdn))
-            ret.append(value)
-        return ret
+    def _process_value(self, value):
+        if not value.endswith('.'):
+            raise Exception('Invalid record {}, value ({}) missing trailing .'
+                            .format(self.fqdn, value))
+        return value
 
 
 class CnameRecord(_ValueMixin, Record):

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -316,12 +316,6 @@ class _ValueMixin(object):
 class AliasRecord(_ValueMixin, Record):
     _type = 'ALIAS'
 
-    def __init__(self, zone, name, data, source=None):
-        data = dict(data)
-        # TODO: this is an ugly way to fake the lack of ttl :-(
-        data['ttl'] = 0
-        super(AliasRecord, self).__init__(zone, name, data, source)
-
     def _process_value(self, value):
         if not value.endswith('.'):
             raise Exception('Invalid record {}, value ({}) missing trailing .'

--- a/tests/fixtures/dnsimple-page-1.json
+++ b/tests/fixtures/dnsimple-page-1.json
@@ -308,7 +308,7 @@
   "pagination": {
     "current_page": 1,
     "per_page": 20,
-    "total_entries": 28,
+    "total_entries": 29,
     "total_pages": 2
   }
 }

--- a/tests/fixtures/dnsimple-page-2.json
+++ b/tests/fixtures/dnsimple-page-2.json
@@ -143,12 +143,28 @@
       "system_record": false,
       "created_at": "2017-03-09T15:55:09Z",
       "updated_at": "2017-03-09T15:55:09Z"
+    },
+    {
+      "id": 11188802,
+      "zone_id": "unit.tests",
+      "parent_id": null,
+      "name": "txt",
+      "content": "ALIAS for www.unit.tests.",
+      "ttl": 600,
+      "priority": null,
+      "type": "TXT",
+      "regions": [
+        "global"
+      ],
+      "system_record": false,
+      "created_at": "2017-03-09T15:55:09Z",
+      "updated_at": "2017-03-09T15:55:09Z"
     }
   ],
   "pagination": {
     "current_page": 2,
     "per_page": 20,
-    "total_entries": 28,
+    "total_entries": 29,
     "total_pages": 2
   }
 }

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -243,15 +243,68 @@ class TestRecord(TestCase):
         a.__repr__()
 
     def test_alias(self):
-        self.assertSingleValue(AliasRecord, 'foo.unit.tests.',
-                               'other.unit.tests.')
+        a_values = [{
+            'name': 'www.unit.tests.',
+            'type': 'A'
+        }, {
+            'name': 'www.unit.tests.',
+            'type': 'AAAA'
+        }]
+        a_data = {'ttl': 0, 'values': a_values}
+        a = AliasRecord(self.zone, '', a_data)
+        self.assertEquals('', a.name)
+        self.assertEquals('unit.tests.', a.fqdn)
+        self.assertEquals(0, a.ttl)
+        self.assertEquals(a_values[0]['name'], a.values[0].name)
+        self.assertEquals(a_values[0]['type'], a.values[0]._type)
+        self.assertEquals(a_values[1]['name'], a.values[1].name)
+        self.assertEquals(a_values[1]['type'], a.values[1]._type)
+        self.assertEquals(a_data, a.data)
 
+        b_value = {
+            'name': 'www.unit.tests.',
+            'type': 'A',
+        }
+        b_data = {'ttl': 0, 'value': b_value}
+        b = AliasRecord(self.zone, 'b', b_data)
+        self.assertEquals(b_value['name'], b.values[0].name)
+        self.assertEquals(b_value['type'], b.values[0]._type)
+        self.assertEquals(b_data, b.data)
+
+        # missing value
         with self.assertRaises(Exception) as ctx:
-            AliasRecord(self.zone, '', {
-                'ttl': 31,
-                'value': 'foo.bar.com.'
-            })
-        self.assertTrue('in same zone' in ctx.exception.message)
+            AliasRecord(self.zone, None, {'ttl': 0})
+        self.assertTrue('missing value(s)' in ctx.exception.message)
+        # invalid value
+        with self.assertRaises(Exception) as ctx:
+            AliasRecord(self.zone, None, {'ttl': 0, 'value': {}})
+        self.assertTrue('Invalid value' in ctx.exception.message)
+        # bad name
+        with self.assertRaises(Exception) as ctx:
+            AliasRecord(self.zone, None, {'ttl': 0, 'value': {
+                'name': 'foo.bar.com.',
+                'type': 'A'
+            }})
+        self.assertTrue('Invalid value' in ctx.exception.message)
+
+        target = SimpleProvider()
+        # No changes with self
+        self.assertFalse(a.changes(a, target))
+        # Diff in priority causes change
+        other = AliasRecord(self.zone, 'a', {'ttl': 30, 'values': a_values})
+        other.values[0].name = 'foo.unit.tests.'
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        # Diff in value causes change
+        other.values[0].name = a.values[0].name
+        other.values[0]._type = 'MX'
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+
+        # __repr__ doesn't blow up
+        a.__repr__()
 
     def test_cname(self):
         self.assertSingleValue(CnameRecord, 'target.foo.com.',

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from octodns.record import ARecord, AaaaRecord, CnameRecord, Create, Delete, \
-    GeoValue, MxRecord, NaptrRecord, NaptrValue, NsRecord, PtrRecord, Record, \
-    SshfpRecord, SpfRecord, SrvRecord, TxtRecord, Update
+from octodns.record import ARecord, AaaaRecord, AliasRecord, CnameRecord, \
+    Create, Delete, GeoValue, MxRecord, NaptrRecord, NaptrValue, NsRecord, \
+    PtrRecord, Record, SshfpRecord, SpfRecord, SrvRecord, TxtRecord, Update
 from octodns.zone import Zone
 
 from helpers import GeoProvider, SimpleProvider
@@ -241,6 +241,17 @@ class TestRecord(TestCase):
 
         # __repr__ doesn't blow up
         a.__repr__()
+
+    def test_alias(self):
+        self.assertSingleValue(AliasRecord, 'foo.unit.tests.',
+                               'other.unit.tests.')
+
+        with self.assertRaises(Exception) as ctx:
+            AliasRecord(self.zone, '', {
+                'ttl': 31,
+                'value': 'foo.bar.com.'
+            })
+        self.assertTrue('in same zone' in ctx.exception.message)
 
     def test_cname(self):
         self.assertSingleValue(CnameRecord, 'target.foo.com.',


### PR DESCRIPTION
This is WIP for the moment. Started working on implementing Route53 provider and quickly ran into the need for the cleanup in https://github.com/github/octodns/pull/46 so I had to side track to do that first.

I still need to look at `ALIAS` support requirements in Dyn, DNSimple, etc. to make sure the underlying schema here makes sense for all of them, but as of now an `AliasRecord` has one or more values each of which references another record in the same zone by `name` and `type`. This matches Route53's requirements and more generally what things need to look like conceptually. 

/cc https://github.com/github/octodns/issues/26 & @michaelmcallister 
/cc https://github.com/github/octodns/issues/30 & @jalogisch