### PR TITLE
Cloudflare ALIAS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | Provider | Record Support | GeoDNS Support | Notes |
 |--|--|--|--|
 | [AzureProvider](/octodns/provider/azuredns.py) | A, AAAA, CNAME, MX, NS, PTR, SRV, TXT | No | |
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CAA, CNAME, MX, NS, SPF, TXT | No | CAA tags restricted |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, ALIAS, CAA, CNAME, MX, NS, SPF, TXT | No | CAA tags restricted |
 | [DigitalOceanProvider](/octodns/provider/digitalocean.py) | A, AAAA, CAA, CNAME, MX, NS, TXT, SRV | No | CAA tags restricted |
 | [DnsimpleProvider](/octodns/provider/dnsimple.py) | All | No | CAA tags restricted |
 | [DynProvider](/octodns/provider/dyn.py) | All | Yes | |

--- a/tests/fixtures/cloudflare-dns_records-page-1.json
+++ b/tests/fixtures/cloudflare-dns_records-page-1.json
@@ -180,7 +180,7 @@
     "per_page": 10,
     "total_pages": 2,
     "count": 10,
-    "total_count": 17
+    "total_count": 19
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-dns_records-page-2.json
+++ b/tests/fixtures/cloudflare-dns_records-page-2.json
@@ -163,7 +163,7 @@
     "per_page": 10,
     "total_pages": 2,
     "count": 9,
-    "total_count": 20
+    "total_count": 19
   },
   "success": true,
   "errors": [],


### PR DESCRIPTION
They're translated to/from root `CNAME` records which have the same semantics in Cloudflare as the octoDNS `ALIAS` record type.

Fixes #91
/cc @parkr @jr-RXcode