### PR TITLE
Make sure to insert new rulesets at the "end"

### DIFF
--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -535,6 +535,12 @@ class DynProvider(BaseProvider):
         for ruleset in existing_rulesets:
             for pool in ruleset.response_pools:
                 pools[pool.response_pool_id] = pool
+        # Reverse sort the existing_rulesets by _ordering so that we'll remove
+        # them in that order later, this will ensure that we remove the old
+        # default before any of the old geo rules preventing it from catching
+        # everything.
+        existing_rulesets.sort(key=lambda r: r._ordering, reverse=True)
+
         # Now we need to find any pools that aren't referenced by rules
         for pool in td.all_response_pools:
             rpid = pool.response_pool_id

--- a/tests/test_octodns_provider_dyn.py
+++ b/tests/test_octodns_provider_dyn.py
@@ -1151,11 +1151,11 @@ class TestDynProviderGeo(TestCase):
         change = Create(self.geo_record)
         provider._mod_rulesets(td_mock, change)
         ruleset_create_mock.assert_has_calls((
-            call(td_mock, index=0),
-            call(td_mock, index=0),
-            call(td_mock, index=0),
-            call(td_mock, index=0),
-            call(td_mock, index=0),
+            call(td_mock, index=2),
+            call(td_mock, index=2),
+            call(td_mock, index=2),
+            call(td_mock, index=2),
+            call(td_mock, index=2),
         ))
         add_response_pool_mock.assert_has_calls((
             # default


### PR DESCRIPTION
Dyn will still match them, even while they're empty before we've had a
chance to add the respons pools to them which is BAD and caused a
medium-size outage (thankfully not as bad as it could have been.) Ideally
we'd use publish=False and stage things, but that seems broken in the client
lib, there's no way to send publish=N. I also tried sending the
response_pool_ids as part of the create calls and response pool config if
one didn't exist, but neither of those routes worked :-(