### PR TITLE
Adds new plan_outputs functionality to allow configuring what to do with plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.pyc
 .coverage
 .env
-^config/
-build/
+/config/
 coverage.xml
 dist/
 env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 .coverage
 .env
+^config/
+build/
 coverage.xml
 dist/
 env/
@@ -9,5 +11,3 @@ nosetests.xml
 octodns.egg-info/
 output/
 tmp/
-build/
-config/

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -68,6 +68,8 @@ class Manager(object):
     def __init__(self, config_file, max_workers=None, include_meta=False):
         self.log.info('__init__: config_file=%s', config_file)
 
+        self.plan_outputs = [PlanLogger(self.log)]
+
         # Read our config file
         with open(config_file, 'r') as fh:
             self.config = safe_load(fh, enforce_order=False)
@@ -259,7 +261,8 @@ class Manager(object):
         # plan pairs.
         plans = [p for f in futures for p in f.result()]
 
-        PlanLogger(self.log).output(plans)
+        for output in self.plan_outputs:
+            output.run(plans)
 
         if not force:
             self.log.debug('sync:   checking safety')

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from StringIO import StringIO
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
 from os import environ
@@ -260,39 +259,7 @@ class Manager(object):
         # plan pairs.
         plans = [p for f in futures for p in f.result()]
 
-        hr = '*************************************************************' \
-            '*******************\n'
-        buf = StringIO()
-        buf.write('\n')
-        if plans:
-            current_zone = None
-            for target, plan in plans:
-                if plan.desired.name != current_zone:
-                    current_zone = plan.desired.name
-                    buf.write(hr)
-                    buf.write('* ')
-                    buf.write(current_zone)
-                    buf.write('\n')
-                    buf.write(hr)
-
-                buf.write('* ')
-                buf.write(target.id)
-                buf.write(' (')
-                buf.write(target)
-                buf.write(')\n*   ')
-                for change in plan.changes:
-                    buf.write(change.__repr__(leader='* '))
-                    buf.write('\n*   ')
-
-                buf.write('Summary: ')
-                buf.write(plan)
-                buf.write('\n')
-        else:
-            buf.write(hr)
-            buf.write('No changes were planned\n')
-        buf.write(hr)
-        buf.write('\n')
-        self.log.info(buf.getvalue())
+        PlanLogger(self.log).output(plans)
 
         if not force:
             self.log.debug('sync:   checking safety')

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -11,7 +11,8 @@ from importlib import import_module
 from os import environ
 import logging
 
-from .provider.base import BaseProvider, Plan
+from .provider.base import BaseProvider
+from .provider.plan import Plan, PlanLogger
 from .provider.yaml import YamlProvider
 from .record import Record
 from .yaml import safe_load

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -7,78 +7,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from ..source.base import BaseSource
 from ..zone import Zone
