### PR TITLE
Features# Geo support added for CNAME Records. ISSUE - #62

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -398,7 +398,7 @@ class AliasRecord(_ValueMixin, Record):
         return value
 
 
-class CnameRecord(_ValueMixin, Record):
+class CnameRecord(_GeoMixin, Record):
     _type = 'CNAME'
 
     @classmethod
@@ -416,8 +416,8 @@ class CnameRecord(_ValueMixin, Record):
             reasons.append('missing trailing .')
         return reasons
 
-    def _process_value(self, value):
-        return value
+    def _process_values(self, values):
+        return values
 
 
 class MxValue(object):


### PR DESCRIPTION
@ross , I have implemented the Geo support for the cname records. Below, you can find out the example configuration snippet that will work after this update. 

```
www2:
  geo:
    AS:
      - cdn.asia.
    EU:
      - cdn.eu.
    NA-US-CA:
      - cdn.com.
  ttl: 300
  type: CNAME
  value: cdn.net.
```

Please, have a look and let me know if anything.