### PR TITLE
Handle Manager.dump with an empty Zone

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -11,7 +11,7 @@ from importlib import import_module
 from os import environ
 import logging
 
-from .provider.base import BaseProvider
+from .provider.base import BaseProvider, Plan
 from .provider.yaml import YamlProvider
 from .record import Record
 from .yaml import safe_load
@@ -362,6 +362,8 @@ class Manager(object):
             source.populate(zone, lenient=lenient)
 
         plan = target.plan(zone)
+        if plan is None:
+            plan = Plan(zone, zone, [])
         target.apply(plan)
 
     def validate_configs(self):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -11,6 +11,7 @@ from unittest import TestCase
 
 from octodns.record import Record
 from octodns.manager import _AggregateTarget, MainThreadExecutor, Manager
+from octodns.yaml import safe_load
 from octodns.zone import Zone
 
 from helpers import GeoProvider, NoSshFpProvider, SimpleProvider, \
@@ -210,6 +211,17 @@ class TestManager(TestCase):
             # tyring to find sub zones
             with self.assertRaises(IOError):
                 manager.dump('unknown.zone.', tmpdir.dirname, False, 'in')
+
+    def test_dump_empty(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+            manager = Manager(get_config_filename('simple.yaml'))
+
+            manager.dump('empty.', tmpdir.dirname, False, 'in')
+
+            with open(join(tmpdir.dirname, 'empty.yaml')) as fh:
+                data = safe_load(fh, False)
+                self.assertFalse(data)
 
     def test_validate_configs(self):
         Manager(get_config_filename('simple-validate.yaml')).validate_configs()


### PR DESCRIPTION
When there's no plan b/c the to be dumped zone is empty, create a fake plan with no changes.

Fixes https://github.com/github/octodns/issues/122
/cc @timhughes who found the problem