### PR TITLE
Update natsort versions to 5.5.0 which has setuptools fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ incf.countryutils==1.0
 ipaddress==1.0.22
 jmespath==0.9.3
 msrestazure==0.4.27
-natsort==5.2.0
+natsort==5.5.0
 nsone==0.9.100
 ovh==0.4.8
 python-dateutil==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'futures>=3.2.0',
         'incf.countryutils>=1.0',
         'ipaddress>=1.0.22',
-        'natsort>=5.2.0,<5.3',
+        'natsort>=5.5.0',
         # botocore doesn't like >=2.7.0 for some reason
         'python-dateutil>=2.6.0,<2.7.0',
         'requests>=2.20.0'


### PR DESCRIPTION
This shifts things to use 5.5.0 which has a fix for the setuptools problem reported over in https://github.com/github/octodns/pull/281.

/cc https://github.com/github/octodns/pull/281#issuecomment-439743369 @SethMMorton @kivikakk 