### PR TITLE
Fix SRV and SSHFP record for OVH provider

### DIFF
--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -259,10 +259,11 @@ class OvhProvider(BaseProvider):
     def _params_for_SRV(record):
         for value in record.values:
             yield {
-                'subDomain': '{} {} {} {}'.format(value.priority,
-                                                  value.weight, value.port,
-                                                  value.target),
-                'target': record.name,
+                'target': '{} {} {} {}'.format(value.priority,
+                                               value.weight,
+                                               value.port,
+                                               value.target),
+                'subDomain': record.name,
                 'ttl': record.ttl,
                 'fieldType': record._type
             }
@@ -271,10 +272,10 @@ class OvhProvider(BaseProvider):
     def _params_for_SSHFP(record):
         for value in record.values:
             yield {
-                'subDomain': '{} {} {}'.format(value.algorithm,
-                                               value.fingerprint_type,
-                                               value.fingerprint),
-                'target': record.name,
+                'target': '{} {} {}'.format(value.algorithm,
+                                            value.fingerprint_type,
+                                            value.fingerprint),
+                'subDomain': record.name,
                 'ttl': record.ttl,
                 'fieldType': record._type
             }

--- a/tests/test_octodns_provider_ovh.py
+++ b/tests/test_octodns_provider_ovh.py
@@ -378,11 +378,11 @@ class TestOvhProvider(TestCase):
                     call(u'/domain/zone/unit.tests/record', fieldType=u'A',
                          subDomain=u'', target=u'1.2.3.4', ttl=100),
                     call(u'/domain/zone/unit.tests/record', fieldType=u'SRV',
-                         subDomain=u'10 20 30 foo-1.unit.tests.',
-                         target='_srv._tcp', ttl=800),
+                         subDomain='_srv._tcp',
+                         target=u'10 20 30 foo-1.unit.tests.', ttl=800),
                     call(u'/domain/zone/unit.tests/record', fieldType=u'SRV',
-                         subDomain=u'40 50 60 foo-2.unit.tests.',
-                         target='_srv._tcp', ttl=800),
+                         subDomain='_srv._tcp',
+                         target=u'40 50 60 foo-2.unit.tests.', ttl=800),
                     call(u'/domain/zone/unit.tests/record', fieldType=u'PTR',
                          subDomain='4', target=u'unit.tests.', ttl=900),
                     call(u'/domain/zone/unit.tests/record', fieldType=u'NS',
@@ -390,8 +390,8 @@ class TestOvhProvider(TestCase):
                     call(u'/domain/zone/unit.tests/record', fieldType=u'NS',
                          subDomain='www3', target=u'ns4.unit.tests.', ttl=700),
                     call(u'/domain/zone/unit.tests/record',
-                         fieldType=u'SSHFP', target=u'', ttl=1100,
-                         subDomain=u'1 1 bf6b6825d2977c511a475bbefb88a'
+                         fieldType=u'SSHFP', subDomain=u'', ttl=1100,
+                         target=u'1 1 bf6b6825d2977c511a475bbefb88a'
                                    u'ad54'
                                    u'a92ac73',
                          ),


### PR DESCRIPTION
 * Fix for SRV and SSHFP record for OVH provider
   - There was an inversion between the target and the subdomain for this two records type

After fix
```
********************************************************************************
* mydomain.tld.
********************************************************************************
* ovh (OvhProvider)
*   Create <SrvRecord SRV 300, _srv._tcp.mydomain.tld., [''1 1 1234 mysrv.mydomain.tld.'']> (config)
*   Create <SshfpRecord SSHFP 300, sshfp.mydomain.tld., [''1 1 bf6b6825d2977c511a475bbefb88aad54a92ac73'']> (config)
*   Summary: Creates=2, Updates=0, Deletes=0, Existing Records=1
********************************************************************************
2018-02-12T17:38:00  [140012798756672] INFO  OvhProvider[ovh] _apply: zone=mydomain.tld., len(changes)=2
2018-02-12T17:38:00  [140012798756672] INFO  Manager sync:   2 total changes
```