### PR TITLE
Route53Provider dynamic record support

### DIFF
--- a/.git_hooks_pre-commit
+++ b/.git_hooks_pre-commit
@@ -8,4 +8,4 @@ ROOT=`dirname $GIT`
 
 . $ROOT/env/bin/activate
 $ROOT/script/lint
-$ROOT/script/test
+$ROOT/script/coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.9.5 - 2019-??-?? - The big one, with all the dynamic stuff
+
+* dynamic record support, essentially a v2 version of geo records with a lot
+  more flexibility and power. Also support dynamic CNAME records.
+* Route53Provider dynamic record support
+* DynProvider dynamic record support
+* SUPPORTS_DYNAMIC is an optional property, defaults to False
+* Route53Provider health checks support disabling latency measurement
+* CloudflareProvider SRV record unpacking fix
+* DNSMadeEasy provider uses supports to avoid blowing up on unknown record
+  types
+
 ## v0.9.4 - 2019-01-28 - The one with a bunch of stuff, before the big one
 
 * A bunch of "dynamic" stuff that'll be detailed in the next release when

--- a/README.md
+++ b/README.md
@@ -149,21 +149,21 @@ The above command pulled the existing data out of Route53 and placed the results
 
 ## Supported providers
 
-| Provider | Requirements | Record Support | GeoDNS Support | Notes |
+| Provider | Requirements | Record Support | Dynamic/Geo Support | Notes |
 |--|--|--|--|--|
 | [AzureProvider](/octodns/provider/azuredns.py) | azure-mgmt-dns | A, AAAA, CNAME, MX, NS, PTR, SRV, TXT | No | |
 | [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, MX, NS, SPF, SRV, TXT | No | CAA tags restricted |
 | [DigitalOceanProvider](/octodns/provider/digitalocean.py) | | A, AAAA, CAA, CNAME, MX, NS, TXT, SRV | No | CAA tags restricted |
 | [DnsMadeEasyProvider](/octodns/provider/dnsmadeeasy.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
 | [DnsimpleProvider](/octodns/provider/dnsimple.py) | | All | No | CAA tags restricted |
-| [DynProvider](/octodns/provider/dyn.py) | dyn | All | Yes | |
+| [DynProvider](/octodns/provider/dyn.py) | dyn | All | Both | |
 | [EtcHostsProvider](/octodns/provider/etc_hosts.py) | | A, AAAA, ALIAS, CNAME | No | |
 | [GoogleCloudProvider](/octodns/provider/googlecloud.py) | google-cloud-dns | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT  | No | |
-| [Ns1Provider](/octodns/provider/ns1.py) | nsone | All | Yes | No health checking for GeoDNS |
+| [Ns1Provider](/octodns/provider/ns1.py) | nsone | All | Partial Geo | No health checking for GeoDNS |
 | [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |
 | [PowerDnsProvider](/octodns/provider/powerdns.py) | | All | No | |
 | [Rackspace](/octodns/provider/rackspace.py) | | A, AAAA, ALIAS, CNAME, MX, NS, PTR, SPF, TXT | No |  |
-| [Route53](/octodns/provider/route53.py) | boto3 | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Yes | |
+| [Route53](/octodns/provider/route53.py) | boto3 | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Both | CNAME health checks don't support a Host header |
 | [AxfrSource](/octodns/source/axfr.py) | | A, AAAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
 | [ZoneFileSource](/octodns/source/axfr.py) | | A, AAAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
 | [TinyDnsFileSource](/octodns/source/tinydns.py) | | A, CNAME, MX, NS, PTR | No | read-only |

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -800,7 +800,6 @@ class Route53Provider(BaseProvider):
             else:
                 # These are the pool value(s)
                 pool_name = rrset['SetIdentifier'][:-4]
-                # TODO: handle different value types
                 value = rrset['ResourceRecords'][0]['Value']
                 pools[pool_name]['values'].append({
                     'value': value,

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -640,6 +640,20 @@ class Route53Provider(BaseProvider):
                                               HealthCheckConfig=config)
         health_check = resp['HealthCheck']
         id = health_check['Id']
+
+        # Set a Name for the benefit of the UI
+        name = '{}:{} - {}'.format(record.fqdn, record._type, value)
+        self._conn.change_tags_for_resource(ResourceType='healthcheck',
+                                            ResourceId=id,
+                                            AddTags=[{
+                                                'Key': 'Name',
+                                                'Value': name,
+                                            }])
+        # Manually add it to our cache
+        health_check['Tags'] = {
+            'Name': name
+        }
+
         # store the new health check so that we'll be able to find it in the
         # future
         self._health_checks[id] = health_check

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -469,9 +469,9 @@ class _Route53GeoRecord(_Route53Record):
 
 
 _mod_keyer_action_order = {
-    'DELETE': '0',  # Delete things first
-    'CREATE': '1',  # Then Create things
-    'UPSERT': '2',  # Upsert things last
+    'DELETE': 0,  # Delete things first
+    'CREATE': 1,  # Then Create things
+    'UPSERT': 2,  # Upsert things last
 }
 
 
@@ -483,18 +483,18 @@ def _mod_keyer(mod):
     # name/id of the rrset
 
     if rrset.get('GeoLocation', False):
-        return '{}3{}'.format(action_order, rrset['SetIdentifier'])
+        return (action_order, 3, rrset['SetIdentifier'])
     elif rrset.get('AliasTarget', False):
         # We use an alias
         if rrset.get('Failover', False) == 'SECONDARY':
             # We're a secondary we'll ref primaries
-            return '{}2{}'.format(action_order, rrset['Name'])
+            return (action_order, 2, rrset['Name'])
         else:
             # We're a primary we'll ref values
-            return '{}1{}'.format(action_order, rrset['Name'])
+            return (action_order, 1, rrset['Name'])
 
     # We're just a plain value, these come first
-    return '{}0{}'.format(action_order, rrset['Name'])
+    return (action_order, 0, rrset['Name'])
 
 
 class Route53Provider(BaseProvider):

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -1067,15 +1067,18 @@ class _ChunkedValuesMixin(_ValuesMixin):
     CHUNK_SIZE = 255
     _unescaped_semicolon_re = re.compile(r'\w;')
 
+    def chunked_value(self, value):
+        value = value.replace('"', '\\"')
+        vs = [value[i:i + self.CHUNK_SIZE]
+              for i in range(0, len(value), self.CHUNK_SIZE)]
+        vs = '" "'.join(vs)
+        return '"{}"'.format(vs)
+
     @property
     def chunked_values(self):
         values = []
         for v in self.values:
-            v = v.replace('"', '\\"')
-            vs = [v[i:i + self.CHUNK_SIZE]
-                  for i in range(0, len(v), self.CHUNK_SIZE)]
-            vs = '" "'.join(vs)
-            values.append('"{}"'.format(vs))
+            values.append(self.chunked_value(v))
         return values
 
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -2273,7 +2273,7 @@ class TestModKeyer(TestCase):
         # First "column"
 
         # Deletes come first
-        self.assertEquals('00something', _mod_keyer({
+        self.assertEquals((0, 0, 'something'), _mod_keyer({
             'Action': 'DELETE',
             'ResourceRecordSet': {
                 'Name': 'something',
@@ -2281,7 +2281,7 @@ class TestModKeyer(TestCase):
         }))
 
         # Creates come next
-        self.assertEquals('10another', _mod_keyer({
+        self.assertEquals((1, 0, 'another'), _mod_keyer({
             'Action': 'CREATE',
             'ResourceRecordSet': {
                 'Name': 'another',
@@ -2289,7 +2289,7 @@ class TestModKeyer(TestCase):
         }))
 
         # Then upserts
-        self.assertEquals('20last', _mod_keyer({
+        self.assertEquals((2, 0, 'last'), _mod_keyer({
             'Action': 'UPSERT',
             'ResourceRecordSet': {
                 'Name': 'last',
@@ -2299,7 +2299,7 @@ class TestModKeyer(TestCase):
         # Second "column" value records tested above
 
         # AliasTarget primary second (to value)
-        self.assertEquals('01thing', _mod_keyer({
+        self.assertEquals((0, 1, 'thing'), _mod_keyer({
             'Action': 'DELETE',
             'ResourceRecordSet': {
                 'AliasTarget': 'some-target',
@@ -2309,7 +2309,7 @@ class TestModKeyer(TestCase):
         }))
 
         # AliasTarget secondary third
-        self.assertEquals('02thing', _mod_keyer({
+        self.assertEquals((0, 2, 'thing'), _mod_keyer({
             'Action': 'DELETE',
             'ResourceRecordSet': {
                 'AliasTarget': 'some-target',
@@ -2319,7 +2319,7 @@ class TestModKeyer(TestCase):
         }))
 
         # GeoLocation fourth
-        self.assertEquals('03some-id', _mod_keyer({
+        self.assertEquals((0, 3, 'some-id'), _mod_keyer({
             'Action': 'DELETE',
             'ResourceRecordSet': {
                 'GeoLocation': 'some-target',

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -841,6 +841,7 @@ class TestRoute53Provider(TestCase):
             'CallerReference': ANY,
             'HealthCheckConfig': health_check_config,
         })
+        stubber.add_response('change_tags_for_resource', {})
 
         record = Record.new(self.expected, '', {
             'ttl': 61,
@@ -947,6 +948,8 @@ class TestRoute53Provider(TestCase):
             'CallerReference': ANY,
             'HealthCheckConfig': health_check_config,
         })
+        stubber.add_response('change_tags_for_resource', {})
+        stubber.add_response('change_tags_for_resource', {})
 
         record = Record.new(self.expected, 'a', {
             'ttl': 61,

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -42,6 +42,202 @@ class TestOctalReplace(TestCase):
             self.assertEquals(expected, _octal_replace(s))
 
 
+dynamic_rrsets = [{
+    'Name': '_octodns-default-pool.unit.tests.',
+    'ResourceRecords': [{'Value': '1.1.2.1'},
+                        {'Value': '1.1.2.2'}],
+    'TTL': 60,
+    'Type': 'A',
+}, {
+    'HealthCheckId': '76',
+    'Name': '_octodns-ap-southeast-1-value.unit.tests.',
+    'ResourceRecords': [{'Value': '1.4.1.1'}],
+    'SetIdentifier': 'ap-southeast-1-000',
+    'TTL': 60,
+    'Type': 'A',
+    'Weight': 2
+}, {
+    'HealthCheckId': '09',
+    'Name': '_octodns-ap-southeast-1-value.unit.tests.',
+    'ResourceRecords': [{'Value': '1.4.1.2'}],
+    'SetIdentifier': 'ap-southeast-1-001',
+    'TTL': 60,
+    'Type': 'A',
+    'Weight': 2
+}, {
+    'HealthCheckId': 'ab',
+    'Name': '_octodns-eu-central-1-value.unit.tests.',
+    'ResourceRecords': [{'Value': '1.3.1.1'}],
+    'SetIdentifier': 'eu-central-1-000',
+    'TTL': 60,
+    'Type': 'A',
+    'Weight': 1
+}, {
+    'HealthCheckId': '1e',
+    'Name': '_octodns-eu-central-1-value.unit.tests.',
+    'ResourceRecords': [{'Value': '1.3.1.2'}],
+    'SetIdentifier': 'eu-central-1-001',
+    'TTL': 60,
+    'Type': 'A',
+    'Weight': 1
+}, {
+    'HealthCheckId': '2a',
+    'Name': '_octodns-us-east-1-value.unit.tests.',
+    'ResourceRecords': [{'Value': '1.5.1.1'}],
+    'SetIdentifier': 'us-east-1-000',
+    'TTL': 60,
+    'Type': 'A',
+    'Weight': 1
+}, {
+    'HealthCheckId': '61',
+    'Name': '_octodns-us-east-1-value.unit.tests.',
+    'ResourceRecords': [{'Value': '1.5.1.2'}],
+    'SetIdentifier': 'us-east-1-001',
+    'TTL': 60,
+    'Type': 'A',
+    'Weight': 1,
+}, {
+    'AliasTarget': {'DNSName': '_octodns-default-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'Failover': 'SECONDARY',
+    'Name': '_octodns-us-east-1-pool.unit.tests.',
+    'SetIdentifier': 'us-east-1-Secondary-default',
+    'Type': 'A'
+}, {
+    'AliasTarget': {
+        'DNSName': '_octodns-us-east-1-value.unit.tests.',
+        'EvaluateTargetHealth': True,
+        'HostedZoneId': 'Z2'
+    },
+    'Failover': 'PRIMARY',
+    'Name': '_octodns-us-east-1-pool.unit.tests.',
+    'SetIdentifier': 'us-east-1-Primary',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-us-east-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'Failover': 'SECONDARY',
+    'Name': '_octodns-eu-central-1-pool.unit.tests.',
+    'SetIdentifier': 'eu-central-1-Secondary-default',
+    'Type': 'A'
+}, {
+    'AliasTarget': {
+        'DNSName': '_octodns-eu-central-1-value.unit.tests.',
+        'EvaluateTargetHealth': True,
+        'HostedZoneId': 'Z2'
+    },
+    'Failover': 'PRIMARY',
+    'Name': '_octodns-eu-central-1-pool.unit.tests.',
+    'SetIdentifier': 'eu-central-1-Primary',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-us-east-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'Failover': 'SECONDARY',
+    'Name': '_octodns-ap-southeast-1-pool.unit.tests.',
+    'SetIdentifier': 'ap-southeast-1-Secondary-default',
+    'Type': 'A'
+}, {
+    'AliasTarget': {
+        'DNSName': '_octodns-ap-southeast-1-value.unit.tests.',
+        'EvaluateTargetHealth': True,
+        'HostedZoneId': 'Z2'
+    },
+    'Failover': 'PRIMARY',
+    'Name': '_octodns-ap-southeast-1-pool.unit.tests.',
+    'SetIdentifier': 'ap-southeast-1-Primary',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-ap-southeast-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'GeoLocation': {'CountryCode': 'JP'},
+    'Name': 'unit.tests.',
+    'SetIdentifier': '1-ap-southeast-1-AS-JP',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-ap-southeast-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'GeoLocation': {'CountryCode': 'CN'},
+    'Name': 'unit.tests.',
+    'SetIdentifier': '1-ap-southeast-1-AS-CN',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-eu-central-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'GeoLocation': {'ContinentCode': 'NA-US-FL'},
+    'Name': 'unit.tests.',
+    'SetIdentifier': '2-eu-central-1-NA-US-FL',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-eu-central-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'GeoLocation': {'ContinentCode': 'EU'},
+    'Name': 'unit.tests.',
+    'SetIdentifier': '2-eu-central-1-EU',
+    'Type': 'A',
+}, {
+    'AliasTarget': {'DNSName': '_octodns-us-east-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2'},
+    'GeoLocation': {'CountryCode': '*'},
+    'Name': 'unit.tests.',
+    'SetIdentifier': '3-us-east-1-None',
+    'Type': 'A',
+}]
+
+dynamic_record_data = {
+    'dynamic': {
+        'pools': {
+            'ap-southeast-1': {
+                'fallback': 'us-east-1',
+                'values': [{
+                    'weight': 2, 'value': '1.4.1.1'
+                }, {
+                    'weight': 2, 'value': '1.4.1.2'
+                }]
+            },
+            'eu-central-1': {
+                'fallback': 'us-east-1',
+                'values': [{
+                    'weight': 1, 'value': '1.3.1.1'
+                }, {
+                    'weight': 1, 'value': '1.3.1.2'
+                }],
+            },
+            'us-east-1': {
+                'values': [{
+                    'weight': 1, 'value': '1.5.1.1'
+                }, {
+                    'weight': 1, 'value': '1.5.1.2'
+                }],
+            }
+        },
+        'rules': [{
+            'geos': ['AS-CN', 'AS-JP'],
+            'pool': 'ap-southeast-1',
+        }, {
+            'geos': ['EU', 'NA-US-FL'],
+            'pool': 'eu-central-1',
+        }, {
+            'pool': 'us-east-1',
+        }],
+    },
+    'ttl': 60,
+    'type': 'A',
+    'values': [
+        '1.1.2.1',
+        '1.1.2.2',
+    ],
+}
+
+
 class TestRoute53Provider(TestCase):
     expected = Zone('unit.tests.', [])
     for name, data in (
@@ -1534,6 +1730,71 @@ class TestRoute53Provider(TestCase):
                           ._unique_id_handlers['retry-config-route53']
                           ['handler']._checker.__dict__['_max_attempts'])
 
+    def test_data_for_dynamic(self):
+        provider = Route53Provider('test', 'abc', '123')
+
+        data = provider._data_for_dynamic('', 'A', dynamic_rrsets)
+        self.assertEquals(dynamic_record_data, data)
+
+    @patch('octodns.provider.route53.Route53Provider._get_zone_id')
+    @patch('octodns.provider.route53.Route53Provider._load_records')
+    def test_dynamic_populate(self, load_records_mock, get_zone_id_mock):
+        provider = Route53Provider('test', 'abc', '123')
+
+        get_zone_id_mock.side_effect = ['z44']
+        load_records_mock.side_effect = [dynamic_rrsets]
+
+        got = Zone('unit.tests.', [])
+        provider.populate(got)
+
+        self.assertEquals(1, len(got.records))
+        record = list(got.records)[0]
+        self.assertEquals('', record.name)
+        self.assertEquals('A', record._type)
+        self.assertEquals([
+            '1.1.2.1',
+            '1.1.2.2',
+        ], record.values)
+        self.assertTrue(record.dynamic)
+
+        self.assertEquals({
+            'ap-southeast-1': {
+                'fallback': 'us-east-1',
+                'values': [{
+                    'weight': 2, 'value': '1.4.1.1'
+                }, {
+                    'weight': 2, 'value': '1.4.1.2'
+                }]
+            },
+            'eu-central-1': {
+                'fallback': 'us-east-1',
+                'values': [{
+                    'weight': 1, 'value': '1.3.1.1'
+                }, {
+                    'weight': 1, 'value': '1.3.1.2'
+                }],
+            },
+            'us-east-1': {
+                'fallback': None,
+                'values': [{
+                    'weight': 1, 'value': '1.5.1.1'
+                }, {
+                    'weight': 1, 'value': '1.5.1.2'
+                }],
+            }
+        }, {k: v.data for k, v in record.dynamic.pools.items()})
+
+        self.assertEquals([
+            {
+                'geos': ['AS-CN', 'AS-JP'],
+                'pool': 'ap-southeast-1',
+            }, {
+                'geos': ['EU', 'NA-US-FL'],
+                'pool': 'eu-central-1',
+            }, {
+                'pool': 'us-east-1',
+            }], [r.data for r in record.dynamic.rules])
+
 
 class TestRoute53Records(TestCase):
     existing = Zone('unit.tests.', [])
@@ -1551,8 +1812,9 @@ class TestRoute53Records(TestCase):
         route53_record = _Route53Record(None, self.record_a, False)
 
         for value in (None, '', 'foo', 'bar', '1.2.3.4'):
-            self.assertEquals(value, route53_record
-                              ._value_convert_value(value, self.record_a))
+            converted = route53_record._value_convert_value(value,
+                                                            self.record_a)
+            self.assertEquals(value, converted)
 
         record_txt = Record.new(self.existing, 'txt', {
             'ttl': 98,
@@ -1623,6 +1885,242 @@ class TestRoute53Records(TestCase):
         a.__repr__()
         e.__repr__()
         f.__repr__()
+
+    def test_new_dynamic(self):
+        provider = Route53Provider('test', 'abc', '123')
+
+        # Just so boto won't try and make any calls
+        stubber = Stubber(provider._conn)
+        stubber.activate()
+
+        # We'll assume we create all healthchecks here, this functionality is
+        # thoroughly tested elsewhere
+        provider._health_checks = {}
+        # When asked for a healthcheck return dummy info
+        provider.get_health_check_id = lambda r, v, c: 'hc42'
+
+        zone = Zone('unit.tests.', [])
+        record = Record.new(zone, '', dynamic_record_data)
+
+        # Convert a record into _Route53Records
+        route53_records = _Route53Record.new(provider, record, 'z45',
+                                             creating=True)
+        self.assertEquals(18, len(route53_records))
+
+        # Convert the route53_records into mods
+        self.assertEquals([{
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'HealthCheckId': 'hc42',
+                'Name': '_octodns-ap-southeast-1-value.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.4.1.2'}],
+                'SetIdentifier': 'ap-southeast-1-001',
+                'TTL': 60,
+                'Type': 'A',
+                'Weight': 2
+            }
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'HealthCheckId': 'hc42',
+                'Name': '_octodns-ap-southeast-1-value.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.4.1.1'}],
+                'SetIdentifier': 'ap-southeast-1-000',
+                'TTL': 60,
+                'Type': 'A',
+                'Weight': 2
+            }
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-ap-southeast-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'
+                },
+                'GeoLocation': {
+                    'CountryCode': 'JP'},
+                'Name': 'unit.tests.',
+                'SetIdentifier': '0-ap-southeast-1-AS-JP',
+                'Type': 'A'
+            }
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-eu-central-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'GeoLocation': {
+                    'CountryCode': 'US',
+                    'SubdivisionCode': 'FL',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '1-eu-central-1-NA-US-FL',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-us-east-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'GeoLocation': {
+                    'CountryCode': '*'},
+                'Name': 'unit.tests.',
+                'SetIdentifier': '2-us-east-1-None',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-us-east-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'Failover': 'SECONDARY',
+                'Name': '_octodns-ap-southeast-1-pool.unit.tests.',
+                'SetIdentifier': 'ap-southeast-1-Secondary-us-east-1',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-ap-southeast-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'GeoLocation': {
+                    'CountryCode': 'CN'},
+                'Name': 'unit.tests.',
+                'SetIdentifier': '0-ap-southeast-1-AS-CN',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-us-east-1-value.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'Failover': 'PRIMARY',
+                'Name': '_octodns-us-east-1-pool.unit.tests.',
+                'SetIdentifier': 'us-east-1-Primary',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-eu-central-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'GeoLocation': {
+                    'ContinentCode': 'EU'},
+                'Name': 'unit.tests.',
+                'SetIdentifier': '1-eu-central-1-EU',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-eu-central-1-value.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'Failover': 'PRIMARY',
+                'Name': '_octodns-eu-central-1-pool.unit.tests.',
+                'SetIdentifier': 'eu-central-1-Primary',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'Name': '_octodns-default-pool.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.1.2.1'},
+                    {
+                        'Value': '1.1.2.2'}],
+                'TTL': 60,
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'HealthCheckId': 'hc42',
+                'Name': '_octodns-eu-central-1-value.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.3.1.2'}],
+                'SetIdentifier': 'eu-central-1-001',
+                'TTL': 60,
+                'Type': 'A',
+                'Weight': 1}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'HealthCheckId': 'hc42',
+                'Name': '_octodns-eu-central-1-value.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.3.1.1'}],
+                'SetIdentifier': 'eu-central-1-000',
+                'TTL': 60,
+                'Type': 'A',
+                'Weight': 1}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-default-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'Failover': 'SECONDARY',
+                'Name': '_octodns-us-east-1-pool.unit.tests.',
+                'SetIdentifier': 'us-east-1-Secondary-default',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'HealthCheckId': 'hc42',
+                'Name': '_octodns-us-east-1-value.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.5.1.2'}],
+                'SetIdentifier': 'us-east-1-001',
+                'TTL': 60,
+                'Type': 'A',
+                'Weight': 1}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'HealthCheckId': 'hc42',
+                'Name': '_octodns-us-east-1-value.unit.tests.',
+                'ResourceRecords': [{
+                    'Value': '1.5.1.1'}],
+                'SetIdentifier': 'us-east-1-000',
+                'TTL': 60,
+                'Type': 'A',
+                'Weight': 1}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-ap-southeast-1-value.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'Failover': 'PRIMARY',
+                'Name': '_octodns-ap-southeast-1-pool.unit.tests.',
+                'SetIdentifier': 'ap-southeast-1-Primary',
+                'Type': 'A'}
+        }, {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': '_octodns-us-east-1-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'z45'},
+                'Failover': 'SECONDARY',
+                'Name': '_octodns-eu-central-1-pool.unit.tests.',
+                'SetIdentifier': 'eu-central-1-Secondary-us-east-1',
+                'Type': 'A'}
+        }], [r.mod('CREATE') for r in route53_records])
+
+        for route53_record in route53_records:
+            # Smoke test stringification
+            route53_record.__repr__()
 
 
 class TestModKeyer(TestCase):

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -773,7 +773,8 @@ class TestRoute53Provider(TestCase):
                 'AF': ['4.2.3.4'],
             }
         })
-        id = provider.get_health_check_id(record, 'AF', record.geo['AF'], True)
+        value = record.geo['AF'].values[0]
+        id = provider.get_health_check_id(record, value, True)
         self.assertEquals('42', id)
 
     def test_health_check_create(self):
@@ -859,12 +860,12 @@ class TestRoute53Provider(TestCase):
         })
 
         # if not allowed to create returns none
-        id = provider.get_health_check_id(record, 'AF', record.geo['AF'],
-                                          False)
+        value = record.geo['AF'].values[0]
+        id = provider.get_health_check_id(record, value, False)
         self.assertFalse(id)
 
         # when allowed to create we do
-        id = provider.get_health_check_id(record, 'AF', record.geo['AF'], True)
+        id = provider.get_health_check_id(record, value, True)
         self.assertEquals('42', id)
         stubber.assert_no_pending_responses()
 
@@ -965,7 +966,8 @@ class TestRoute53Provider(TestCase):
             }
         })
 
-        id = provider.get_health_check_id(record, 'AF', record.geo['AF'], True)
+        value = record.geo['AF'].values[0]
+        id = provider.get_health_check_id(record, value, True)
         ml = provider.health_checks[id]['HealthCheckConfig']['MeasureLatency']
         self.assertEqual(False, ml)
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -1010,7 +1010,7 @@ class TestRoute53Provider(TestCase):
             'HealthCheckId': '44',
         })
         change = Create(record)
-        provider._mod_Create(change)
+        provider._mod_Create(change, 'z43')
         stubber.assert_no_pending_responses()
 
         # gc through _mod_Update
@@ -1019,7 +1019,7 @@ class TestRoute53Provider(TestCase):
         })
         # first record is ignored for our purposes, we have to pass something
         change = Update(record, record)
-        provider._mod_Create(change)
+        provider._mod_Create(change, 'z43')
         stubber.assert_no_pending_responses()
 
         # gc through _mod_Delete, expect 3 to go away, can't check order
@@ -1034,7 +1034,7 @@ class TestRoute53Provider(TestCase):
             'HealthCheckId': ANY,
         })
         change = Delete(record)
-        provider._mod_Delete(change)
+        provider._mod_Delete(change, 'z43')
         stubber.assert_no_pending_responses()
 
         # gc only AAAA, leave the A's alone


### PR DESCRIPTION
- [x] Code up a POC/mostly working setup that's uncommitted and messy (just happens to be how I went about this.)
- [x] Break up ^ into logical/meaningful commits and make sure bits are tested as committed
- [x] Write tests for all the new dynamic bits 
- [x] Go back through and address remaining TODOs or call them out as 🏈s
- [x] Review
- [x] :shipit: 