### PR TITLE
if user does not explicitly set Access Key ID and Secret Access Key t…

### DIFF
--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -17,7 +17,7 @@ class BaseProvider(BaseSource):
                  delete_pcent_threshold=Plan.MAX_SAFE_DELETE_PCENT):
         super(BaseProvider, self).__init__(id)
         self.log.debug('__init__: id=%s, apply_disabled=%s, '
-                       'update_pcent_threshold=%.2f'
+                       'update_pcent_threshold=%.2f, '
                        'delete_pcent_threshold=%.2f',
                        id,
                        apply_disabled,

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -217,10 +217,13 @@ class Route53Provider(BaseProvider):
 
     route53:
         class: octodns.provider.route53.Route53Provider
-        # The AWS access key id (required)
+        # The AWS access key id
         access_key_id:
-        # The AWS secret access key (required)
+        # The AWS secret access key
         secret_access_key:
+
+    Alternatively, you may leave out access_key_id and secret_access_key,
+    this will result in boto3 deciding authentication dynamically.
 
     In general the account used will need full permissions on Route53.
     '''

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -167,6 +167,23 @@ class TestRoute53Provider(TestCase):
 
         return (provider, stubber)
 
+    def _get_stubbed_fallback_auth_provider(self):
+        provider = Route53Provider('test')
+
+        # Use the stubber
+        stubber = Stubber(provider._conn)
+        stubber.activate()
+
+        return (provider, stubber)
+
+    def test_populate_with_fallback(self):
+        provider, stubber = self._get_stubbed_fallback_auth_provider()
+
+        got = Zone('unit.tests.', [])
+        with self.assertRaises(ClientError):
+            stubber.add_client_error('list_hosted_zones')
+            provider.populate(got)
+
     def test_populate(self):
         provider, stubber = self._get_stubbed_provider()
 


### PR DESCRIPTION
Addresses #94 

The Route53 provider uses boto3 as the package for working with AWS, previously authentication was very explicit, requiring the user to specify their AWS Access Key ID and Secret Access Key through OctoDNS's configuration. This limits the authentication options for this provider.

This change is simple in that, if the user does not explicitly provide the Access Key and Secret Access Key via the configuration, then the provider will simply make a generic boto3 client, this gives us the ability to use the various authentication methods built into boto3 (https://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials)

It is then up to the user to decide what method they wish to use and set it up via the methods documented in the link above.

I tested this with environment variables, with the default profile in the `~/.aws/credentials` file, a alternative profile + `AWS_PROFILE` environment variable set.