### PR TITLE
Remove unnecessary argument "cdn" from CloudflareProvider

### DIFF
--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -56,7 +56,7 @@ class CloudflareProvider(BaseProvider):
         self.log = getLogger('CloudflareProvider[{}]'.format(id))
         self.log.debug('__init__: id=%s, email=%s, token=***, cdn=%s', id,
                        email, cdn)
-        super(CloudflareProvider, self).__init__(id, cdn, *args, **kwargs)
+        super(CloudflareProvider, self).__init__(id, *args, **kwargs)
 
         sess = Session()
         sess.headers.update({


### PR DESCRIPTION
Hi,
I found a bug that if `cdn` argument is set to true, applying the changes will be disabled with following message.
`2018-02-17T20:28:06  [140736029999936] INFO  CloudflareProvider[cloudflare] apply: disabled`

This is because `cdn` arguement is given to `CloudflareProvider`'s super class `BaseProvider` as `apply_disabled`.

This PR solves this issue.