### PR TITLE
Use google-cloud-dns instead of google-cloud for GoogleCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [DnsimpleProvider](/octodns/provider/dnsimple.py) | | All | No | CAA tags restricted |
 | [DynProvider](/octodns/provider/dyn.py) | dyn | All | Yes | |
 | [EtcHostsProvider](/octodns/provider/etc_hosts.py) | | A, AAAA, ALIAS, CNAME | No | |
-| [GoogleCloudProvider](/octodns/provider/googlecloud.py) | google-cloud | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT  | No | |
+| [GoogleCloudProvider](/octodns/provider/googlecloud.py) | google-cloud-dns | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT  | No | |
 | [Ns1Provider](/octodns/provider/ns1.py) | nsone | All | Yes | No health checking for GeoDNS |
 | [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |
 | [PowerDnsProvider](/octodns/provider/powerdns.py) | | All | No | |

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ dnspython==1.15.0
 docutils==0.14
 dyn==1.8.1
 futures==3.2.0
-google-cloud==0.32.0
+google-cloud-core==0.28.1
+google-cloud-dns==0.29.0
 incf.countryutils==1.0
 ipaddress==1.0.22
 jmespath==0.9.3


### PR DESCRIPTION
On 2018-06-18, google-cloud package was deprecated and so
it requires us to use google-cloud-dns instead of google-cloud
for GoogleCloudProvider (Google Cloud DNS).

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

Closes #256