### PR TITLE
set default value for nsone cname to None, use first value if non-zer…

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -69,10 +69,14 @@ class Ns1Provider(BaseProvider):
         }
 
     def _data_for_CNAME(self, _type, record):
+        try:
+            value = record['short_answers'][0]
+        except IndexError:
+            value = None
         return {
             'ttl': record['ttl'],
             'type': _type,
-            'value': record['short_answers'][0],
+            'value': value,
         }
 
     _data_for_ALIAS = _data_for_CNAME

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -326,3 +326,34 @@ class TestNs1Provider(TestCase):
         })
         self.assertEquals(['foo; bar baz; blip'],
                           provider._params_for_TXT(record)['answers'])
+
+    def test_data_for_CNAME(self):
+        provider = Ns1Provider('test', 'api-key')
+
+        # answers from nsone
+        a_record = {
+            'ttl': 31,
+            'type': 'CNAME',
+            'short_answers': ['foo.unit.tests.']
+        }
+        a_expected = {
+            'ttl': 31,
+            'type': 'CNAME',
+            'value': 'foo.unit.tests.'
+        }
+        self.assertEqual(a_expected,
+                         provider._data_for_CNAME(a_record['type'], a_record))
+
+        # no answers from nsone
+        b_record = {
+            'ttl': 32,
+            'type': 'CNAME',
+            'short_answers': []
+        }
+        b_expected = {
+            'ttl': 32,
+            'type': 'CNAME',
+            'value': None
+        }
+        self.assertEqual(b_expected,
+                         provider._data_for_CNAME(b_record['type'], b_record))


### PR DESCRIPTION
NS1 will allow you to create a record with no answer. You cannot query for it however, but it will come back in their API/UI (According to their support, this is a feature/expected behavior, there is no RFC saying it is incorrect)

Other record types have a default value of `values = []`. CNAME, ALIAS, and PTR are the special cases in which only 1 answer is valid.

This adds a default value of None, otherwise only set the value if there is one

This addresses one part of: #131
