### PR TITLE
Bump requests to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ natsort==5.2.0
 nsone==0.9.100
 ovh==0.4.8
 python-dateutil==2.6.1
-requests==2.18.4
+requests==2.20.0
 s3transfer==0.1.13
 six==1.11.0
 setuptools==38.5.2

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'natsort>=5.2.0,<5.3',
         # botocore doesn't like >=2.7.0 for some reason
         'python-dateutil>=2.6.0,<2.7.0',
-        'requests>=2.18.4'
+        'requests>=2.20.0'
     ],
     license='MIT',
     long_description=open('README.md').read(),


### PR DESCRIPTION
Security alert prompted version bump.

/cc https://nvd.nist.gov/vuln/detail/CVE-2018-18074