### PR TITLE
Properly set filter rules for geo answers

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -234,10 +234,9 @@ class Ns1Provider(BaseProvider):
                     )
             params['filters'] = []
             if has_country:
-                if len(params['answers']) > 1:
-                    params['filters'].append(
-                        {"filter": "shuffle", "config": {}}
-                    )
+                params['filters'].append(
+                    {"filter": "shuffle", "config": {}}
+                )
                 params['filters'].append(
                     {"filter": "geotarget_country", "config": {}}
                 )

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -233,11 +233,11 @@ class Ns1Provider(BaseProvider):
                         },
                     )
             params['filters'] = []
-            if len(params['answers']) > 1:
-                params['filters'].append(
-                    {"filter": "shuffle", "config": {}}
-                )
             if has_country:
+                if len(params['answers']) > 1:
+                    params['filters'].append(
+                        {"filter": "shuffle", "config": {}}
+                    )
                 params['filters'].append(
                     {"filter": "geotarget_country", "config": {}}
                 )


### PR DESCRIPTION
Only set filter rules when geo target information is configured.  If the answer has no geo target, don't set the rules.
