### PR TITLE
Refactor shell script syntax and consistency

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,7 +4,7 @@
 
 set -e
 
-cd "$(dirname $0)"/..
+cd "$(dirname "$0")"/..
 ROOT=$(pwd)
 
 if [ -z "$VENV_NAME" ]; then
@@ -13,9 +13,9 @@ fi
 
 if [ ! -d "$VENV_NAME" ]; then
     if [ -z "$VENV_PYTHON" ]; then
-        VENV_PYTHON=`which python`
+        VENV_PYTHON=$(command -v python)
     fi
-    virtualenv --python=$VENV_PYTHON $VENV_NAME
+    virtualenv --python="$VENV_PYTHON" "$VENV_NAME"
 fi
 . "$VENV_NAME/bin/activate"
 

--- a/script/coverage
+++ b/script/coverage
@@ -26,11 +26,11 @@ export DYN_PASSWORD=
 export DYN_USERNAME=
 export GOOGLE_APPLICATION_CREDENTIALS=
 
-coverage run --branch --source=octodns --omit=octodns/cmds/* `which nosetests` --with-xunit "$@"
+coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v nosetests)" --with-xunit "$@"
 coverage html
 coverage xml
 coverage report
-coverage report | grep ^TOTAL| grep -qv 100% && {
-    echo "Incomplete code coverage"
+coverage report | grep ^TOTAL | grep -qv 100% && {
+    echo "Incomplete code coverage" >&2
     exit 1
 } || echo "Code coverage 100%"

--- a/script/release
+++ b/script/release
@@ -2,7 +2,7 @@
 
 set -e
 
-cd "$(dirname $0)"/..
+cd "$(dirname "$0")"/..
 ROOT=$(pwd)
 
 if [ -z "$VENV_NAME" ]; then
@@ -16,10 +16,10 @@ if [ ! -f "$ACTIVATE" ]; then
 fi
 . "$ACTIVATE"
 
-VERSION=$(grep __VERSION__ $ROOT/octodns/__init__.py | sed -e "s/.* = '//" -e "s/'$//")
+VERSION="$(grep __VERSION__ "$ROOT/octodns/__init__.py" | sed -e "s/.* = '//" -e "s/'$//")"
 
-git tag -s v$VERSION -m "Release $VERSION"
-git push origin v$VERSION
+git tag -s "v$VERSION" -m "Release $VERSION"
+git push origin "v$VERSION"
 echo "Tagged and pushed v$VERSION"
 python setup.py sdist
 twine upload dist/*$VERSION.tar.gz

--- a/script/sdist
+++ b/script/sdist
@@ -3,13 +3,13 @@
 set -e
 
 if ! git diff-index --quiet HEAD --; then
-    echo "Changes in local directory, commit or clear"
+    echo "Changes in local directory, commit or clear" >&2
     exit 1
 fi
 
 SHA=$(git rev-parse HEAD)
 python setup.py sdist
-TARBALL=dist/octodns-$SHA.tar.gz
-mv dist/octodns-0.*.tar.gz $TARBALL
+TARBALL="dist/octodns-$SHA.tar.gz"
+mv dist/octodns-0.*.tar.gz "$TARBALL"
 
 echo "Created $TARBALL"


### PR DESCRIPTION
- Add a missing space for styling
- Replace legacy "\`...\`" with `$(...)`
- Quote variable to prevent word splitting
- Use builtin `command -v` instead of non-standard `which`
- Add two missing `>&2` redirection for error/warning message