### PR TITLE
Implement "chunked" TXT/SPF value support for long values

### DIFF
--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -455,7 +455,7 @@ class DynProvider(BaseProvider):
         return [{
             'txtdata': v,
             'ttl': record.ttl,
-        } for v in record.values]
+        } for v in record.chunked_values]
 
     def _kwargs_for_SRV(self, record):
         return [{

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -114,8 +114,7 @@ class _Route53Record(object):
                 for v in record.values]
 
     def _values_for_quoted(self, record):
-        return ['"{}"'.format(v.replace('"', '\\"'))
-                for v in record.values]
+        return record.chunked_values
 
     _values_for_SPF = _values_for_quoted
     _values_for_TXT = _values_for_quoted

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -1493,28 +1493,30 @@ class TestRecordValidation(TestCase):
 
     def test_TXT_long_value_chunking(self):
         expected = '"Lorem ipsum dolor sit amet, consectetur adipiscing ' \
-            'elit, seddo eiusmod tempor incididunt ut labore et dolore ' \
+            'elit, sed do eiusmod tempor incididunt ut labore et dolore ' \
             'magna aliqua. Ut enim ad minim veniam, quis nostrud ' \
             'exercitation ullamco laboris nisi ut aliquip ex ea commodo ' \
-            'consequat. Duis aute irure dolor in" " reprehenderit in ' \
+            'consequat. Duis aute irure dolor i" "n reprehenderit in ' \
             'voluptate velit esse cillum dolore eu fugiat nulla pariatur. ' \
             'Excepteur sint occaecat cupidatat non proident, sunt in culpa ' \
             'qui officia deserunt mollit anim id est laborum."'
 
+        long_value = 'Lorem ipsum dolor sit amet, consectetur adipiscing ' \
+            'elit, sed do eiusmod tempor incididunt ut labore et dolore ' \
+            'magna aliqua. Ut enim ad minim veniam, quis nostrud ' \
+            'exercitation ullamco laboris nisi ut aliquip ex ea commodo ' \
+            'consequat. Duis aute irure dolor in reprehenderit in ' \
+            'voluptate velit esse cillum dolore eu fugiat nulla ' \
+            'pariatur. Excepteur sint occaecat cupidatat non proident, ' \
+            'sunt in culpa qui officia deserunt mollit anim id est ' \
+            'laborum.'
         # Single string
         single = Record.new(self.zone, '', {
             'type': 'TXT',
             'ttl': 600,
             'values': [
                 'hello world',
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'
-                'do eiusmod tempor incididunt ut labore et dolore magna '
-                'aliqua. Ut enim ad minim veniam, quis nostrud exercitation '
-                'ullamco laboris nisi ut aliquip ex ea commodo consequat. '
-                'Duis aute irure dolor in reprehenderit in voluptate velit '
-                'esse cillum dolore eu fugiat nulla pariatur. Excepteur sint '
-                'occaecat cupidatat non proident, sunt in culpa qui officia '
-                'deserunt mollit anim id est laborum.',
+                long_value,
                 'this has some\; semi-colons\; in it',
             ]
         })
@@ -1524,20 +1526,22 @@ class TestRecordValidation(TestCase):
         # get out what we put in.
         self.assertEquals(expected, single.chunked_values[0])
 
+        long_split_value = '"Lorem ipsum dolor sit amet, consectetur ' \
+            'adipiscing elit, sed do eiusmod tempor incididunt ut ' \
+            'labore et dolore magna aliqua. Ut enim ad minim veniam, ' \
+            'quis nostrud exercitation ullamco laboris nisi ut aliquip ' \
+            'ex" " ea commodo consequat. Duis aute irure dolor in ' \
+            'reprehenderit in voluptate velit esse cillum dolore eu ' \
+            'fugiat nulla pariatur. Excepteur sint occaecat cupidatat ' \
+            'non proident, sunt in culpa qui officia deserunt mollit ' \
+            'anim id est laborum."'
         # Chunked
         chunked = Record.new(self.zone, '', {
             'type': 'TXT',
             'ttl': 600,
             'values': [
                 '"hello world"',
-                '"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'
-                'do eiusmod tempor incididunt ut labore et dolore magna '
-                'aliqua. Ut enim ad minim veniam, quis nostrud exercitation '
-                'ullamco laboris nisi ut aliquip ex" " ea commodo consequat. '
-                'Duis aute irure dolor in reprehenderit in voluptate velit '
-                'esse cillum dolore eu fugiat nulla pariatur. Excepteur sint '
-                'occaecat cupidatat non proident, sunt in culpa qui officia '
-                'deserunt mollit anim id est laborum."',
+                long_split_value,
                 '"this has some\; semi-colons\; in it"',
             ]
         })

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -1490,3 +1490,59 @@ class TestRecordValidation(TestCase):
                 'value': 'this has some; semi-colons\; in it',
             })
         self.assertEquals(['unescaped ;'], ctx.exception.reasons)
