### PR TITLE
Prevent digital ocean provider to crash if records type is not supported

### DIFF
--- a/octodns/provider/digitalocean.py
+++ b/octodns/provider/digitalocean.py
@@ -223,6 +223,10 @@ class DigitalOceanProvider(BaseProvider):
         values = defaultdict(lambda: defaultdict(list))
         for record in self.zone_records(zone):
             _type = record['type']
+            if _type not in self.SUPPORTS:
+                self.log.warning('populate: skipping unsupported %s record',
+                                 _type)
+                continue
             values[record['name']][record['type']].append(record)
 
         before = len(zone.records)

--- a/tests/fixtures/digitalocean-page-1.json
+++ b/tests/fixtures/digitalocean-page-1.json
@@ -1,5 +1,16 @@
 {
 	"domain_records": [{
+		"id": null,
+		"type": "SOA",
+		"name": "@",
+		"data": null,
+		"priority": null,
+		"port": null,
+		"ttl": null,
+		"weight": null,
+		"flags": null,
+		"tag": null
+	}, {
 		"id": 11189874,
 		"type": "NS",
 		"name": "@",


### PR DESCRIPTION
This patch will prevent Digital Ocean provider to crash if records type is not supported

Fix #363 