### PR TITLE
Skip unsupported records for NS1 & DNSimple

### DIFF
--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -256,7 +256,7 @@ class DnsimpleProvider(BaseProvider):
         values = defaultdict(lambda: defaultdict(list))
         for record in self.zone_records(zone):
             _type = record['type']
-            if _type == 'SOA':
+            if _type not in self.SUPPORTS:
                 continue
             elif _type == 'TXT' and record['content'].startswith('ALIAS for'):
                 # ALIAS has a "ride along" TXT record with 'ALIAS for XXXX',

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -204,6 +204,8 @@ class Ns1Provider(BaseProvider):
         zone_hash = {}
         for record in chain(records, geo_records):
             _type = record['type']
+            if _type not in self.SUPPORTS:
+                continue
             data_for = getattr(self, '_data_for_{}'.format(_type))
             name = zone.hostname_from_fqdn(record['domain'])
             record = Record.new(zone, name, data_for(_type, record),


### PR DESCRIPTION
Implements the unsupported records skipping fix [proposed by ross](https://github.com/github/octodns/issues/176#issuecomment-359294960) in #176 for DNSimple and additionally for NS1.

Fixes #176 and also the NS1 version of it (`AttributeError: 'Ns1Provider' object has no attribute '_data_for_DNSKEY'`) that currently affect domains that have DNSSEC enabled.