### PR TITLE
Version bump to 0.9.3 & CHANGELOG.md update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.2 - 2018-10-29 - Misc. stuff sort of release
+## v0.9.3 - 2018-10-29 - Misc. stuff sort of release
 
 * ZoneFile source added
 * Major rework/improvements to the Cloudflare record update process, fixed bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.9.2 - 2018-10-29 - Misc. stuff sort of release
+
+* ZoneFile source added
+* Major rework/improvements to the Cloudflare record update process, fixed bugs
+  and optimized it quite a bit
+* Add ability to manage Cloudflare proxy flag
+* Bump requests version to 2.20.0
+
 ## v0.9.2 - 2018-08-20 - More sources
 
 * EtcHostsProvider implementation to create static/emergency best effort

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.2'
+__VERSION__ = '0.9.3'


### PR DESCRIPTION
## v0.9.2 - 2018-10-29 - Misc. stuff sort of release

* ZoneFile source added
* Major rework/improvements to the Cloudflare record update process, fixed bugs
  and optimized it quite a bit
* Add ability to manage Cloudflare proxy flag
* Bump requests version to 2.20.0