### PR TITLE
Normalize CNAME/ALIAS/PTR value to lower-case

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -714,6 +714,8 @@ class _TargetValue(object):
 
     @classmethod
     def process(self, value):
+        if value:
+            return value.lower()
         return value
 
 

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -8,8 +8,8 @@ from __future__ import absolute_import, division, print_function, \
 from unittest import TestCase
 
 from octodns.record import ARecord, AaaaRecord, AliasRecord, CaaRecord, \
-    CnameRecord, Create, Delete, GeoValue, MxRecord, NaptrRecord, \
-    NaptrValue, NsRecord, Record, SshfpRecord, SpfRecord, SrvRecord, \
+    CnameRecord, Create, Delete, GeoValue, MxRecord, NaptrRecord, NaptrValue, \
+    NsRecord, PtrRecord, Record, SshfpRecord, SpfRecord, SrvRecord, \
     TxtRecord, Update, ValidationError, _Dynamic, _DynamicPool, _DynamicRule
 from octodns.zone import Zone
 
@@ -26,6 +26,45 @@ class TestRecord(TestCase):
             'value': '1.2.3.4',
         })
         self.assertEquals('mixedcase', record.name)
+
+    def test_alias_lowering_value(self):
+        upper_record = AliasRecord(self.zone, 'aliasUppwerValue', {
+            'ttl': 30,
+            'type': 'ALIAS',
+            'value': 'GITHUB.COM',
+        })
+        lower_record = AliasRecord(self.zone, 'aliasLowerValue', {
+            'ttl': 30,
+            'type': 'ALIAS',
+            'value': 'github.com',
+        })
+        self.assertEquals(upper_record.value, lower_record.value)
+
+    def test_cname_lowering_value(self):
+        upper_record = CnameRecord(self.zone, 'CnameUppwerValue', {
+            'ttl': 30,
+            'type': 'CNAME',
+            'value': 'GITHUB.COM',
+        })
+        lower_record = CnameRecord(self.zone, 'CnameLowerValue', {
+            'ttl': 30,
+            'type': 'CNAME',
+            'value': 'github.com',
+        })
+        self.assertEquals(upper_record.value, lower_record.value)
+
+    def test_ptr_lowering_value(self):
+        upper_record = PtrRecord(self.zone, 'PtrUppwerValue', {
+            'ttl': 30,
+            'type': 'PTR',
+            'value': 'GITHUB.COM',
+        })
+        lower_record = PtrRecord(self.zone, 'PtrLowerValue', {
+            'ttl': 30,
+            'type': 'PTR',
+            'value': 'github.com',
+        })
+        self.assertEquals(upper_record.value, lower_record.value)
 
     def test_a_and_record(self):
         a_values = ['1.2.3.4', '2.2.3.4']


### PR DESCRIPTION
Related to #337

Currently, CNAME value is not normalized, but might but stored by provider in lower case, which will cause just almost the same issue as #322(one is MX but one is CNAME): found diff and update every sync, and it could be solved by normalization CNAME value.

I also add a small test, just like #337, to make sure the behavior won't appear in the future become a regression bug. Without the normalization, tests will fail as below:

```
..............................................................................................................................................................................................................................F........................................................
======================================================================
FAIL: test_cname_lowering_value (test_octodns_record.TestRecord)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pete/octodns/tests/test_octodns_record.py", line 42, in test_cname_lowering_value
    self.assertEquals(upper_record.value, lower_record.value)
AssertionError: u'GITHUB.COM' != u'github.com'
- GITHUB.COM
+ github.com

-------------------- >> begin captured logging << --------------------
Record: DEBUG: __init__: zone.name=unit.tests., type=CnameRecord, name=CnameUppwerValue
Record: DEBUG: __init__: zone.name=unit.tests., type=CnameRecord, name=CnameLowerValue
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 279 tests in 4.730s

FAILED (failures=1)

```