+
+    def test_TXT_long_value_chunking(self):
+        expected = '"Lorem ipsum dolor sit amet, consectetur adipiscing ' \
+            'elit, seddo eiusmod tempor incididunt ut labore et dolore ' \
+            'magna aliqua. Ut enim ad minim veniam, quis nostrud ' \
+            'exercitation ullamco laboris nisi ut aliquip ex ea commodo ' \
+            'consequat. Duis aute irure dolor in" " reprehenderit in ' \
+            'voluptate velit esse cillum dolore eu fugiat nulla pariatur. ' \
+            'Excepteur sint occaecat cupidatat non proident, sunt in culpa ' \
+            'qui officia deserunt mollit anim id est laborum."'
+
+        # Single string
+        single = Record.new(self.zone, '', {
+            'type': 'TXT',
+            'ttl': 600,
+            'values': [
+                'hello world',
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'
+                'do eiusmod tempor incididunt ut labore et dolore magna '
+                'aliqua. Ut enim ad minim veniam, quis nostrud exercitation '
+                'ullamco laboris nisi ut aliquip ex ea commodo consequat. '
+                'Duis aute irure dolor in reprehenderit in voluptate velit '
+                'esse cillum dolore eu fugiat nulla pariatur. Excepteur sint '
+                'occaecat cupidatat non proident, sunt in culpa qui officia '
+                'deserunt mollit anim id est laborum.',
+                'this has some\; semi-colons\; in it',
+            ]
+        })
+        self.assertEquals(3, len(single.values))
+        self.assertEquals(3, len(single.chunked_values))
+        # Note we are checking that this normalizes the chunking, not that we
+        # get out what we put in.
+        self.assertEquals(expected, single.chunked_values[0])
+
+        # Chunked
+        chunked = Record.new(self.zone, '', {
+            'type': 'TXT',
+            'ttl': 600,
+            'values': [
+                '"hello world"',
+                '"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'
+                'do eiusmod tempor incididunt ut labore et dolore magna '
+                'aliqua. Ut enim ad minim veniam, quis nostrud exercitation '
+                'ullamco laboris nisi ut aliquip ex" " ea commodo consequat. '
+                'Duis aute irure dolor in reprehenderit in voluptate velit '
+                'esse cillum dolore eu fugiat nulla pariatur. Excepteur sint '
+                'occaecat cupidatat non proident, sunt in culpa qui officia '
+                'deserunt mollit anim id est laborum."',
+                '"this has some\; semi-colons\; in it"',
+            ]
+        })
+        self.assertEquals(expected, chunked.chunked_values[0])
+        # should be single values, no quoting
+        self.assertEquals(single.values, chunked.values)
+        # should be chunked values, with quoting
+        self.assertEquals(single.chunked_values, chunked.chunked_values)


### PR DESCRIPTION
This implements it transparently at Record level. Providers that need things to
be chunked (seems to just be Route53 an Dyn) switch to use `chunked_values`, but
everything else can stick with `values`. I've run through each provider I have
access to verifying that things operate as expected/required. OVH and Azure are
untested.

The record length can be completely ignored by the end user and octoDNS will break it up if needed. E.g.

```yaml
txt:
  ttl: 600
  type: TXT
  values:
  - Bah bah black sheep
  - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
  - have you\; any wool.
```

```shell
(env) sweetums:octodns ross$ dig +short TXT txt.githubtest.net. @ns1.p10.dynect.net.
;; Truncated, retrying in TCP mode.
"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor i" "n reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
"have you\; any wool."
"Bah bah black sheep"
```

Fixes https://github.com/github/octodns/issues/110
/cc @antonio @brianeclow who hit this problem previously
/cc @trnsnt for OVH provider
/cc @h-hwang for Azure provier 
