### PR TITLE
adds warning to dyn provider when it cannot load a trafficdirector

### DIFF
--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -291,7 +291,8 @@ class DynProvider(BaseProvider):
                 try:
                     fqdn, _type = td.label.split(':', 1)
                 except ValueError as e:
-                    self.log.warn("Failed to load TraficDirector '{}': {}".format(td.label, e))
+                    self.log.warn("Failed to load TrafficDirector %s: %s",
+                            td.label, e.message)
                     continue
                 tds[fqdn][_type] = td
             self._traffic_directors = dict(tds)

--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -290,7 +290,8 @@ class DynProvider(BaseProvider):
             for td in get_all_dsf_services():
                 try:
                     fqdn, _type = td.label.split(':', 1)
-                except ValueError:
+                except ValueError as e:
+                    self.log.warn("Failed to load TraficDirector '{}': {}".format(td.label, e))
                     continue
                 tds[fqdn][_type] = td
             self._traffic_directors = dict(tds)

--- a/tests/test_octodns_provider_dyn.py
+++ b/tests/test_octodns_provider_dyn.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function, \
 from dyn.tm.errors import DynectGetError
 from dyn.tm.services.dsf import DSFResponsePool
 from json import loads
-from mock import MagicMock, call, patch
+from mock import MagicMock, call, patch, Mock
 from unittest import TestCase
 
 from octodns.record import Create, Delete, Record, Update
@@ -601,6 +601,7 @@ class TestDynProviderGeo(TestCase):
         provider = DynProvider('test', 'cust', 'user', 'pass', True)
         # short-circuit session checking
         provider._dyn_sess = True
+        provider.log.warn = MagicMock()
 
         # no tds
         mock.side_effect = [{'data': []}]
@@ -649,6 +650,8 @@ class TestDynProviderGeo(TestCase):
                           set(tds.keys()))
         self.assertEquals(['A'], tds['unit.tests.'].keys())
         self.assertEquals(['A'], tds['geo.unit.tests.'].keys())
+        provider.log.warn.assert_called_with("Failed to load TraficDirector 'something else': need more than 1 value to unpack")
+
 
     @patch('dyn.core.SessionEngine.execute')
     def test_traffic_director_monitor(self, mock):

--- a/tests/test_octodns_provider_dyn.py
+++ b/tests/test_octodns_provider_dyn.py
@@ -650,7 +650,11 @@ class TestDynProviderGeo(TestCase):
                           set(tds.keys()))
         self.assertEquals(['A'], tds['unit.tests.'].keys())
         self.assertEquals(['A'], tds['geo.unit.tests.'].keys())
-        provider.log.warn.assert_called_with("Failed to load TraficDirector 'something else': need more than 1 value to unpack")
+        provider.log.warn.assert_called_with(
+                u'Failed to load TrafficDirector %s: %s',
+                u'something else',
+                'need more than 1 value to unpack'
+                )
 
 
     @patch('dyn.core.SessionEngine.execute')


### PR DESCRIPTION
If a traffic director is not named correctly the Dyn provider will not load it. This patch adds feedback to the user to make them aware of this issue rather than just continuing with no notification.  Fixes some of #126