### PR TITLE
0.8.8 version bump and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.8.8 - 2017-10-24 - Google Cloud DNS, Large TXT Record support
+
+* Added support for "chunking" TXT records where individual values were larger
+  than 255 chars. This is common with DKIM records involving multiple
+  providers.
+* Added `GoogleCloudProvider`
+* Configurable `UnsafePlan` thresholds to allow modification of how many
+  updates/deletes are allowed before a plan is declared dangerous.
+* Manager.dump bug fix around empty zones.
+* Prefer use of `.` over `source` in shell scripts
+* `DynProvider` warns when it ignores unrecognized traffic directors.
+
 ## v0.8.7 - 2017-09-29 - OVH support
 
 Adds an OVH provider.

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.8.7'
+__VERSION__ = '0.8.8'


### PR DESCRIPTION
## v0.8.8 - 2017-10-24 - Google Cloud DNS, Large TXT Record support

* Added support for "chunking" TXT records where individual values were larger than 255 chars. This is common with DKIM records involving multiple providers.
* Added `GoogleCloudProvider`
* Configurable `UnsafePlan` thresholds to allow modification of how many updates/deletes are allowed before a plan is declared dangerous.
* Manager.dump bug fix around empty zones.
* Prefer use of `.` over `source` in shell scripts
* `DynProvider` warns when it ignores unrecognized traffic directors.