### PR TITLE
Skip Alias recordset for Route53 Provider

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -463,6 +463,12 @@ class Route53Provider(BaseProvider):
                 record_type = rrset['Type']
                 if record_type == 'SOA':
                     continue
+                if 'AliasTarget' in rrset:
+                    # Alias records are Route53 specific and are not
+                    # portable, so we need to skip them
+                    self.log.warning("%s is an Alias record. Skipping..."
+                                     % rrset['Name'])
+                    continue
                 data = getattr(self, '_data_for_{}'.format(record_type))(rrset)
                 records[record_name][record_type].append(data)
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -313,6 +313,14 @@ class TestRoute53Provider(TestCase):
                     'Value': '0 issue "ca.unit.tests"',
                 }],
                 'TTL': 69,
+            }, {
+                'AliasTarget': {
+                    'HostedZoneId': 'Z119WBBTVP5WFX',
+                    'EvaluateTargetHealth': False,
+                    'DNSName': 'unit.tests.'
+                },
+                'Type': 'A',
+                'Name': 'alias.unit.tests.'
             }],
             'IsTruncated': False,
             'MaxItems': '100',


### PR DESCRIPTION
Fixes #26

Alias records are essentially CNAME records, but can be designated to
the Apex of the domain. They are typically for AWS resources only and
are not portable