### PR TITLE
use . instead of source [SC2039]

### DIFF
--- a/.git_hooks_pre-commit
+++ b/.git_hooks_pre-commit
@@ -6,6 +6,6 @@ HOOKS=`dirname $0`
 GIT=`dirname $HOOKS`
 ROOT=`dirname $GIT`
 
-source $ROOT/env/bin/activate
+. $ROOT/env/bin/activate
 $ROOT/script/lint
 $ROOT/script/test


### PR DESCRIPTION
Just a little fix to make it more portable across distributions.
`source` doesn't work everywhere under `/bin/sh`

cf. https://github.com/koalaman/shellcheck/wiki/SC2039