### PR TITLE
Fixed powerdns provider

### DIFF
--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -20,6 +20,10 @@ class PowerDnsBaseProvider(BaseProvider):
 
     def __init__(self, id, host, api_key, port=8081, scheme="http",
                  timeout=TIMEOUT, *args, **kwargs):
+        self.log = logging.getLogger('PowerDnsBaseProvider[{}]'.format(id))
+        self.log.debug('__init__: id=%s, host=%s, api_key=%d, '
+                       'port=%d, scheme=%s', id, host, api_key,
+                       port, scheme)
         super(PowerDnsBaseProvider, self).__init__(id, *args, **kwargs)
 
         self.host = host

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -21,7 +21,7 @@ class PowerDnsBaseProvider(BaseProvider):
     def __init__(self, id, host, api_key, port=8081, scheme="http",
                  timeout=TIMEOUT, *args, **kwargs):
         self.log = logging.getLogger('PowerDnsBaseProvider[{}]'.format(id))
-        self.log.debug('__init__: id=%s, host=%s, api_key=%d, '
+        self.log.debug('__init__: id=%s, host=%s, api_key=%s, '
                        'port=%d, scheme=%s', id, host, api_key,
                        port, scheme)
         super(PowerDnsBaseProvider, self).__init__(id, *args, **kwargs)


### PR DESCRIPTION
Not implemented error:

```
(env) [rick.stokkingreef@WPL290 dns]$ octodns-sync --config-file ./config/production.yml
2018-05-03T15:21:56  [140127664113472] INFO  Manager __init__: config_file=./config/production.yml
2018-05-03T15:21:56  [140127664113472] INFO  Manager __init__:   max_workers=1
2018-05-03T15:21:56  [140127664113472] INFO  Manager __init__:   max_workers=False
Traceback (most recent call last):
  File "env/bin/octodns-sync", line 11, in <module>
    sys.exit(main())
  File "env/lib/python2.7/site-packages/octodns/cmds/sync.py", line 37, in main
    manager = Manager(args.config_file)
  File "env/lib/python2.7/site-packages/octodns/manager.py", line 101, in __init__
    self.providers[provider_name] = _class(provider_name, **kwargs)
  File "env/lib/python2.7/site-packages/octodns/provider/powerdns.py", line 23, in __init__
    super(PowerDnsBaseProvider, self).__init__(id, *args, **kwargs)
  File "env/lib/python2.7/site-packages/octodns/provider/base.py", line 18, in __init__
    super(BaseProvider, self).__init__(id)
  File "env/lib/python2.7/site-packages/octodns/source/base.py", line 14, in __init__
    raise NotImplementedError('Abstract base class, log property '
NotImplementedError: Abstract base class, log property missing
```