### PR TITLE
Allow enabling lenient on a per-record basis with octodns.lenient

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -95,6 +95,10 @@ class Record(object):
         except KeyError:
             raise Exception('Unknown record type: "{}"'.format(_type))
         reasons = _class.validate(name, data)
+        try:
+            lenient |= data['octodns']['lenient']
+        except KeyError:
+            pass
         if reasons:
             if lenient:
                 cls.log.warn(ValidationError.build_message(fqdn, reasons))

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -733,6 +733,16 @@ class TestRecordValidation(TestCase):
             }, lenient=True)
         self.assertEquals(('value',), ctx.exception.args)
 
+        # no exception if we're in lenient mode from config
+        Record.new(self.zone, 'www', {
+            'octodns': {
+                'lenient': True
+            },
+            'type': 'A',
+            'ttl': -1,
+            'value': '1.2.3.4',
+        }, lenient=True)
+
     def test_A_and_values_mixin(self):
         # doesn't blow up
         Record.new(self.zone, '', {


### PR DESCRIPTION
```yaml
---
'':
    octodns:
        ignored: True
        lenient: True
    type: CNAME # not valid to have a root cname
    value: foo.com.
```

This came out of looking at and thinking about https://github.com/github/octodns/issues/91#issuecomment-339629992, but I don't believe it's a fix to the specific problem there.