### PR TITLE
Manually join self.values to avoid double escapes, e.g. \\;

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -254,9 +254,10 @@ class _ValuesMixin(object):
         return ret
 
     def __repr__(self):
+        values = "['{}']".format("', '".join([str(v) for v in self.values]))
         return '<{} {} {}, {}, {}>'.format(self.__class__.__name__,
                                            self._type, self.ttl,
-                                           self.fqdn, self.values)
+                                           self.fqdn, values)
 
 
 class _GeoMixin(_ValuesMixin):


### PR DESCRIPTION
```
...
* route53 (Route53Provider)
*   Update
*     <TxtRecord TXT 600, txt.githubtest.net., ['Bah bah black sheep', 'have you any wool.']> ->
*     <TxtRecord TXT 600, txt.githubtest.net., ['Bah bah black sheep', 'have you\; any wool.']> (config)
```

/cc https://github.com/github/octodns/issues/66#issuecomment-311469481
/cc @blakestoddard 