### PR TITLE
change all answers from NS1 to absolute for types that require it

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -189,6 +189,15 @@ class Ns1Provider(BaseProvider):
         try:
             nsone_zone = self._client.loadZone(zone.name[:-1])
             records = nsone_zone.data['records']
+
+            # change answers for certain types to always be absolute
+            for record in records:
+                if record['type'] in ['ALIAS', 'CNAME', 'MX', 'NS', 'PTR',
+                                      'SRV']:
+                    for i, a in enumerate(record['short_answers']):
+                        if not a.endswith('.'):
+                            record['short_answers'][i] = '{}.'.format(a)
+
             geo_records = nsone_zone.search(has_geo=True)
             exists = True
         except ResourceException as e:

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -133,12 +133,12 @@ class TestNs1Provider(TestCase):
     }, {
         'type': 'CNAME',
         'ttl': 34,
-        'short_answers': ['foo.unit.tests.'],
+        'short_answers': ['foo.unit.tests'],
         'domain': 'cname.unit.tests.',
     }, {
         'type': 'MX',
         'ttl': 35,
-        'short_answers': ['10 mx1.unit.tests.', '20 mx2.unit.tests.'],
+        'short_answers': ['10 mx1.unit.tests.', '20 mx2.unit.tests'],
         'domain': 'unit.tests.',
     }, {
         'type': 'NAPTR',
@@ -151,18 +151,18 @@ class TestNs1Provider(TestCase):
     }, {
         'type': 'NS',
         'ttl': 37,
-        'short_answers': ['ns1.unit.tests.', 'ns2.unit.tests.'],
+        'short_answers': ['ns1.unit.tests.', 'ns2.unit.tests'],
         'domain': 'unit.tests.',
     }, {
         'type': 'SRV',
         'ttl': 38,
         'short_answers': ['12 30 30 foo-2.unit.tests.',
-                          '10 20 30 foo-1.unit.tests.'],
+                          '10 20 30 foo-1.unit.tests'],
         'domain': '_srv._tcp.unit.tests.',
     }, {
         'type': 'NS',
         'ttl': 39,
-        'short_answers': ['ns3.unit.tests.', 'ns4.unit.tests.'],
+        'short_answers': ['ns3.unit.tests.', 'ns4.unit.tests'],
         'domain': 'sub.unit.tests.',
     }, {
         'type': 'CAA',


### PR DESCRIPTION
Addresses #179 

NS1 will always return absolute values when you query their DNS servers, but do not require them in the UI/API, in addition they will return these non-absolute values in the UI/API.

This change takes the answers from NS1 and makes them absolute. This brings it more in line of comparing what you'll actually get from DNS rather than differences between providers APIs

I removed a couple periods from answers in the tests to make sure this new code was exercised.