### PR TITLE
Update .gitignore to exclude setup.py generated build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .coverage
 .env
 /config/
+/build/
 coverage.xml
 dist/
 env/


### PR DESCRIPTION
`setup.py build` will build the package underneath 'build/', which doesn't need to be tracked by git.