### PR TITLE
Generate the zone name following the spec of Google Cloud DNS

### DIFF
--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -127,9 +127,12 @@ class GoogleCloudProvider(BaseProvider):
             :type return: new google.cloud.dns.ManagedZone
         """
         # Zone name must begin with a letter, end with a letter or digit,
-        # and only contain lowercase letters, digits or dashes
+        # and only contain lowercase letters, digits or dashes,
+        # and be 63 characters or less
         zone_name = '{}-{}'.format(
-            dns_name[:-1].replace('.', '-'), uuid4().hex)
+            dns_name.replace('.', '-'), uuid4().hex)[:63]
+        if not zone_name[:1].isalpha():
+            zone_name = 'zone-{}'.format(zone_name[:58])
 
         gcloud_zone = self.gcloud_client.zone(
             name=zone_name,

--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -129,10 +129,8 @@ class GoogleCloudProvider(BaseProvider):
         # Zone name must begin with a letter, end with a letter or digit,
         # and only contain lowercase letters, digits or dashes,
         # and be 63 characters or less
-        zone_name = '{}-{}'.format(
+        zone_name = 'zone-{}-{}'.format(
             dns_name.replace('.', '-'), uuid4().hex)[:63]
-        if not zone_name[:1].isalpha():
-            zone_name = 'zone-{}'.format(zone_name[:58])
 
         gcloud_zone = self.gcloud_client.zone(
             name=zone_name,

--- a/tests/test_octodns_provider_googlecloud.py
+++ b/tests/test_octodns_provider_googlecloud.py
@@ -427,3 +427,18 @@ class TestGoogleCloudProvider(TestCase):
 
         mock_zone.create.assert_called()
         provider.gcloud_client.zone.assert_called()
+
+    def test__create_zone_ip6_arpa(self):
+        def _create_dummy_zone(name, dns_name):
+            return DummyGoogleCloudZone(name=name, dns_name=dns_name)
+
+        provider = self._get_provider()
+
+        provider.gcloud_client = Mock()
+        provider.gcloud_client.zone = Mock(side_effect=_create_dummy_zone)
+
+        mock_zone = \
+            provider._create_gcloud_zone('0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa')
+
+        self.assertRegexpMatches(mock_zone.name, '^[a-z][a-z0-9-]*[a-z0-9]$')
+        self.assertEqual(len(mock_zone.name), 63)


### PR DESCRIPTION
According to the [document](https://developers.google.com/resources/api-libraries/documentation/dns/v1/csharp/latest/classGoogle_1_1Apis_1_1Dns_1_1v1_1_1Data_1_1ManagedZone.html), the zone name must **begin with a letter**, end with a letter or digit, and only contain lowercase letters, digits or dashes, and be **63 characters or less**.

For instance, a reverse zone of IPv6 may violate these two rules.

```
google.api_core.exceptions.BadRequest: 400 POST https://www.googleapis.com/dns/v1/projects/test-195012/managedZones: Invalid value for 'entity.managedZone.name': '2-0-0-c-0-8-d-b-3-0-4-2-ip6-arpa-8fac44e4673543a499d9da974f210a69'
```

This PR implements two logics in generating the zone name so that we may follow the spec of Google Cloud DNS.