### PR TITLE
Fixed UnboundLocalError in manager.py

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -273,7 +273,7 @@ class Manager(object):
             for target, plan in plans:
                 plan.raise_if_unsafe()
 
-        if dry_run or config.get('always-dry-run', False):
+        if dry_run or self.config.get('always-dry-run', False):
             return 0
 
         total_changes = 0


### PR DESCRIPTION
I've got following traceback while running this command-line
`octodns-sync --debug --config-file=./config/production.yaml --doit --target pdns test.it`

2017-06-08T14:21:02  [140735208611840] INFO  Manager __init__: config_file=./config/production.yaml
2017-06-08T14:21:02  [140735208611840] DEBUG Manager __init__:   configuring providers
2017-06-08T14:21:03  [140735208611840] DEBUG PowerDnsProvider[pdns] __init__: id=pdns, host=10.135.192.22, port=8081, nameserver_values=None, nameserver_ttl=600
2017-06-08T14:21:03  [140735208611840] DEBUG PowerDnsProvider[pdns] __init__: id=pdns, apply_disabled=False
2017-06-08T14:21:03  [140735208611840] DEBUG Route53Provider[route53] __init__: id=route53, access_key_id=AKIAJ6***LLNA, secret_access_key=***
2017-06-08T14:21:03  [140735208611840] DEBUG Route53Provider[route53] __init__: id=route53, apply_disabled=False
2017-06-08T14:21:03  [140735208611840] INFO  Manager sync: eligible_zones=['***.it'], eligible_targets=['pdns'], dry_run=False, force=False
2017-06-08T14:21:03  [140735208611840] INFO  Manager 
********************************************************************************
No changes were planned
********************************************************************************


2017-06-08T14:21:03  [140735208611840] DEBUG Manager sync:   checking safety
Traceback (most recent call last):
  File "/Users/test/tmp/octodns/bin/octodns-sync", line 11, in <module>
    sys.exit(main())
  File "/Users/test/tmp/octodns/lib/python2.7/site-packages/octodns/cmds/sync.py", line 39, in main
    dry_run=not args.doit, force=args.force)
  File "/Users/test/tmp/octodns/lib/python2.7/site-packages/octodns/manager.py", line 275, in sync
    if dry_run or config.get('always-dry-run', False):
UnboundLocalError: local variable 'config' referenced before assignment