### PR TITLE
Handle MX preference of 0

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -506,7 +506,10 @@ class MxValue(object):
     def _validate_value(cls, value):
         reasons = []
         try:
-            int(value.get('preference', None) or value['priority'])
+            try:
+                int(value['preference'])
+            except KeyError:
+                int(value['priority'])
         except KeyError:
             reasons.append('missing preference')
         except ValueError:

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -345,7 +345,7 @@ class TestRecord(TestCase):
         self.assertEquals(a_data, a.data)
 
         b_value = {
-            'preference': 12,
+            'preference': 0,
             'exchange': 'smtp3.',
         }
         b_data = {'ttl': 30, 'value': b_value}


### PR DESCRIPTION

Logic would fail when `preference` existed, but was `0`. 

Fixes https://github.com/github/octodns/issues/172
/cc @bcruik