### PR TITLE
Fix zone-level always-dry-run functionality

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -273,12 +273,18 @@ class Manager(object):
             for target, plan in plans:
                 plan.raise_if_unsafe()
 
-        if dry_run or config.get('always-dry-run', False):
+        if dry_run:
             return 0
 
         total_changes = 0
         self.log.debug('sync:   applying')
+        zones = self.config['zones']
         for target, plan in plans:
+            zone_name = plan.existing.name
+            if zones[zone_name].get('always-dry-run', False):
+                self.log.info('sync: zone=%s skipping always-dry-run',
+                              zone_name)
+                continue
             total_changes += target.apply(plan)
 
         self.log.info('sync:   %d total changes', total_changes)

--- a/tests/config/always-dry-run.yaml
+++ b/tests/config/always-dry-run.yaml
@@ -1,0 +1,20 @@
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+  dump:
+    class: octodns.provider.yaml.YamlProvider
+    directory: env/YAML_TMP_DIR
+zones:
+  unit.tests.:
+    always-dry-run: true
+    sources:
+    - in
+    targets:
+    - dump
+  subzone.unit.tests.:
+    always-dry-run: false
+    sources:
+    - in
+    targets:
+    - dump

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -88,6 +88,14 @@ class TestManager(TestCase):
                 .sync(['not.targetable.'])
         self.assertTrue('does not support targeting' in ctx.exception.message)
 
+    def test_always_dry_run(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+            tc = Manager(get_config_filename('always-dry-run.yaml')) \
+                .sync(dry_run=False)
+            # only the stuff from subzone, unit.tests. is always-dry-run
+            self.assertEquals(3, tc)
+
     def test_simple(self):
         with TemporaryDirectory() as tmpdir:
             environ['YAML_TMP_DIR'] = tmpdir.dirname


### PR DESCRIPTION
The code that was there was no-where near functional/didn't make any sense now. Thanks for pointing me at the problem @offmindby.

Replaces https://github.com/github/octodns/pull/58.