### PR TITLE
Mark SSHFP algorithm 4 as valid

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -722,7 +722,7 @@ class PtrRecord(_ValueMixin, Record):
 
 
 class SshfpValue(object):
-    VALID_ALGORITHMS = (1, 2, 3)
+    VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
 
     @classmethod


### PR DESCRIPTION
[RFC 7479](https://tools.ietf.org/html/rfc7479) introduces support for Ed25519 host keys for the SSHFP record.