### PR TITLE
Option to handle Cloudflare proxied records

### DIFF
--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -251,15 +251,8 @@ class CloudflareProvider(BaseProvider):
 
         # If this is a record to enable Cloudflare CDN don't update as
         # we don't know the original values.
-        if (hasattr(change.new, '_type') and
-            (change.new._type == 'CNAME' or
-             change.new._type == 'ALIAS') and
-                change.new.value.endswith('.cdn.cloudflare.net.')):
-            return False
-        if (hasattr(change.existing, '_type') and
-            (change.existing._type == 'CNAME' or
-             change.existing._type == 'ALIAS') and
-                change.existing.value.endswith('.cdn.cloudflare.net.')):
+        if (change.record._type in ('ALIAS', 'CNAME') and
+                change.record.value.endswith('.cdn.cloudflare.net.')):
             return False
 
         return True

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -541,21 +541,61 @@ class TestCloudflareProvider(TestCase):
                     "auto_added": False
                 }
             },
+            {
+                "id": "fc12ab34cd5611334422ab3322997642",
+                "type": "A",
+                "name": "multi.unit.tests",
+                "content": "1.1.1.3",
+                "proxiable": True,
+                "proxied": True,
+                "ttl": 300,
+                "locked": False,
+                "zone_id": "ff12ab34cd5611334422ab3322997650",
+                "zone_name": "unit.tests",
+                "modified_on": "2017-03-11T18:01:43.420689Z",
+                "created_on": "2017-03-11T18:01:43.420689Z",
+                "meta": {
+                    "auto_added": False
+                }
+            },
+            {
+                "id": "fc12ab34cd5611334422ab3322997642",
+                "type": "AAAA",
+                "name": "multi.unit.tests",
+                "content": "::1",
+                "proxiable": True,
+                "proxied": True,
+                "ttl": 300,
+                "locked": False,
+                "zone_id": "ff12ab34cd5611334422ab3322997650",
+                "zone_name": "unit.tests",
+                "modified_on": "2017-03-11T18:01:43.420689Z",
+                "created_on": "2017-03-11T18:01:43.420689Z",
+                "meta": {
+                    "auto_added": False
+                }
+            },
         ])
 
         zone = Zone('unit.tests.', [])
         provider.populate(zone)
 
         # the two A records get merged into one CNAME record poining to the CDN
-        self.assertEquals(2, len(zone.records))
+        self.assertEquals(3, len(zone.records))
 
         record = list(zone.records)[0]
+        self.assertEquals('multi', record.name)
+        self.assertEquals('multi.unit.tests.', record.fqdn)
+        self.assertEquals('CNAME', record._type)
+        self.assertEquals('multi.unit.tests.cdn.cloudflare.net.', record.value)
+
+        record = list(zone.records)[1]
         self.assertEquals('cname', record.name)
         self.assertEquals('cname.unit.tests.', record.fqdn)
         self.assertEquals('CNAME', record._type)
         self.assertEquals('cname.unit.tests.cdn.cloudflare.net.', record.value)
 
-        record = list(zone.records)[1]
+        record = list(zone.records)[2]
         self.assertEquals('a', record.name)
         self.assertEquals('a.unit.tests.', record.fqdn)
         self.assertEquals('CNAME', record._type)
@@ -573,6 +613,11 @@ class TestCloudflareProvider(TestCase):
             'ttl': 300,
             'type': 'CNAME',
             'value': 'new.unit.tests.cdn.cloudflare.net.'
+        }))
+        wanted.add_record(Record.new(wanted, 'created', {
+            'ttl': 300,
+            'type': 'CNAME',
+            'value': 'www.unit.tests.'
         }))
 
         plan = provider.plan(wanted)


### PR DESCRIPTION
This change imports records that are marked as proxied so that they can be synced to other DNS providers as described in [this support acticle](https://support.cloudflare.com/hc/en-us/articles/115000830351-How-to-configure-DNS-for-CNAME-partial-setup-when-managing-DNS-externally). Records that use this functionality will be ignored by this provider and not be synced back to Cloudflare as we don't know the origin record values that would be required.

This change does not allow you to enable, disable or configure the CDN itself as that would require a lot of metadata to be handled by OctoDNS. 

The intention of this change is to allow users to run a multi-DNS provider setup without sending any traffic to their origin directly.

Resolves https://github.com/github/octodns/issues/65