### PR TITLE
Don't escape semicolons when using PowerDNS API

### DIFF
--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -89,9 +89,11 @@ class PowerDnsBaseProvider(BaseProvider):
     _data_for_PTR = _data_for_single
 
     def _data_for_quoted(self, rrset):
+        values = [r['content'][1:-1].replace(';', '\\;')
+                  for r in rrset['records']]
         return {
             'type': rrset['type'],
-            'values': [r['content'][1:-1] for r in rrset['records']],
+            'values': values,
             'ttl': rrset['ttl']
         }
 
@@ -227,8 +229,10 @@ class PowerDnsBaseProvider(BaseProvider):
     _records_for_PTR = _records_for_single
 
     def _records_for_quoted(self, record):
-        return [{'content': '"{}"'.format(v), 'disabled': False}
-                for v in record.values]
+        return [{
+            'content': '"{}"'.format(v.replace('\\;', ';')),
+            'disabled': False
+        } for v in record.values]
 
     _records_for_SPF = _records_for_quoted
     _records_for_TXT = _records_for_quoted

--- a/tests/fixtures/powerdns-full-data.json
+++ b/tests/fixtures/powerdns-full-data.json
@@ -88,7 +88,7 @@
                     "disabled": false
                 },
                 {
-                    "content": "\"v=DKIM1\\;k=rsa\\;s=email\\;h=sha256\\;p=A/kinda+of/long/string+with+numb3rs\"",
+                    "content": "\"v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs\"",
                     "disabled": false
                 }
             ],


### PR DESCRIPTION
Semicolons aren't escaped in the PowerDNS API representation of a record but they are in octodns's representation of TXT and SRV records. This led to literal backslashes unexpectedly appearing in query responses after syncing a zone with PowerDNS.