### PR TITLE
Allow proto to be specified for powerdns

### DIFF
--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -18,11 +18,13 @@ class PowerDnsBaseProvider(BaseProvider):
                     'SPF', 'SSHFP', 'SRV', 'TXT'))
     TIMEOUT = 5
 
-    def __init__(self, id, host, api_key, port=8081, *args, **kwargs):
+    def __init__(self, id, host, api_key, port=8081, scheme="http", *args,
+                 **kwargs):
         super(PowerDnsBaseProvider, self).__init__(id, *args, **kwargs)
 
         self.host = host
         self.port = port
+        self.scheme = scheme
 
         sess = Session()
         sess.headers.update({'X-API-Key': api_key})
@@ -31,8 +33,8 @@ class PowerDnsBaseProvider(BaseProvider):
     def _request(self, method, path, data=None):
         self.log.debug('_request: method=%s, path=%s', method, path)
 
-        url = 'http://{}:{}/api/v1/servers/localhost/{}' \
-            .format(self.host, self.port, path)
+        url = '{}://{}:{}/api/v1/servers/localhost/{}' \
+            .format(self.scheme, self.host, self.port, path)
         resp = self._sess.request(method, url, json=data, timeout=self.TIMEOUT)
         self.log.debug('_request:   status=%d', resp.status_code)
         resp.raise_for_status()


### PR DESCRIPTION
This allows a protocol to be set for the PowerDNS API. It defaults to
http to retain backwards compatibility.