### PR TITLE
Base dynamic record support

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -37,6 +37,13 @@ class _AggregateTarget(object):
                 return False
         return True
 
+    @property
+    def SUPPORTS_DYNAMIC(self):
+        for target in self.targets:
+            if not target.SUPPORTS_DYNAMIC:
+                return False
+        return True
+
 
 class MakeThreadFuture(object):
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -239,6 +239,7 @@ class AzureProvider(BaseProvider):
         possible to also hard-code into the config file: eg, resource_group.
     '''
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT'))
 
     def __init__(self, id, client_id, key, directory_id, sub_id,

--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -59,6 +59,7 @@ class CloudflareProvider(BaseProvider):
                 value: 1.2.3.4
     '''
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'SRV',
                     'SPF', 'TXT'))
 

--- a/octodns/provider/digitalocean.py
+++ b/octodns/provider/digitalocean.py
@@ -116,6 +116,7 @@ class DigitalOceanProvider(BaseProvider):
         token: foo
     '''
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV'))
 
     def __init__(self, id, token, *args, **kwargs):

--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -91,6 +91,7 @@ class DnsimpleProvider(BaseProvider):
         account: 42
     '''
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
                     'PTR', 'SPF', 'SRV', 'SSHFP', 'TXT'))
 

--- a/octodns/provider/dnsmadeeasy.py
+++ b/octodns/provider/dnsmadeeasy.py
@@ -150,6 +150,7 @@ class DnsMadeEasyProvider(BaseProvider):
         sandbox: true
     '''
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
 

--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -259,6 +259,11 @@ class DynProvider(BaseProvider):
     def SUPPORTS_GEO(self):
         return self.traffic_directors_enabled
 
+    @property
+    def SUPPORTS_DYNAMIC(self):
+        # TODO: dynamic
+        return False
+
     def _check_dyn_sess(self):
         # We don't have to worry about locking for the check since the
         # underlying pieces are pre-thread. We can check to see if this thread

--- a/octodns/provider/etc_hosts.py
+++ b/octodns/provider/etc_hosts.py
@@ -25,6 +25,7 @@ class EtcHostsProvider(BaseProvider):
         directory: ./hosts
     '''
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME'))
 
     def __init__(self, id, directory, *args, **kwargs):

--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -40,6 +40,7 @@ class GoogleCloudProvider(BaseProvider):
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
 
     CHANGE_LOOP_WAIT = 5
 

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -26,6 +26,7 @@ class Ns1Provider(BaseProvider):
         api_key: env/NS1_API_KEY
     '''
     SUPPORTS_GEO = True
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
 

--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -34,6 +34,7 @@ class OvhProvider(BaseProvider):
     """
 
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     ZONE_NOT_FOUND_MESSAGE = 'This service does not exist'
 
     # This variable is also used in populate method to filter which OVH record

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -14,6 +14,7 @@ from .base import BaseProvider
 
 class PowerDnsBaseProvider(BaseProvider):
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
                     'PTR', 'SPF', 'SSHFP', 'SRV', 'TXT'))
     TIMEOUT = 5

--- a/octodns/provider/rackspace.py
+++ b/octodns/provider/rackspace.py
@@ -38,6 +38,7 @@ def unescape_semicolon(s):
 
 class RackspaceProvider(BaseProvider):
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
                     'TXT'))
     TIMEOUT = 5

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -232,6 +232,8 @@ class Route53Provider(BaseProvider):
     In general the account used will need full permissions on Route53.
     '''
     SUPPORTS_GEO = True
