### PR TITLE
Drop dynamic record value weight to 0-16

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -514,7 +514,7 @@ class _DynamicMixin(object):
                     try:
                         weight = value['weight']
                         weight = int(weight)
-                        if weight < 1 or weight > 255:
+                        if weight < 1 or weight > 15:
                             reasons.append('invalid weight "{}" in pool "{}" '
                                            'value {}'.format(weight, _id,
                                                              value_num))

--- a/tests/config/dynamic.tests.yaml
+++ b/tests/config/dynamic.tests.yaml
@@ -19,7 +19,7 @@ a:
           - value: 6.6.6.6
             weight: 10
           - value: 5.5.5.5
-            weight: 25
+            weight: 15
     rules:
       - geos:
         - EU-GB
@@ -90,9 +90,9 @@ cname:
       sea:
         values:
           - value: target-sea-1.unit.tests.
-            weight: 100
+            weight: 10
           - value: target-sea-2.unit.tests.
-            weight: 175
+            weight: 14
     rules:
       - geos:
         - EU-GB

--- a/tests/config/split/dynamic.tests./a.yaml
+++ b/tests/config/split/dynamic.tests./a.yaml
@@ -23,7 +23,7 @@ a:
         fallback: null
         values:
         - value: 5.5.5.5
-          weight: 25
+          weight: 15
         - value: 6.6.6.6
           weight: 10
     rules:

--- a/tests/config/split/dynamic.tests./cname.yaml
+++ b/tests/config/split/dynamic.tests./cname.yaml
@@ -21,9 +21,9 @@ cname:
         fallback: null
         values:
         - value: target-sea-1.unit.tests.
-          weight: 100
+          weight: 10
         - value: target-sea-2.unit.tests.
-          weight: 175
+          weight: 14
     rules:
     - geos:
       - EU-GB

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -2460,7 +2460,7 @@ class TestDynamicRecords(TestCase):
                             'weight': 1,
                             'value': '6.6.6.6',
                         }, {
-                            'weight': 256,
+                            'weight': 16,
                             'value': '7.7.7.7',
                         }],
                     },
@@ -2484,7 +2484,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['invalid weight "256" in pool "three" value 2'],
+        self.assertEquals(['invalid weight "16" in pool "three" value 2'],
                           ctx.exception.reasons)
 
         # invalid non-int weight


### PR DESCRIPTION
That's all Dyn supports and it's cleaner to match it than to scale dyn since
we'd lose precision we can't get back during populate.