### PR TITLE
Improve Validations for None/Empty values, Ignore None/Empty values during dump

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -211,9 +211,30 @@ class _ValuesMixin(object):
         values = []
         try:
             values = data['values']
+            if not values:
+                values = []
+                reasons.append('missing value(s)')
+            else:
+                # loop through copy of values
+                # remove invalid value from values
+                for value in list(values):
+                    if value is None:
+                        reasons.append('missing value(s)')
+                        values.remove(value)
+                    elif len(value) == 0:
+                        reasons.append('empty value')
+                        values.remove(value)
         except KeyError:
             try:
-                values = [data['value']]
+                value = data['value']
+                if value is None:
+                    reasons.append('missing value(s)')
+                    values = []
+                elif len(value) == 0:
+                    reasons.append('empty value')
+                    values = []
+                else:
+                    values = [value]
             except KeyError:
                 reasons.append('missing value(s)')
 
@@ -238,10 +259,16 @@ class _ValuesMixin(object):
     def _data(self):
         ret = super(_ValuesMixin, self)._data()
         if len(self.values) > 1:
-            ret['values'] = [getattr(v, 'data', v) for v in self.values]
-        else:
+            values = [getattr(v, 'data', v) for v in self.values if v]
+            if len(values) > 1:
+                ret['values'] = values
+            elif len(values) == 1:
+                ret['value'] = values[0]
+        elif len(self.values) == 1:
             v = self.values[0]
-            ret['value'] = getattr(v, 'data', v)
+            if v:
+                ret['value'] = getattr(v, 'data', v)
+
         return ret
 
     def __repr__(self):
@@ -349,6 +376,10 @@ class _ValueMixin(object):
         value = None
         try:
             value = data['value']
+            if value is None:
+                reasons.append('missing value')
+            elif value == '':
+                reasons.append('empty value')
         except KeyError:
             reasons.append('missing value')
         if value:
@@ -366,7 +397,8 @@ class _ValueMixin(object):
 
     def _data(self):
         ret = super(_ValueMixin, self)._data()
-        ret['value'] = getattr(self.value, 'data', self.value)
+        if self.value:
+            ret['value'] = getattr(self.value, 'data', self.value)
         return ret
 
     def __repr__(self):

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -96,23 +96,23 @@ class TestDnsimpleProvider(TestCase):
                 mock.get(ANY, text=fh.read())
 
             zone = Zone('unit.tests.', [])
-            provider.populate(zone)
+            provider.populate(zone, lenient=True)
             self.assertEquals(set([
                 Record.new(zone, '', {
                     'ttl': 3600,
                     'type': 'SSHFP',
                     'values': []
-                }),
+                }, lenient=True),
                 Record.new(zone, '_srv._tcp', {
                     'ttl': 600,
                     'type': 'SRV',
                     'values': []
-                }),
+                }, lenient=True),
                 Record.new(zone, 'naptr', {
                     'ttl': 600,
                     'type': 'NAPTR',
                     'values': []
-                }),
+                }, lenient=True),
             ]), zone.records)
 
     def test_apply(self):


### PR DESCRIPTION
**Fixes**: https://github.com/github/octodns/issues/131

When dumping a zone, one tested provider (NS1) allows a user to create a record with no answers. A record with no answers is not valid.

# Dump

1. When a user dumps a zone, it will fail with a ValidationError, for a `missing value(s)` reason
2. When the user specifies `--lenient` during the dump, it will give them a warning, write the record to the file, and a `value` or `values` key will not be present

If a user attempts to apply changes from that file, it will fail normally if `value` or `values` is not specified.

* Previous Behavior:

	**Command**:
	
	```
	octodns-dump --config-file=config/production.yaml --output-dir=tmp/ yzguy.io. nsone
	```
	
	**Output**:
	
	```
	IndexError: list index out of range
	```

* New Behavior

	User does not specify `--lenient`

	**Command**:
	
	```
	octodns-dump --config-file=config/production.yaml --output-dir=tmp/ yzguy.io. nsone
	```
	
	**Output**:
	
	```
	octodns.record.ValidationError: Invalid record test.yzguy.io.
	  - missing value(s)
	```
	
	User does specify `--lenient`
	
	**Command**:

	```
	octodns-dump --config-file=config/production.yaml --output-dir=tmp/ yzguy.io. nsone --lenient
	```
	
	**Output**:
	

	```
	2017-10-22T22:54:58  [140737049330624] WARNING Record Invalid record test.yzguy.io.
	  - missing value(s)
	```
	
	**File**:
	
	```
	test:
	  type: A
	```

# Noop and Doit

 1. If a user applies a file where the `values` key is an empty list or nothing, it will show a ValidationError with `missing value(s)` reason.
 
To fix this the user should apply a value, values, or delete the record as it is not valid.

* Previous Behavior:

	**Command**:

	```
	octodns-sync --config-file=./config/production.yaml
	```
	
	**File**:
	
	```
	test:
	  type: A
	  values:
   ```
   
   **Output**:
   
   ```
   TypeError: 'NoneType' object is not iterable
   ```

* New Behavior

	**Output**:
		
	```
	octodns.record.ValidationError: Invalid record test.yzguy.io.
	- missing value(s)
	```

* Add tests for ValuesMixin (overs records that allow multiple values), ValueMixin (cover records that allow single value)
* Add tests for data method for ValueMixin and ValuesMixin