### PR TITLE
bound natsort to 5.2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'futures>=3.2.0',
         'incf.countryutils>=1.0',
         'ipaddress>=1.0.22',
-        'natsort>=5.2.0',
+        'natsort>=5.2.0,<5.3',
         # botocore doesn't like >=2.7.0 for some reason
         'python-dateutil>=2.6.0,<2.7.0',
         'requests>=2.18.4'


### PR DESCRIPTION
Current latest (5.4.1) FTBFS on Python 2.7. Here's what the end of `python setup.py install` looks like without this change, in a fresh venv:

```
...
Installed /Users/kivikakk/github/octodns/venvx/lib/python2.7/site-packages/python_dateutil-2.6.1-py2.7.egg
Searching for natsort>=5.2.0
Reading https://pypi.python.org/simple/natsort/
Best match: natsort 5.4.1
Downloading https://files.pythonhosted.org/packages/16/02/85eb578d42593d095c7c9c96bc9ad68d09812952c719f3599df0cb5af3b9/natsort-5.4.1.tar.gz#sha256=ae73b005135dc152e7b282b2d4cf19380d8cab4c4026461ee9f37bf3aa12e344
Processing natsort-5.4.1.tar.gz
Writing /var/folders/d9/k640fh3d4z31wq_2j8vr9dsw0000gn/T/easy_install-oOO7if/natsort-5.4.1/setup.cfg
Running natsort-5.4.1/setup.py -q bdist_egg --dist-dir /var/folders/d9/k640fh3d4z31wq_2j8vr9dsw0000gn/T/easy_install-oOO7if/natsort-5.4.1/egg-dist-tmp-ufZeRS
error: Setup script exited with error in natsort setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected version spec in argparse; python_version < '2.7' at ; python_version < '2.7'
```

With this change it's all 🍏.