### PR TITLE
Check Route 53 records against all supported types

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -461,7 +461,7 @@ class Route53Provider(BaseProvider):
                 record_name = zone.hostname_from_fqdn(rrset['Name'])
                 record_name = _octal_replace(record_name)
                 record_type = rrset['Type']
-                if record_type == 'SOA':
+                if record_type not in self.SUPPORTS:
                     continue
                 data = getattr(self, '_data_for_{}'.format(record_type))(rrset)
                 records[record_name][record_type].append(data)


### PR DESCRIPTION
As discussed at https://github.com/github/octodns/pull/111#issuecomment-365614180, a small fix to check Route 53 records are of a type contained in the `SUPPORTS` set.