### PR TITLE
Route53's NAPTR values should default to '' not None

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -385,10 +385,10 @@ class Route53Provider(BaseProvider):
             values.append({
                 'order': order,
                 'preference': preference,
-                'flags': flags if flags else None,
-                'service': service if service else None,
-                'regexp': regexp if regexp else None,
-                'replacement': replacement if replacement else None,
+                'flags': flags,
+                'service': service,
+                'regexp': regexp,
+                'replacement': replacement,
             })
         return {
             'type': rrset['Type'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,15 +45,15 @@ exclude =
 
 [options.extras_require]
 dev = 
-    azure-mgmt-dns>=1.0.1
-    azure-common>=1.1.6
+    azure-mgmt-dns==1.0.1
+    azure-common==1.1.6
     boto3>=1.4.6
     botocore>=1.6.8
     docutils>=0.14
     dyn>=1.8.0
     google-cloud>=0.27.0
     jmespath>=0.9.3
-    msrestazure>=0.4.10
+    msrestazure==0.4.10
     nsone>=0.9.14
     ovh>=0.4.7
     s3transfer>=0.1.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,12 +22,12 @@ classifiers =
 install_requires = 
     PyYaml>=3.12
     dnspython>=1.15.0
-    futures==3.1.1
-    incf.countryutils==1.0
-    ipaddress==1.0.18
-    natsort==5.0.3
-    python-dateutil==2.6.1
-    requests==2.13.0
+    futures>=3.1.1
+    incf.countryutils>=1.0
+    ipaddress>=1.0.18
+    natsort>=5.0.3
+    python-dateutil>=2.6.1
+    requests>=2.13.0
 packages = find:
 include_package_data = True
 
@@ -45,19 +45,19 @@ exclude =
 
 [options.extras_require]
 dev = 
-    azure-mgmt-dns==1.0.1
-    azure-common==1.1.6
-    boto3==1.4.6
-    botocore==1.6.8
-    docutils==0.14
-    dyn==1.8.0
-    google-cloud==0.27.0
-    jmespath==0.9.3
-    msrestazure==0.4.10
-    nsone==0.9.14
-    ovh==0.4.7
-    s3transfer==0.1.10
-    six==1.10.0
+    azure-mgmt-dns>=1.0.1
+    azure-common>=1.1.6
+    boto3>=1.4.6
+    botocore>=1.6.8
+    docutils>=0.14
+    dyn>=1.8.0
+    google-cloud>=0.27.0
+    jmespath>=0.9.3
+    msrestazure>=0.4.10
+    nsone>=0.9.14
+    ovh>=0.4.7
+    s3transfer>=0.1.10
+    six>=1.10.0
 test =
     coverage
     mock


### PR DESCRIPTION
To be consistent with the other providers the default should be to use the empty strings rather than `None`. There's a TODO around validation of NAPTR values that should also include checks for `None`, but I'm not taking on that change as part of this fix.

Fixes https://github.com/github/octodns/issues/161