### PR TITLE
Escape unescaped semicolons coming out of Route53

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -253,10 +253,13 @@ class Route53Provider(BaseProvider):
     _data_for_PTR = _data_for_single
     _data_for_CNAME = _data_for_single
 
+    _fix_semicolons = re.compile(r'(?<!\\);')
+
     def _data_for_quoted(self, rrset):
         return {
             'type': rrset['Type'],
-            'values': [rr['Value'][1:-1] for rr in rrset['ResourceRecords']],
+            'values': [self._fix_semicolons.sub('\;', rr['Value'][1:-1])
+                       for rr in rrset['ResourceRecords']],
             'ttl': int(rrset['TTL'])
         }
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -1217,3 +1217,23 @@ class TestRoute53Provider(TestCase):
         with self.assertRaises(Exception) as ctx:
             provider.apply(plan)
         self.assertTrue('modifications' in ctx.exception.message)
+
+    def test_semicolon_fixup(self):
+        provider = Route53Provider('test', 'abc', '123')
+
+        self.assertEquals({
+            'type': 'TXT',
+            'ttl': 30,
+            'values': [
+                'abcd\\; ef\\;g',
+                'hij\\; klm\\;n',
+            ],
+        }, provider._data_for_quoted({
+            'ResourceRecords': [{
+                'Value': '"abcd; ef;g"',
+            }, {
+                'Value': '"hij\\; klm\\;n"',
+            }],
+            'TTL': 30,
+            'Type': 'TXT',
+        }))


### PR DESCRIPTION
Route53 automatically escapes unescaped `;` when it serves TXT records, but octoDNS enforces them since that's technically correct.

This handles pulling records from Route53 when they don't have `\;`. They won't show as diffs, but any time octoDNS goes to modify these records for any reason they'll be fixed.

/cc @brianeclow @blakestoddard please give this a look/try and 👍 / 👎 
Fixes https://github.com/github/octodns/issues/34