### PR TITLE
Fix stacktraces on MainThreadExecutor

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from StringIO import StringIO
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
 from os import environ
 import logging
@@ -38,6 +38,17 @@ class _AggregateTarget(object):
         return True
 
 
+class MakeThreadFuture(object):
+
+    def __init__(self, func, args, kwargs):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def result(self):
+        return self.func(*self.args, **self.kwargs)
+
+
 class MainThreadExecutor(object):
     '''
     Dummy executor that runs things on the main thread during the involcation
@@ -48,13 +59,7 @@ class MainThreadExecutor(object):
     '''
 
     def submit(self, func, *args, **kwargs):
-        future = Future()
-        try:
-            future.set_result(func(*args, **kwargs))
-        except Exception as e:
-            # TODO: get right stacktrace here
-            future.set_exception(e)
-        return future
+        return MakeThreadFuture(func, args, kwargs)
 
 
 class Manager(object):


### PR DESCRIPTION
```
2017-07-02T18:38:14  [140735305896704] INFO  Manager sync:   sources=['config'] -> targets=['route53']
Traceback (most recent call last):
  File "./octodns/cmds/sync.py", line 43, in <module>
    main()
  File "./octodns/cmds/sync.py", line 39, in main
    dry_run=not args.doit, force=args.force)
  File "/Users/ross/github/octodns/octodns/manager.py", line 266, in sync
    plans = [p for f in futures for p in f.result()]
  File "/Users/ross/github/octodns/octodns/manager.py", line 49, in result
    return self.func(*self.args, **self.kwargs)
  File "/Users/ross/github/octodns/octodns/manager.py", line 189, in _populate_and_plan
    source.populate(zone)
  File "/Users/ross/github/octodns/octodns/provider/yaml.py", line 69, in populate
    lenient=lenient)
  File "/Users/ross/github/octodns/octodns/record.py", line 115, in new
    raise ValidationError(fqdn, reasons)
octodns.record.ValidationError: Invalid record *.sub.githubtest.net.
  - invalid ip address "2.2.3.3a"
```

vs

```
2017-07-02T18:42:05  [140735305896704] INFO  Manager sync:   sources=['config'] -> targets=['route53']
Traceback (most recent call last):
  File "./octodns/cmds/sync.py", line 43, in <module>
    main()
  File "./octodns/cmds/sync.py", line 39, in main
    dry_run=not args.doit, force=args.force)
  File "/Users/ross/github/octodns/octodns/manager.py", line 255, in sync
    plans = [p for f in futures for p in f.result()]
  File "/Users/ross/github/octodns/env/lib/python2.7/site-packages/concurrent/futures/_base.py", line 398, in result
    return self.__get_result()
  File "/Users/ross/github/octodns/env/lib/python2.7/site-packages/concurrent/futures/_base.py", line 357, in __get_result
    raise type(self._exception), self._exception, self._traceback
octodns.record.ValidationError: Invalid record *.sub.githubtest.net.
  - invalid ip address "2.2.3.3a"
```