+    # TODO: dynamic
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR',
                     'SPF', 'SRV', 'TXT'))
 

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -31,6 +31,7 @@ class YamlProvider(BaseProvider):
         enforce_order: True
     '''
     SUPPORTS_GEO = True
+    SUPPORTS_DYNAMIC = True
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
                     'PTR', 'SSHFP', 'SPF', 'SRV', 'TXT'))
 

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -254,35 +254,13 @@ class _ValuesMixin(object):
     def validate(cls, name, data):
         reasons = super(_ValuesMixin, cls).validate(name, data)
 
-        values = []
         try:
             values = data['values']
-            if not values:
-                values = []
-                reasons.append('missing value(s)')
-            else:
-                # loop through copy of values
-                # remove invalid value from values
-                for value in list(values):
-                    if value is None:
-                        reasons.append('missing value(s)')
-                        values.remove(value)
-                    elif len(value) == 0:
-                        reasons.append('empty value')
-                        values.remove(value)
         except KeyError:
             try:
-                value = data['value']
-                if value is None:
-                    reasons.append('missing value(s)')
-                    values = []
-                elif len(value) == 0:
-                    reasons.append('empty value')
-                    values = []
-                else:
-                    values = value
+                values = data['value']
             except KeyError:
-                reasons.append('missing value(s)')
+                values = []
 
         reasons.extend(cls._value_type.validate(values))
 
@@ -391,10 +369,10 @@ class _ValueMixin(object):
         value = None
         try:
             value = data['value']
-            if value is None:
-                reasons.append('missing value')
-            elif value == '':
+            if value == '':
                 reasons.append('empty value')
+            elif value is None:
+                reasons.append('missing value')
         except KeyError:
             reasons.append('missing value')
         if value:
@@ -451,12 +429,19 @@ class Ipv4List(object):
     def validate(cls, data):
         if not isinstance(data, (list, tuple)):
             data = (data,)
+        if len(data) == 0:
+            return ['missing value(s)']
         reasons = []
         for value in data:
-            try:
-                IPv4Address(unicode(value))
-            except Exception:
-                reasons.append('invalid IPv4 address "{}"'.format(value))
+            if value is '':
+                reasons.append('empty value')
+            elif value is None:
+                reasons.append('missing value(s)')
+            else:
+                try:
+                    IPv4Address(unicode(value))
+                except Exception:
+                    reasons.append('invalid IPv4 address "{}"'.format(value))
         return reasons
 
 
@@ -466,12 +451,19 @@ class Ipv6List(object):
     def validate(cls, data):
         if not isinstance(data, (list, tuple)):
             data = (data,)
+        if len(data) == 0:
+            return ['missing value(s)']
         reasons = []
         for value in data:
-            try:
-                IPv6Address(unicode(value))
-            except Exception:
-                reasons.append('invalid IPv6 address "{}"'.format(value))
+            if value is '':
+                reasons.append('empty value')
+            elif value is None:
+                reasons.append('missing value(s)')
+            else:
+                try:
+                    IPv6Address(unicode(value))
+                except Exception:
+                    reasons.append('invalid IPv6 address "{}"'.format(value))
         return reasons
 
 
@@ -743,7 +735,9 @@ class _NsValue(object):
 
     @classmethod
     def validate(cls, data):
-        if not isinstance(data, (list, tuple)):
+        if not data:
+            return ['missing value(s)']
+        elif not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
         for value in data:
@@ -869,7 +863,9 @@ class _ChunkedValue(object):
 
     @classmethod
     def validate(cls, data):
-        if not isinstance(data, (list, tuple)):
+        if not data:
+            return ['missing value(s)']
+        elif not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
         for value in data:

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -396,6 +396,15 @@ class _DynamicPool(object):
     def _data(self):
         return self.data
 
+    def __eq__(self, other):
+        return self.data == other.data
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}'.format(self.data)
+
 
 class _DynamicRule(object):
 
@@ -406,6 +415,15 @@ class _DynamicRule(object):
 
     def _data(self):
         return self.data
+
+    def __eq__(self, other):
+        return self.data == other.data
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}'.format(self.data)
 
 
 class _Dynamic(object):
@@ -425,6 +443,16 @@ class _Dynamic(object):
             'pools': pools,
             'rules': rules,
         }
+
+    def __eq__(self, other):
+        ret = self.pools == other.pools and self.rules == other.rules
+        return ret
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}, {}'.format(self.pools, self.rules)
 
 
 class _DynamicMixin(object):

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -382,38 +382,6 @@ class _GeoMixin(_ValuesMixin):
         return super(_GeoMixin, self).__repr__()
 
 
-class ARecord(_GeoMixin, Record):
-    _type = 'A'
-
-    @classmethod
-    def _validate_value(self, value):
-        reasons = []
-        try:
-            IPv4Address(unicode(value))
-        except Exception:
-            reasons.append('invalid ip address "{}"'.format(value))
-        return reasons
-
-    def _process_values(self, values):
-        return values
-
-
-class AaaaRecord(_GeoMixin, Record):
-    _type = 'AAAA'
-
-    @classmethod
-    def _validate_value(self, value):
-        reasons = []
-        try:
-            IPv6Address(unicode(value))
-        except Exception:
-            reasons.append('invalid ip address "{}"'.format(value))
-        return reasons
-
-    def _process_values(self, values):
-        return values
-
-
 class _ValueMixin(object):
 
     @classmethod
@@ -451,6 +419,50 @@ class _ValueMixin(object):
         return '<{} {} {}, {}, {}>'.format(self.__class__.__name__,
                                            self._type, self.ttl,
                                            self.fqdn, self.value)
+
+
+class _DynamicBaseMixin(object):
+    pass
+
+
+class _DynamicValuesMixin(_DynamicBaseMixin, _GeoMixin):
+    pass
+
+
+class _DynamicValueMixin(_DynamicBaseMixin, _ValueMixin):
+    pass
+
+
+class ARecord(_DynamicValuesMixin, Record):
+    _type = 'A'
+
+    @classmethod
+    def _validate_value(self, value):
+        reasons = []
+        try:
+            IPv4Address(unicode(value))
+        except Exception:
+            reasons.append('invalid ip address "{}"'.format(value))
+        return reasons
+
+    def _process_values(self, values):
+        return values
+
+
+class AaaaRecord(_GeoMixin, Record):
+    _type = 'AAAA'
+
+    @classmethod
+    def _validate_value(self, value):
+        reasons = []
+        try:
+            IPv6Address(unicode(value))
+        except Exception:
+            reasons.append('invalid ip address "{}"'.format(value))
+        return reasons
+
+    def _process_values(self, values):
+        return values
 
 
 class AliasRecord(_ValueMixin, Record):

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -366,17 +366,7 @@ class _ValueMixin(object):
     @classmethod
     def validate(cls, name, data):
         reasons = super(_ValueMixin, cls).validate(name, data)
-        value = None
-        try:
-            value = data['value']
-            if value == '':
-                reasons.append('empty value')
-            elif value is None:
-                reasons.append('missing value')
-        except KeyError:
-            reasons.append('missing value')
-        if value:
-            reasons.extend(cls._value_type.validate(value, cls))
+        reasons.extend(cls._value_type.validate(data.get('value', None), cls))
         return reasons
 
     def __init__(self, zone, name, data, source=None):
@@ -472,7 +462,11 @@ class _TargetValue(object):
     @classmethod
     def validate(cls, data, record_cls):
         reasons = []
-        if not data.endswith('.'):
+        if data == '':
+            reasons.append('empty value')
+        elif not data:
+            reasons.append('missing value')
+        elif not data.endswith('.'):
             reasons.append('{} value "{}" missing trailing .'
                            .format(record_cls._type, data))
         return reasons

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -322,10 +322,6 @@ class _GeoMixin(_ValuesMixin):
             pass
         return reasons
 
-    # TODO: support 'value' as well
-    # TODO: move away from "data" hash to strict params, it's kind of leaking
-    # the yaml implementation into here and then forcing it back out into
-    # non-yaml providers during input
     def __init__(self, zone, name, data, *args, **kwargs):
         super(_GeoMixin, self).__init__(zone, name, data, *args, **kwargs)
         try:
@@ -453,7 +449,8 @@ class _DynamicMixin(object):
             self.dynamic = dict(data['dynamic'])
         except:
             self.dynamic = {}
-        # TODO:
+
+    # TODO: implement all this
 
 
 class Ipv4List(object):

--- a/octodns/record.py
+++ b/octodns/record.py
@@ -262,7 +262,7 @@ class _ValuesMixin(object):
             except KeyError:
                 values = []
 
-        reasons.extend(cls._value_type.validate(values))
+        reasons.extend(cls._value_type.validate(values, cls))
 
         return reasons
 
@@ -317,7 +317,7 @@ class _GeoMixin(_ValuesMixin):
             # TODO: validate legal codes
             for code, values in geo.items():
                 reasons.extend(GeoValue._validate_geo(code))
-                reasons.extend(cls._value_type.validate(values))
+                reasons.extend(cls._value_type.validate(values, cls))
         except KeyError:
             pass
         return reasons
@@ -408,7 +408,7 @@ class _DynamicMixin(object):
             reasons.append('missing pools')
         else:
             for pool in sorted(pools.values()):
-                reasons.extend(cls._value_type.validate(pool))
+                reasons.extend(cls._value_type.validate(pool, cls))
 
         try:
             rules = data['dynamic']['rules']
@@ -459,7 +459,7 @@ class _DynamicMixin(object):
 class Ipv4List(object):
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         if len(data) == 0:
@@ -485,7 +485,7 @@ class Ipv4List(object):
 class Ipv6List(object):
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         if len(data) == 0:
@@ -536,7 +536,7 @@ class ARecord(_DynamicMixin, _GeoMixin, Record):
     _value_type = Ipv4List
 
 
-class AaaaRecord(_GeoMixin, Record):
+class AaaaRecord(_DynamicMixin, _GeoMixin, Record):
     _type = 'AAAA'
     _value_type = Ipv6List
 
@@ -554,7 +554,7 @@ class CaaValue(object):
     # https://tools.ietf.org/html/rfc6844#page-5
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
@@ -605,7 +605,7 @@ class CaaRecord(_ValuesMixin, Record):
     _value_type = CaaValue
 
 
-class CnameRecord(_ValueMixin, Record):
+class CnameRecord(_DynamicMixin, _ValueMixin, Record):
     _type = 'CNAME'
     _value_type = CnameValue
 
@@ -621,7 +621,7 @@ class CnameRecord(_ValueMixin, Record):
 class MxValue(object):
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
@@ -689,7 +689,7 @@ class NaptrValue(object):
     VALID_FLAGS = ('S', 'A', 'U', 'P')
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
@@ -774,7 +774,7 @@ class NaptrRecord(_ValuesMixin, Record):
 class _NsValue(object):
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not data:
             return ['missing value(s)']
         elif not isinstance(data, (list, tuple)):
@@ -810,7 +810,7 @@ class SshfpValue(object):
     VALID_FINGERPRINT_TYPES = (1, 2)
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
@@ -893,7 +893,7 @@ class _ChunkedValue(object):
     _unescaped_semicolon_re = re.compile(r'\w;')
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not data:
             return ['missing value(s)']
         elif not isinstance(data, (list, tuple)):
@@ -922,7 +922,7 @@ class SpfRecord(_ChunkedValuesMixin, Record):
 class SrvValue(object):
 
     @classmethod
-    def validate(cls, data):
+    def validate(cls, data, record_cls):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []

--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -24,6 +24,7 @@ from .base import BaseSource
 class AxfrBaseSource(BaseSource):
 
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
                     'SRV', 'TXT'))
 

--- a/octodns/source/base.py
+++ b/octodns/source/base.py
@@ -16,6 +16,9 @@ class BaseSource(object):
         if not hasattr(self, 'SUPPORTS_GEO'):
             raise NotImplementedError('Abstract base class, SUPPORTS_GEO '
                                       'property missing')
+        if not hasattr(self, 'SUPPORTS_DYNAMIC'):
+            raise NotImplementedError('Abstract base class, SUPPORTS_DYNAMIC '
+                                      'property missing')
         if not hasattr(self, 'SUPPORTS'):
             raise NotImplementedError('Abstract base class, SUPPORTS '
                                       'property missing')

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -19,6 +19,7 @@ from .base import BaseSource
 
 class TinyDnsBaseSource(BaseSource):
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'CNAME', 'MX', 'NS'))
 
     split_re = re.compile(r':+')

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -2,17 +2,12 @@
 a:
   dynamic:
     pools:
-      ams:
-        values:
-          - 1.1.1.1
+      ams: 1.1.1.1
       iad:
-        values:
           - 2.2.2.2
           - 3.3.3.3
-      lax:
-        value: 4.4.4.4
-      sea:
-        value: 5.5.5.5
+      lax: 4.4.4.4
+      sea: 5.5.5.5
     rules:
       - geo: EU-UK
         pools:
@@ -28,8 +23,7 @@ a:
         pools:
           25: iad
           75: sea
-      - default:
-        pool: iad
+      - pool: iad
   type: A
   values:
     - 2.2.2.2
@@ -60,7 +54,7 @@ cname:
         pools:
           12: sea
           250: iad
-      - default:
+      - pools:
           1: sea
           4: iad
   type: CNAME
@@ -69,12 +63,12 @@ simple-weighted:
   dynamic:
     pools:
       one:
-        one.unit.tests.
+        value: one.unit.tests.
       two:
-        two.unit.tests.
+        value: two.unit.tests.
     rules:
-      - default:
-         100: one
-         200: two
+      - pools:
+          100: one
+          200: two
   type: CNAME
   value: default.unit.tests.

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -29,6 +29,36 @@ a:
   values:
     - 2.2.2.2
     - 3.3.3.3
+aaaa:
+  dynamic:
+    pools:
+      ams: 2601:642:500:e210:62f8:1dff:feb8:9471
+      iad:
+          - 2601:642:500:e210:62f8:1dff:feb8:9472
+          - 2601:642:500:e210:62f8:1dff:feb8:9473
+      lax: 2601:642:500:e210:62f8:1dff:feb8:9474
+      sea: 2601:642:500:e210:62f8:1dff:feb8:9475
+    rules:
+      - geo: EU-UK
+        pools:
+          10: iad
+      - geo: EU
+        pools:
+          10: ams
+          10: iad
+      - geos:
+          - NA-US-CA
+          - NA-US-OR
+          - NA-US-WA
+        pools:
+          25: iad
+          75: sea
+      - pools:
+          10: iad
+  type: AAAA
+  values:
+    - 2601:642:500:e210:62f8:1dff:feb8:947a
+    - 2601:644:500:e210:62f8:1dff:feb8:947a
 cname:
   dynamic:
     pools:

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -26,8 +26,8 @@ a:
           - NA-US-OR
           - NA-US-WA
         pools:
-          - sea
-          - iad
+          25: iad
+          75: sea
       - default:
         pool: iad
   type: A
@@ -58,8 +58,8 @@ cname:
           - NA-US-OR
           - NA-US-WA
         pools:
-          - sea
-          - iad
+          25: iad
+          75: sea
       - default:
         pool: iad
   type: CNAME

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -1,0 +1,66 @@
+---
+a:
+  dynamic:
+    pools:
+      ams:
+        values:
+          - 1.1.1.1
+      iad:
+        values:
+          - 2.2.2.2
+          - 3.3.3.3
+      lax:
+        value: 4.4.4.4
+      sea:
+        value: 5.5.5.5
+    rules:
+      - geo: EU-UK
+        pools:
+          - iad
+      - geo: EU
+        pools:
+          - ams
+          - iad
+      - geos:
+          - NA-US-CA
+          - NA-US-OR
+          - NA-US-WA
+        pools:
+          - sea
+          - iad
+      - default:
+        pool: iad
+  type: A
+  values:
+    - 2.2.2.2
+    - 3.3.3.3
+cname:
+  dynamic:
+    pools:
+      ams:
+        value: target-ams.unit.tests.
+      iad:
+        value: target-iad.unit.tests.
+      lax:
+        value: target-lax.unit.tests.
+      sea:
+        value: target-sea.unit.tests.
+    rules:
+      - geo: EU-UK
+        pools:
+          - iad
+      - geo: EU
+        pools:
+          - ams
+          - iad
+      - geos:
+          - NA-US-CA
+          - NA-US-OR
+          - NA-US-WA
+        pools:
+          - sea
+          - iad
+      - default:
+        pool: iad
+  type: CNAME
+  value: target.unit.tests.

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -32,14 +32,10 @@ a:
 cname:
   dynamic:
     pools:
-      ams:
-        value: target-ams.unit.tests.
-      iad:
-        value: target-iad.unit.tests.
-      lax:
-        value: target-lax.unit.tests.
-      sea:
-        value: target-sea.unit.tests.
+      ams: target-ams.unit.tests.
+      iad: target-iad.unit.tests.
+      lax: target-lax.unit.tests.
+      sea: target-sea.unit.tests.
     rules:
       - geo: EU-UK
         pools:
@@ -63,10 +59,8 @@ cname:
 simple-weighted:
   dynamic:
     pools:
-      one:
-        value: one.unit.tests.
-      two:
-        value: two.unit.tests.
+      one: one.unit.tests.
+      two: two.unit.tests.
     rules:
       - pools:
           100: one

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -11,11 +11,11 @@ a:
     rules:
       - geo: EU-UK
         pools:
-          - iad
+          10: iad
       - geo: EU
         pools:
-          - ams
-          - iad
+          10: ams
+          10: iad
       - geos:
           - NA-US-CA
           - NA-US-OR
@@ -23,7 +23,8 @@ a:
         pools:
           25: iad
           75: sea
-      - pool: iad
+      - pools:
+          10: iad
   type: A
   values:
     - 2.2.2.2
@@ -42,11 +43,11 @@ cname:
     rules:
       - geo: EU-UK
         pools:
-          - iad
+          10: iad
       - geo: EU
         pools:
-          - ams
-          - iad
+          10: ams
+          10: iad
       - geos:
           - NA-US-CA
           - NA-US-OR

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -58,9 +58,23 @@ cname:
           - NA-US-OR
           - NA-US-WA
         pools:
-          25: iad
-          75: sea
+          12: sea
+          250: iad
       - default:
-        pool: iad
+          1: sea
+          4: iad
   type: CNAME
   value: target.unit.tests.
+simple-weighted:
+  dynamic:
+    pools:
+      one:
+        one.unit.tests.
+      two:
+        two.unit.tests.
+    rules:
+      - default:
+         100: one
+         200: two
+  type: CNAME
+  value: default.unit.tests.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,6 +17,7 @@ class SimpleSource(object):
 
 class SimpleProvider(object):
     SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A',))
     id = 'test'
 
@@ -35,6 +36,25 @@ class SimpleProvider(object):
 
 class GeoProvider(object):
     SUPPORTS_GEO = True
+    SUPPORTS_DYNAMIC = False
+    id = 'test'
+
+    def __init__(self, id='test'):
+        pass
+
+    def populate(self, zone, source=False, lenient=False):
+        pass
+
+    def supports(self, record):
+        return True
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+
+class DynamicProvider(object):
+    SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = True
     id = 'test'
 
     def __init__(self, id='test'):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -14,8 +14,8 @@ from octodns.manager import _AggregateTarget, MainThreadExecutor, Manager
 from octodns.yaml import safe_load
 from octodns.zone import Zone
 
-from helpers import GeoProvider, NoSshFpProvider, SimpleProvider, \
-    TemporaryDirectory
+from helpers import DynamicProvider, GeoProvider, NoSshFpProvider, \
+    SimpleProvider, TemporaryDirectory
 
 config_dir = join(dirname(__file__), 'config')
 
@@ -187,12 +187,18 @@ class TestManager(TestCase):
     def test_aggregate_target(self):
         simple = SimpleProvider()
         geo = GeoProvider()
+        dynamic = DynamicProvider()
         nosshfp = NoSshFpProvider()
 
         self.assertFalse(_AggregateTarget([simple, simple]).SUPPORTS_GEO)
         self.assertFalse(_AggregateTarget([simple, geo]).SUPPORTS_GEO)
         self.assertFalse(_AggregateTarget([geo, simple]).SUPPORTS_GEO)
         self.assertTrue(_AggregateTarget([geo, geo]).SUPPORTS_GEO)
+
+        self.assertFalse(_AggregateTarget([simple, simple]).SUPPORTS_DYNAMIC)
+        self.assertFalse(_AggregateTarget([simple, dynamic]).SUPPORTS_DYNAMIC)
+        self.assertFalse(_AggregateTarget([dynamic, simple]).SUPPORTS_DYNAMIC)
+        self.assertTrue(_AggregateTarget([dynamic, dynamic]).SUPPORTS_DYNAMIC)
 
         zone = Zone('unit.tests.', [])
         record = Record.new(zone, 'sshfp', {

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -61,13 +61,21 @@ class TestBaseProvider(TestCase):
         class HasSupportsGeo(HasLog):
             SUPPORTS_GEO = False
 
+        with self.assertRaises(NotImplementedError) as ctx:
+            HasSupportsGeo('hassupportsgeo')
+        self.assertEquals('Abstract base class, SUPPORTS_DYNAMIC '
+                          'property missing', ctx.exception.message)
+
+        class HasSupportsDyanmic(HasSupportsGeo):
+            SUPPORTS_DYNAMIC = False
+
         zone = Zone('unit.tests.', ['sub'])
         with self.assertRaises(NotImplementedError) as ctx:
-            HasSupportsGeo('hassupportsgeo').populate(zone)
+            HasSupportsDyanmic('hassupportsdynamic').populate(zone)
         self.assertEquals('Abstract base class, SUPPORTS property missing',
                           ctx.exception.message)
 
-        class HasSupports(HasSupportsGeo):
+        class HasSupports(HasSupportsDyanmic):
             SUPPORTS = set(('A',))
         with self.assertRaises(NotImplementedError) as ctx:
             HasSupports('hassupports').populate(zone)

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -34,7 +34,7 @@ class TestYamlProvider(TestCase):
         self.assertEquals(18, len(zone.records))
 
         source.populate(dynamic_zone)
-        self.assertEquals(3, len(dynamic_zone.records))
+        self.assertEquals(4, len(dynamic_zone.records))
 
         # Assumption here is that a clean round-trip means that everything
         # worked as expected, data that went in came back out and could be
@@ -64,11 +64,11 @@ class TestYamlProvider(TestCase):
 
             # Dynamic plan
             plan = target.plan(dynamic_zone)
-            self.assertEquals(3, len(filter(lambda c: isinstance(c, Create),
+            self.assertEquals(4, len(filter(lambda c: isinstance(c, Create),
                                             plan.changes)))
             self.assertFalse(isfile(dynamic_yaml_file))
             # Apply it
-            self.assertEquals(3, target.apply(plan))
+            self.assertEquals(4, target.apply(plan))
             self.assertTrue(isfile(dynamic_yaml_file))
 
             # There should be no changes after the round trip
@@ -120,6 +120,12 @@ class TestYamlProvider(TestCase):
 
                 # make sure new dynamic records made the trip
                 dyna = data.pop('a')
+                self.assertTrue('values' in dyna)
+                # self.assertTrue('dynamic' in dyna)
+                # TODO:
+
+                # make sure new dynamic records made the trip
+                dyna = data.pop('aaaa')
                 self.assertTrue('values' in dyna)
                 # self.assertTrue('dynamic' in dyna)
 

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -34,7 +34,7 @@ class TestYamlProvider(TestCase):
         self.assertEquals(18, len(zone.records))
 
         source.populate(dynamic_zone)
-        self.assertEquals(2, len(dynamic_zone.records))
+        self.assertEquals(3, len(dynamic_zone.records))
 
         # Assumption here is that a clean round-trip means that everything
         # worked as expected, data that went in came back out and could be
@@ -64,11 +64,11 @@ class TestYamlProvider(TestCase):
 
             # Dynamic plan
             plan = target.plan(dynamic_zone)
-            self.assertEquals(2, len(filter(lambda c: isinstance(c, Create),
+            self.assertEquals(3, len(filter(lambda c: isinstance(c, Create),
                                             plan.changes)))
             self.assertFalse(isfile(dynamic_yaml_file))
             # Apply it
-            self.assertEquals(2, target.apply(plan))
+            self.assertEquals(3, target.apply(plan))
             self.assertTrue(isfile(dynamic_yaml_file))
 
             # There should be no changes after the round trip
@@ -124,6 +124,10 @@ class TestYamlProvider(TestCase):
                 # self.assertTrue('dynamic' in dyna)
 
                 dyna = data.pop('cname')
+                self.assertTrue('value' in dyna)
+                # self.assertTrue('dynamic' in dyna)
+
+                dyna = data.pop('simple-weighted')
                 self.assertTrue('value' in dyna)
                 # self.assertTrue('dynamic' in dyna)
 

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -121,11 +121,11 @@ class TestYamlProvider(TestCase):
                 # make sure new dynamic records made the trip
                 dyna = data.pop('a')
                 self.assertTrue('values' in dyna)
-                #self.assertTrue('dynamic' in dyna)
+                # self.assertTrue('dynamic' in dyna)
 
                 dyna = data.pop('cname')
                 self.assertTrue('value' in dyna)
-                #self.assertTrue('dynamic' in dyna)
+                # self.assertTrue('dynamic' in dyna)
 
                 # make sure nothing is left
                 self.assertEquals([], data.keys())

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -934,7 +934,7 @@ class TestRecordValidation(TestCase):
         self.assertEquals(['missing ttl', 'missing value(s)'],
                           ctx.exception.reasons)
 
-        # invalid ip address
+        # invalid ipv4 address
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'A',
@@ -944,7 +944,7 @@ class TestRecordValidation(TestCase):
         self.assertEquals(['invalid IPv4 address "hello"'],
                           ctx.exception.reasons)
 
-        # invalid ip addresses
+        # invalid ipv4 addresses
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'A',
@@ -956,7 +956,7 @@ class TestRecordValidation(TestCase):
             'invalid IPv4 address "goodbye"'
         ], ctx.exception.reasons)
 
-        # invalid & valid ip addresses, no ttl
+        # invalid & valid ipv4 addresses, no ttl
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'A',
@@ -965,6 +965,128 @@ class TestRecordValidation(TestCase):
         self.assertEquals([
             'missing ttl',
             'invalid IPv4 address "hello"',
+        ], ctx.exception.reasons)
+
+    def test_AAAA_validation(self):
+        # doesn't blow up
+        Record.new(self.zone, '', {
+            'type': 'AAAA',
+            'ttl': 600,
+            'value': '2601:644:500:e210:62f8:1dff:feb8:947a',
+        })
+        Record.new(self.zone, '', {
+            'type': 'AAAA',
+            'ttl': 600,
+            'values': [
+                '2601:644:500:e210:62f8:1dff:feb8:947a',
+            ]
+        })
+        Record.new(self.zone, '', {
+            'type': 'AAAA',
+            'ttl': 600,
+            'values': [
+                '2601:644:500:e210:62f8:1dff:feb8:947a',
+                '2601:642:500:e210:62f8:1dff:feb8:947a',
+            ]
+        })
+
+        # missing value(s), no value or value
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {
+                'type': 'AAAA',
+                'ttl': 600,
+            })
+        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+
+        # missing value(s), empty values
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, 'www', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'values': []
+            })
+        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+
+        # missing value(s), None values
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, 'www', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'values': None
+            })
+        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+
+        # missing value(s) and empty value
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, 'www', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'values': [None, '']
+            })
+        self.assertEquals(['missing value(s)',
+                           'empty value'], ctx.exception.reasons)
+
+        # missing value(s), None value
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, 'www', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'value': None
+            })
+        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+
+        # empty value, empty string value
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, 'www', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'value': ''
+            })
+        self.assertEquals(['empty value'], ctx.exception.reasons)
+
+        # missing value(s) & ttl
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {
+                'type': 'AAAA',
+            })
+        self.assertEquals(['missing ttl', 'missing value(s)'],
+                          ctx.exception.reasons)
+
+        # invalid IPv6 address
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'value': 'hello'
+            })
+        self.assertEquals(['invalid IPv6 address "hello"'],
+                          ctx.exception.reasons)
+
+        # invalid IPv6 addresses
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {
+                'type': 'AAAA',
+                'ttl': 600,
+                'values': ['hello', 'goodbye']
+            })
+        self.assertEquals([
+            'invalid IPv6 address "hello"',
+            'invalid IPv6 address "goodbye"'
+        ], ctx.exception.reasons)
+
+        # invalid & valid IPv6 addresses, no ttl
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {
+                'type': 'AAAA',
+                'values': [
+                    '2601:644:500:e210:62f8:1dff:feb8:947a',
+                    'hello',
+                    '2601:642:500:e210:62f8:1dff:feb8:947a'
+                ]
+            })
+        self.assertEquals([
+            'missing ttl',
+            'invalid IPv6 address "hello"',
         ], ctx.exception.reasons)
 
     def test_geo(self):

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -111,6 +111,7 @@ class TestZone(TestCase):
         class NoAaaaProvider(object):
             id = 'no-aaaa'
             SUPPORTS_GEO = False
+            SUPPORTS_DYNAMIC = False
 
             def supports(self, record):
                 return record._type != 'AAAA'


### PR DESCRIPTION
This PR implements the base functionality of `dynamic` records in octoDNS. This is the intended replacement of `geo` records and will vastly improve our ability to support various "dynamic" DNS records systems. 

At a high level the primary change is to break things up into (response) `pools` which are simply value(s) that a query can respond with. These pools are selected based on `rules`. The full details of the `rules` implementation are still in the works, but the gist is that `rules` are an array of "tests" to be evaluated in order against a request and a set of weighted pools to respond with when the test passes. 

An example might look like, the details of weighting and fallbacks are still in flux:

```yaml
a:
  dynamic:
    pools:
      ams: 1.1.1.1
      iad:
          - 2.2.2.2
          - 3.3.3.3
      lax: 4.4.4.4
      sea: 5.5.5.5
    rules:
      - geo: EU-UK
        pools:
          10: iad
      - geo: EU
        pools:
          10: ams
          10: iad
      - geos:
          - NA-US-CA
          - NA-US-OR
          - NA-US-WA
        pools:
          25: iad
          75: sea
      - pools:
          10: iad
  type: A
  values:
    - 2.2.2.2
    - 3.3.3.3
```

The implementation allows dynamic support to extend to `CNAME` records (and in theory any other record type) which gets past the `geo` record's limitation to only `A` and `AAAA`.

Obviously this functionality depends on provider implementation. This PR will not implement any provider support (beyond `YamlProvider`) and that work will happen in subsequent PRs once this has shipped.

### TODO:

- [ ] Work out the final details of weights and fallbacks
- [ ] Implement more robust parsing and handling of pools and rules
- [ ] Review and discussion of the PR

/cc @github/traffic 
/cc @yzguy 

### Related issues

/cc https://github.com/github/octodns/issues/49 @dolvany which was about healthchecking non-Geo records which I believe this will support as a use case via pool fallback (it won't help with the wider importing/dumping of random configs there
/cc https://github.com/github/octodns/issues/62 @vanbroup for geo-dns support for CNAMES 


