### PR TITLE
Remove ; escapes before sending to ns1 and when pulling from

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -154,7 +154,7 @@ class Ns1Provider(BaseProvider):
         # NS1 seems to be the only provider that doesn't want things escaped in
         # values so we have to strip them here and add them when going the
         # other way
-        values = [v.replace('\\', '') for v in record.values]
+        values = [v.replace('\;', ';') for v in record.values]
         return {'answers': values, 'ttl': record.ttl}
 
     _params_for_TXT = _params_for_SPF

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -42,8 +42,16 @@ class Ns1Provider(BaseProvider):
         }
 
     _data_for_AAAA = _data_for_A
-    _data_for_SPF = _data_for_A
-    _data_for_TXT = _data_for_A
+
+    def _data_for_SPF(self, _type, record):
+        values = [v.replace(';', '\;') for v in record['short_answers']]
+        return {
+            'ttl': record['ttl'],
+            'type': _type,
+            'values': values
+        }
+
+    _data_for_TXT = _data_for_SPF
 
     def _data_for_CNAME(self, _type, record):
         return {
@@ -141,8 +149,15 @@ class Ns1Provider(BaseProvider):
 
     _params_for_AAAA = _params_for_A
     _params_for_NS = _params_for_A
-    _params_for_SPF = _params_for_A
-    _params_for_TXT = _params_for_A
+
+    def _params_for_SPF(self, record):
+        # NS1 seems to be the only provider that doesn't want things escaped in
+        # values so we have to strip them here and add them when going the
+        # other way
+        values = [v.replace('\\', '') for v in record.values]
+        return {'answers': values, 'ttl': record.ttl}
+
+    _params_for_TXT = _params_for_SPF
 
     def _params_for_CNAME(self, record):
         return {'answers': [record.value], 'ttl': record.ttl}

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -277,3 +277,37 @@ class TestNs1Provider(TestCase):
             call.update(answers=[u'1.2.3.4'], ttl=32),
             call.delete()
         ])
+
+    def test_escaping(self):
+        provider = Ns1Provider('test', 'api-key')
+
+        record = {
+            'ttl': 31,
+            'short_answers': ['foo; bar baz; blip']
+        }
+        self.assertEquals(['foo\; bar baz\; blip'],
+                          provider._data_for_SPF('SPF', record)['values'])
+
+        record = {
+            'ttl': 31,
+            'short_answers': ['no', 'foo; bar baz; blip', 'yes']
+        }
+        self.assertEquals(['no', 'foo\; bar baz\; blip', 'yes'],
+                          provider._data_for_TXT('TXT', record)['values'])
+
+        zone = Zone('unit.tests.', [])
+        record = Record.new(zone, 'spf', {
+            'ttl': 34,
+            'type': 'SPF',
+            'value': 'foo\; bar baz\; blip'
+        })
+        self.assertEquals(['foo; bar baz; blip'],
+                          provider._params_for_SPF(record)['answers'])
+
+        record = Record.new(zone, 'txt', {
+            'ttl': 35,
+            'type': 'TXT',
+            'value': 'foo\; bar baz\; blip'
+        })
+        self.assertEquals(['foo; bar baz; blip'],
+                          provider._params_for_TXT(record)['answers'])


### PR DESCRIPTION

So apparently NS1 doesn't want `;` to be escaped in its API/UI. This PR attempts to comply. So far it's the only provider I'm aware of that that doesn't adhere to the original RFCs for the values, some make it optional, others require it. 

Still need to add tests.

/cc blakestoddard
/cc https://github.com/github/octodns/issues/79