### PR TITLE
v0.9.6 version bump and CHANGELOG updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.9.6 - 2019-07-16 - The little one that fixes stuff from the big one
+
+* Reduced dynamic record value weight range to 0-15 so that Dyn and Route53
+  match up behaviors. Dyn is limited to 0-15 and scaling that up would lose
+  resolution that couldn't be recovered during populate.
+* Addressed issues with Route53 change set ordering for dynamic records
+* Ignore unsupported record types in DigitalOceanProvider
+* Fix bugs in Route53 extra changes handling and health check managagement
+
 ## v0.9.5 - 2019-05-06 - The big one, with all the dynamic stuff
 
 * dynamic record support, essentially a v2 version of geo records with a lot

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.5'
+__VERSION__ = '0.9.6'


### PR DESCRIPTION
## v0.9.6 - 2019-07-16 - The little one that fixes stuff from the big one

* Reduced dynamic record value weight range to 0-15 so that Dyn and Route53
  match up behaviors. Dyn is limited to 0-15 and scaling that up would lose
  resolution that couldn't be recovered during populate.
* Addressed issues with Route53 change set ordering for dynamic records
* Ignore unsupported record types in DigitalOceanProvider
* Fix bugs in Route53 extra changes handling and health check managagement