### PR TITLE
Adding more details to OctoDNS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ providers:
   config:
     class: octodns.provider.yaml.YamlProvider
     directory: ./config
+    default_ttl: 3600
+    enforce_order: True
   dyn:
     class: octodns.provider.dyn.DynProvider
     customer: 1234
@@ -55,6 +57,10 @@ zones:
 ```
 
 `class` is a special key that tells OctoDNS what python class should be loaded. Any other keys will be passed as configuration values to that provider. In general any sensitive or frequently rotated values should come from environmental variables. When OctoDNS sees a value that starts with `env/` it will look for that value in the process's environment and pass the result along.
+
+`enforce_order` is a special key that tells OctoDNS to enforce sorting order on the yaml config. By default it is set to True.
+
+If you don't want to set same TTL each time for your records, you can optionally use `default_ttl` key - it will be used in records when not specified in the data. By default it is set to 3600 seconds.
 
 Further information can be found in the `docstring` of each source and provider class.
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ zones:
 
 `class` is a special key that tells OctoDNS what python class should be loaded. Any other keys will be passed as configuration values to that provider. In general any sensitive or frequently rotated values should come from environmental variables. When OctoDNS sees a value that starts with `env/` it will look for that value in the process's environment and pass the result along.
 
-`enforce_order` is a special key that tells OctoDNS to enforce sorting order on the yaml config. By default it is set to True.
-
-If you don't want to set same TTL each time for your records, you can optionally use `default_ttl` key - it will be used in records when not specified in the data. By default it is set to 3600 seconds.
-
 Further information can be found in the `docstring` of each source and provider class.
 
 Now that we have something to tell OctoDNS about our providers & zones we need to tell it about or records. We'll keep it simple for now and just create a single `A` record at the top-level of the domain.

--- a/docs/records.md
+++ b/docs/records.md
@@ -120,10 +120,10 @@ In the above example each name had a single record, but there are cases where a 
       - 1.2.3.5
   - type: MX
     values:
-      - priority: 10
-        value: mx1.example.com.
-      - priority: 10
-        value: mx2.example.com.
+      - exchange: mx1.example.com.
+        preference: 10
+      - exchange: mx2.example.com.
+        preference: 10
 ```
 
 ### Record data


### PR DESCRIPTION
- Add description to `default_ttl` and `enforce_order` keys in config
- Replace `priority/value` to `preference/exchange` in MX example. As far as I see from code and my personal experience with OctoDNS this is the right syntax.

I've added these commits since I think they'll be useful for newbies when it comes to first interaction with OctoDNS. Personally it could help me a lot when I had started.

Hopes it helps. Ready to listen your thoughts around this pr. Thanks in advance. 