-from logging import getLogger
-
-
-class UnsafePlan(Exception):
-    pass
-
-
-class Plan(object):
-    log = getLogger('Plan')
-
-    MAX_SAFE_UPDATE_PCENT = .3
-    MAX_SAFE_DELETE_PCENT = .3
-    MIN_EXISTING_RECORDS = 10
-
-    def __init__(self, existing, desired, changes,
-                 update_pcent_threshold=MAX_SAFE_UPDATE_PCENT,
-                 delete_pcent_threshold=MAX_SAFE_DELETE_PCENT):
-        self.existing = existing
-        self.desired = desired
-        self.changes = changes
-        self.update_pcent_threshold = update_pcent_threshold
-        self.delete_pcent_threshold = delete_pcent_threshold
-
-        change_counts = {
-            'Create': 0,
-            'Delete': 0,
-            'Update': 0
-        }
-        for change in changes:
-            change_counts[change.__class__.__name__] += 1
-        self.change_counts = change_counts
-
-        try:
-            existing_n = len(self.existing.records)
-        except AttributeError:
-            existing_n = 0
-
-        self.log.debug('__init__: Creates=%d, Updates=%d, Deletes=%d'
-                       'Existing=%d',
-                       self.change_counts['Create'],
-                       self.change_counts['Update'],
-                       self.change_counts['Delete'], existing_n)
-
-    def raise_if_unsafe(self):
-        # TODO: what is safe really?
-        if self.existing and \
-           len(self.existing.records) >= self.MIN_EXISTING_RECORDS:
-
-            existing_record_count = len(self.existing.records)
-            update_pcent = self.change_counts['Update'] / existing_record_count
-            delete_pcent = self.change_counts['Delete'] / existing_record_count
-
-            if update_pcent > self.update_pcent_threshold:
-                raise UnsafePlan('Too many updates, {} is over {} percent'
-                                 '({}/{})'.format(
-                                     update_pcent,
-                                     self.MAX_SAFE_UPDATE_PCENT * 100,
-                                     self.change_counts['Update'],
-                                     existing_record_count))
-            if delete_pcent > self.delete_pcent_threshold:
-                raise UnsafePlan('Too many deletes, {} is over {} percent'
-                                 '({}/{})'.format(
-                                     delete_pcent,
-                                     self.MAX_SAFE_DELETE_PCENT * 100,
-                                     self.change_counts['Delete'],
-                                     existing_record_count))
-
-    def __repr__(self):
-        return 'Creates={}, Updates={}, Deletes={}, Existing Records={}' \
-            .format(self.change_counts['Create'], self.change_counts['Update'],
-                    self.change_counts['Delete'],
-                    len(self.existing.records))
+from .plan import Plan
 
 
 class BaseProvider(BaseSource):

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -218,7 +218,7 @@ class PlanHtml(_PlanOutput):
                 fh.write('<h3>')
                 fh.write(target.id)
                 fh.write('''</h3>
-<table border=3>
+<table>
   <tr>
     <th>Operation</th>
     <th>Name</th>

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -143,7 +143,7 @@ def _value_stringifier(record, sep):
         values = [str(v) for v in record.values]
     except AttributeError:
         values = [record.value]
-    for code, gv in getattr(record, 'geo', {}).items():
+    for code, gv in sorted(getattr(record, 'geo', {}).items()):
         vs = ', '.join([str(v) for v in gv.values])
         values.append('{}: {}'.format(code, vs))
     return sep.join(values)

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -263,4 +263,4 @@ class PlanHtml(_PlanOutput):
                 fh.write(str(plan))
                 fh.write('</td>\n  </tr>\n</table>\n')
         else:
-            fh.write('<h2>No changes were planned</h2>')
+            fh.write('<b>No changes were planned</b>')

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -155,15 +155,16 @@ class PlanMarkdown(_PlanOutput):
                 fh.write(target.id)
                 fh.write('\n\n')
 
-                fh.write('| Name | Type | Existing TTL | New TTL | '
-                         'Existing Value | New Value| Source |\n'
-                         '|--|--|--|--|--|--|--|\n')
+                fh.write('| Operation | Name | Type | TTL | Value | Source |\n'
+                         '|--|--|--|--|--|--|\n')
 
                 for change in plan.changes:
                     existing = change.existing
                     new = change.new
                     record = change.record
                     fh.write('| ')
+                    fh.write(change.__class__.__name__)
+                    fh.write(' | ')
                     fh.write(record.name)
                     fh.write(' | ')
                     fh.write(record._type)
@@ -171,27 +172,30 @@ class PlanMarkdown(_PlanOutput):
                     # TTL
                     if existing:
                         fh.write(str(existing.ttl))
-                    else:
-                        fh.write('n/a')
-                    fh.write(' | ')
+                        fh.write(' | ')
+                        if existing:
+                            try:
+                                v = existing.values
+                            except AttributeError:
+                                v = existing.value
+                            fh.write(str(v))
+                        else:
+                            fh.write('n/a')
+                        fh.write(' | |\n')
+                        if new:
+                            fh.write('| | | | ')
+
                     if new:
                         fh.write(str(new.ttl))
-                    else:
-                        fh.write('n/a')
-                    fh.write(' | ')
-                    # Value
-                    if existing:
-                        fh.write('todo')
-                    else:
-                        fh.write('n/a')
-                    fh.write(' | ')
-                    if new:
-                        fh.write('todo')
+                        fh.write(' | ')
+                        try:
+                            v = new.values
+                        except AttributeError:
+                            v = new.value
+                        fh.write(str(v))
                         fh.write(' | ')
                         fh.write(new.source.id)
-                    else:
-                        fh.write('n/a')
-                    fh.write(' |\n')
+                        fh.write(' |\n')
 
                 fh.write('\nSummary: ')
                 fh.write(str(plan))

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -86,7 +86,7 @@ class PlanLogger(object):
         self.log = log
         self.level = level
 
-    def output(self, plans):
+    def run(self, plans):
         hr = '*************************************************************' \
             '*******************\n'
         buf = StringIO()

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -1,0 +1,79 @@
+#
+#
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from logging import getLogger
+
+
+class UnsafePlan(Exception):
+    pass
+
+
+class Plan(object):
+    log = getLogger('Plan')
+
+    MAX_SAFE_UPDATE_PCENT = .3
+    MAX_SAFE_DELETE_PCENT = .3
+    MIN_EXISTING_RECORDS = 10
+
+    def __init__(self, existing, desired, changes,
+                 update_pcent_threshold=MAX_SAFE_UPDATE_PCENT,
+                 delete_pcent_threshold=MAX_SAFE_DELETE_PCENT):
+        self.existing = existing
+        self.desired = desired
+        self.changes = changes
+        self.update_pcent_threshold = update_pcent_threshold
+        self.delete_pcent_threshold = delete_pcent_threshold
+
+        change_counts = {
+            'Create': 0,
+            'Delete': 0,
+            'Update': 0
+        }
+        for change in changes:
+            change_counts[change.__class__.__name__] += 1
+        self.change_counts = change_counts
+
+        try:
+            existing_n = len(self.existing.records)
+        except AttributeError:
+            existing_n = 0
+
+        self.log.debug('__init__: Creates=%d, Updates=%d, Deletes=%d'
+                       'Existing=%d',
+                       self.change_counts['Create'],
+                       self.change_counts['Update'],
+                       self.change_counts['Delete'], existing_n)
+
+    def raise_if_unsafe(self):
+        # TODO: what is safe really?
+        if self.existing and \
+           len(self.existing.records) >= self.MIN_EXISTING_RECORDS:
+
+            existing_record_count = len(self.existing.records)
+            update_pcent = self.change_counts['Update'] / existing_record_count
+            delete_pcent = self.change_counts['Delete'] / existing_record_count
+
+            if update_pcent > self.update_pcent_threshold:
+                raise UnsafePlan('Too many updates, {} is over {} percent'
+                                 '({}/{})'.format(
+                                     update_pcent,
+                                     self.MAX_SAFE_UPDATE_PCENT * 100,
+                                     self.change_counts['Update'],
+                                     existing_record_count))
+            if delete_pcent > self.delete_pcent_threshold:
+                raise UnsafePlan('Too many deletes, {} is over {} percent'
+                                 '({}/{})'.format(
+                                     delete_pcent,
+                                     self.MAX_SAFE_DELETE_PCENT * 100,
+                                     self.change_counts['Delete'],
+                                     existing_record_count))
+
+    def __repr__(self):
+        return 'Creates={}, Updates={}, Deletes={}, Existing Records={}' \
+            .format(self.change_counts['Create'], self.change_counts['Update'],
+                    self.change_counts['Delete'],
+                    len(self.existing.records))

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -138,6 +138,17 @@ class PlanLogger(_PlanOutput):
         log.log(self.level, buf.getvalue())
 
 
+def _value_stringifier(record, sep):
+    try:
+        values = [str(v) for v in record.values]
+    except AttributeError:
+        values = [record.value]
+    for code, gv in getattr(record, 'geo', {}).items():
+        vs = ', '.join([str(v) for v in gv.values])
+        values.append('{}: {}'.format(code, vs))
+    return sep.join(values)
+
+
 class PlanMarkdown(_PlanOutput):
 
     def run(self, plans, *args, **kwargs):
@@ -174,11 +185,7 @@ class PlanMarkdown(_PlanOutput):
                         fh.write(str(existing.ttl))
                         fh.write(' | ')
                         if existing:
-                            try:
-                                v = existing.values
-                            except AttributeError:
-                                v = existing.value
-                            fh.write(str(v))
+                            fh.write(_value_stringifier(existing, '; '))
                         else:
                             fh.write('n/a')
                         fh.write(' | |\n')
@@ -188,11 +195,7 @@ class PlanMarkdown(_PlanOutput):
                     if new:
                         fh.write(str(new.ttl))
                         fh.write(' | ')
-                        try:
-                            v = new.values
-                        except AttributeError:
-                            v = new.value
-                        fh.write(str(v))
+                        fh.write(_value_stringifier(new, '; '))
                         fh.write(' | ')
                         fh.write(new.source.id)
                         fh.write(' |\n')

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from StringIO import StringIO
-from logging import INFO, getLogger
+from logging import DEBUG, ERROR, INFO, WARN, getLogger
 
 
 class UnsafePlan(Exception):
@@ -80,13 +80,28 @@ class Plan(object):
                     len(self.existing.records))
 
 
-class PlanLogger(object):
+class _PlanOutput(object):
 
-    def __init__(self, log, level=INFO):
-        self.log = log
-        self.level = level
+    def __init__(self, name):
+        self.name = name
 
-    def run(self, plans):
+
+class PlanLogger(_PlanOutput):
+
+    def __init__(self, name, level='info'):
+        super(PlanLogger, self).__init__(name)
+        try:
+            self.level = {
+                'debug': DEBUG,
+                'info': INFO,
+                'warn': WARN,
+                'warning': WARN,
+                'error': ERROR
+            }[level.lower()]
+        except (AttributeError, KeyError):
+            raise Exception('Unsupported level: {}'.format(level))
+
+    def run(self, log, plans, *args, **kwargs):
         hr = '*************************************************************' \
             '*******************\n'
         buf = StringIO()
@@ -119,4 +134,4 @@ class PlanLogger(object):
             buf.write('No changes were planned\n')
         buf.write(hr)
         buf.write('\n')
-        self.log.log(self.level, buf.getvalue())
+        log.log(self.level, buf.getvalue())

--- a/tests/config/bad-plan-output-config.yaml
+++ b/tests/config/bad-plan-output-config.yaml
@@ -1,0 +1,7 @@
+manager:
+  plan_outputs:
+    'bad': 
+      class: octodns.provider.plan.PlanLogger
+      invalid: config
+providers: {}
+zones: {}

--- a/tests/config/bad-plan-output-missing-class.yaml
+++ b/tests/config/bad-plan-output-missing-class.yaml
@@ -1,0 +1,5 @@
+manager:
+  plan_outputs:
+    'bad': {}
+providers: {}
+zones: {}

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -83,6 +83,19 @@ class TestManager(TestCase):
                 .sync(['unknown.target.'])
         self.assertTrue('unknown target' in ctx.exception.message)
 
+    def test_bad_plan_output_class(self):
+        with self.assertRaises(Exception) as ctx:
+            name = 'bad-plan-output-missing-class.yaml'
+            Manager(get_config_filename(name)).sync()
+        self.assertEquals('plan_output bad is missing class',
+                          ctx.exception.message)
+
+    def test_bad_plan_output_config(self):
+        with self.assertRaises(Exception) as ctx:
+            Manager(get_config_filename('bad-plan-output-config.yaml')).sync()
+        self.assertEqual('Incorrect plan_output config for bad',
+                         ctx.exception.message)
+
     def test_source_only_as_a_target(self):
         with self.assertRaises(Exception) as ctx:
             Manager(get_config_filename('unknown-provider.yaml')) \

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -1,0 +1,19 @@
+#
+#
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from unittest import TestCase
+
+from octodns.provider.plan import PlanLogger
+
+
+class TestPlanLogger(TestCase):
+
+    def test_invalid_level(self):
+        with self.assertRaises(Exception) as ctx:
+            PlanLogger('invalid', 'not-a-level')
+        self.assertEquals('Unsupported level: not-a-level',
+                          ctx.exception.message)

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -5,9 +5,15 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
+from StringIO import StringIO
+from logging import getLogger
 from unittest import TestCase
 
-from octodns.provider.plan import PlanLogger
+from octodns.provider.plan import Plan, PlanHtml, PlanLogger, PlanMarkdown
+from octodns.record import Create, Delete, Record, Update
+from octodns.zone import Zone
+
+from helpers import SimpleProvider
 
 
 class TestPlanLogger(TestCase):
@@ -17,3 +23,70 @@ class TestPlanLogger(TestCase):
             PlanLogger('invalid', 'not-a-level')
         self.assertEquals('Unsupported level: not-a-level',
                           ctx.exception.message)
+
+
+simple = SimpleProvider()
+zone = Zone('unit.tests.', [])
+existing = Record.new(zone, 'a', {
+    'ttl': 300,
+    'type': 'A',
+    # This matches the zone data above, one to swap, one to leave
+    'values': ['1.1.1.1', '2.2.2.2'],
+})
+new = Record.new(zone, 'a', {
+    'geo': {
+        'AF': ['5.5.5.5'],
+        'NA-US': ['6.6.6.6']
+    },
+    'ttl': 300,
+    'type': 'A',
+    # This leaves one, swaps ones, and adds one
+    'values': ['2.2.2.2', '3.3.3.3', '4.4.4.4'],
+}, simple)
+create = Create(Record.new(zone, 'b', {
+    'ttl': 60,
+    'type': 'CNAME',
+    'value': 'foo.unit.tests.'
+}, simple))
+update = Update(existing, new)
+delete = Delete(new)
+changes = [create, delete, update]
+plans = [
+    (simple, Plan(zone, zone, changes)),
+    (simple, Plan(zone, zone, changes)),
+]
+
+
+class TestPlanHtml(TestCase):
+    log = getLogger('TestPlanHtml')
+
+    def test_empty(self):
+        out = StringIO()
+        PlanHtml('html').run([], fh=out)
+        self.assertEquals('<b>No changes were planned</b>', out.getvalue())
+
+    def test_simple(self):
+        out = StringIO()
+        PlanHtml('html').run(plans, fh=out)
+        out = out.getvalue()
+        self.assertTrue('    <td colspan=6>Summary: Creates=1, Updates=1, '
+                        'Deletes=1, Existing Records=0</td>' in out)
+
+
+class TestPlanMarkdown(TestCase):
+    log = getLogger('TestPlanMarkdown')
+
+    def test_empty(self):
+        out = StringIO()
+        PlanMarkdown('markdown').run([], fh=out)
+        self.assertEquals('## No changes were planned\n', out.getvalue())
+
+    def test_simple(self):
+        out = StringIO()
+        PlanMarkdown('markdown').run(plans, fh=out)
+        out = out.getvalue()
+        self.assertTrue('## unit.tests.' in out)
+        self.assertTrue('Create | b | CNAME | 60 | foo.unit.tests.' in out)
+        self.assertTrue('Update | a | A | 300 | 1.1.1.1;' in out)
+        self.assertTrue('NA-US: 6.6.6.6 | test' in out)
+        self.assertTrue('Delete | a | A | 300 | 2.2.2.2;' in out)

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -9,7 +9,8 @@ from logging import getLogger
 from unittest import TestCase
 
 from octodns.record import Create, Delete, Record, Update
-from octodns.provider.base import BaseProvider, Plan, UnsafePlan
+from octodns.provider.base import BaseProvider
+from octodns.provider.plan import Plan, UnsafePlan
 from octodns.zone import Zone
 
 


### PR DESCRIPTION

- [x] Plumbing for `plan_output` support, configurable from the config file
- [x] Port existing logger output to a `plan_output` ^
- [x]  Create a Markdown `plan_output`
- [x]  Create a HTML `plan_output`

/cc @wrouesnel
/cc Fixes https://github.com/github/octodns/issues/155