### PR TITLE
Improved/actionable keys out of order error message

### DIFF
--- a/octodns/yaml.py
+++ b/octodns/yaml.py
@@ -21,9 +21,13 @@ class SortEnforcingLoader(SafeLoader):
         self.flatten_mapping(node)
         ret = self.construct_pairs(node)
         keys = [d[0] for d in ret]
-        if keys != sorted(keys, key=_natsort_key):
-            raise ConstructorError(None, None, "keys out of order: {}"
-                                   .format(', '.join(keys)), node.start_mark)
+        keys_sorted = sorted(keys, key=_natsort_key)
+        for key in keys:
+            expected = keys_sorted.pop(0)
+            if key != expected:
+                raise ConstructorError(None, None, 'keys out of order: '
+                                       'expected {} got {} at {}'
+                                       .format(expected, key, node.start_mark))
         return dict(ret)
 
 

--- a/tests/test_octodns_yaml.py
+++ b/tests/test_octodns_yaml.py
@@ -48,8 +48,8 @@ class TestYaml(TestCase):
 '*.11.2': 'd'
 '*.10.1': 'c'
 ''')
-        self.assertEquals('keys out of order: *.2.2, *.1.2, *.11.2, *.10.1',
-                          ctx.exception.problem)
+        self.assertTrue('keys out of order: expected *.1.2 got *.2.2 at' in
+                        ctx.exception.problem)
 
         buf = StringIO()
         safe_dump({


### PR DESCRIPTION
Rather than spew 2 big lists indicate exactly the unexpected value and what was expected so that they can be flipped. It may not show all the changes that are needed in one go, but thinking about it for a second and seeing the others and/or running multiple rounds until it's happy should do the trick.