### PR TITLE
remove default config file for octodns-validate

### DIFF
--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -15,7 +15,7 @@ from octodns.manager import Manager
 def main():
     parser = ArgumentParser(description=__doc__.split('\n')[1])
 
-    parser.add_argument('--config-file', default='./config/production.yaml',
+    parser.add_argument('--config-file', required=True,
                         help='The Manager configuration file to use')
 
     args = parser.parse_args(WARN)


### PR DESCRIPTION
Addresses #95 

octodns-validate specifies a default config file, whereas other commands do not. This removes the default, and replaces it with a required.

As mentioned in #95, this will have small affects if people are relying on this default. The fix is relatively simple, users will just need to specify `--config-file=./config/production.yaml` when running the command.