### PR TITLE
Fix typos across octodns repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ Adds an OVH provider.
 
 ## v0.8.6 - 2017-09-06 - CAA record type,
 
-Misc fixes and improvments.
+Misc fixes and improvements.
 
 * Azure TXT record fix
 * PowerDNS api support for https

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -528,13 +528,13 @@ def _mod_keyer(mod):
     # before all changes, followed by a "CREATE", internally in the AWS API.
     # Because of this, we order changes as follows:
     #   - Delete any records that we wish to delete that are GEOS
-    #      (because they are never targetted by anything)
+    #      (because they are never targeted by anything)
     #   - Delete any records that we wish to delete that are SECONDARY
-    #      (because they are no longer targetted by GEOS)
+    #      (because they are no longer targeted by GEOS)
     #   - Delete any records that we wish to delete that are PRIMARY
-    #      (because they are no longer targetted by SECONDARY)
+    #      (because they are no longer targeted by SECONDARY)
     #   - Delete any records that we wish to delete that are VALUES
-    #      (because they are no longer targetted by PRIMARY)
+    #      (because they are no longer targeted by PRIMARY)
     #   - CREATE/UPSERT any records that are VALUES
     #      (because they don't depend on other records)
     #   - CREATE/UPSERT any records that are PRIMARY
@@ -1028,7 +1028,7 @@ class Route53Provider(BaseProvider):
             .get('healthcheck', {}) \
             .get('measure_latency', True)
 
-    def _health_check_equivilent(self, host, path, protocol, port,
+    def _health_check_equivalent(self, host, path, protocol, port,
                                  measure_latency, health_check, value=None):
         config = health_check['HealthCheckConfig']
 
@@ -1080,7 +1080,7 @@ class Route53Provider(BaseProvider):
             if not health_check['CallerReference'].startswith(expected_ref):
                 # not match, ignore
                 continue
-            if self._health_check_equivilent(healthcheck_host,
+            if self._health_check_equivalent(healthcheck_host,
                                              healthcheck_path,
                                              healthcheck_protocol,
                                              healthcheck_port,
@@ -1237,7 +1237,7 @@ class Route53Provider(BaseProvider):
             health_check = self.health_checks[health_check_id]
             caller_ref = health_check['CallerReference']
             if caller_ref.startswith(self.HEALTH_CHECK_VERSION):
-                if self._health_check_equivilent(healthcheck_host,
+                if self._health_check_equivalent(healthcheck_host,
                                                  healthcheck_path,
                                                  healthcheck_protocol,
                                                  healthcheck_port,

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -102,7 +102,7 @@ class TestCloudflareProvider(TestCase):
                 provider.populate(zone)
             self.assertEquals(502, ctx.exception.response.status_code)
 
-        # Non-existant zone doesn't populate anything
+        # Non-existent zone doesn't populate anything
         with requests_mock() as mock:
             mock.get(ANY, status_code=200, json=self.empty)
 
@@ -110,7 +110,7 @@ class TestCloudflareProvider(TestCase):
             provider.populate(zone)
             self.assertEquals(set(), zone.records)
 
-        # re-populating the same non-existant zone uses cache and makes no
+        # re-populating the same non-existent zone uses cache and makes no
         # calls
         again = Zone('unit.tests.', [])
         provider.populate(again)
@@ -173,7 +173,7 @@ class TestCloudflareProvider(TestCase):
             },  # zone create
         ] + [None] * 20  # individual record creates
 
-        # non-existant zone, create everything
+        # non-existent zone, create everything
         plan = provider.plan(self.expected)
         self.assertEquals(12, len(plan.changes))
         self.assertEquals(12, provider.apply(plan))

--- a/tests/test_octodns_provider_digitalocean.py
+++ b/tests/test_octodns_provider_digitalocean.py
@@ -61,7 +61,7 @@ class TestDigitalOceanProvider(TestCase):
                 provider.populate(zone)
             self.assertEquals(502, ctx.exception.response.status_code)
 
-        # Non-existant zone doesn't populate anything
+        # Non-existent zone doesn't populate anything
         with requests_mock() as mock:
             mock.get(ANY, status_code=404,
                      text='{"id":"not_found","message":"The resource you '
@@ -153,7 +153,7 @@ class TestDigitalOceanProvider(TestCase):
             }
         }
 
-        # non-existant domain, create everything
+        # non-existent domain, create everything
         resp.json.side_effect = [
             DigitalOceanClientNotFound,  # no zone in populate
             DigitalOceanClientNotFound,  # no domain during apply

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -58,7 +58,7 @@ class TestDnsimpleProvider(TestCase):
                 provider.populate(zone)
             self.assertEquals(502, ctx.exception.response.status_code)
 
-        # Non-existant zone doesn't populate anything
+        # Non-existent zone doesn't populate anything
         with requests_mock() as mock:
             mock.get(ANY, status_code=404,
                      text='{"message": "Domain `foo.bar` not found"}')
@@ -122,7 +122,7 @@ class TestDnsimpleProvider(TestCase):
         resp.json = Mock()
         provider._client._request = Mock(return_value=resp)
 
-        # non-existant domain, create everything
+        # non-existent domain, create everything
         resp.json.side_effect = [
             DnsimpleClientNotFound,  # no zone in populate
             DnsimpleClientNotFound,  # no domain during apply

--- a/tests/test_octodns_provider_dnsmadeeasy.py
+++ b/tests/test_octodns_provider_dnsmadeeasy.py
@@ -87,7 +87,7 @@ class TestDnsMadeEasyProvider(TestCase):
                 provider.populate(zone)
             self.assertEquals(502, ctx.exception.response.status_code)
 
-        # Non-existant zone doesn't populate anything
+        # Non-existent zone doesn't populate anything
         with requests_mock() as mock:
             mock.get(ANY, status_code=404,
                      text='<html><head></head><body></body></html>')
@@ -130,7 +130,7 @@ class TestDnsMadeEasyProvider(TestCase):
         with open('tests/fixtures/dnsmadeeasy-domains.json') as fh:
             domains = json.load(fh)
 
-        # non-existant domain, create everything
+        # non-existent domain, create everything
         resp.json.side_effect = [
             DnsMadeEasyClientNotFound,  # no zone in populate
             DnsMadeEasyClientNotFound,  # no domain during apply

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -191,7 +191,7 @@ class TestNs1Provider(TestCase):
         self.assertEquals(load_mock.side_effect, ctx.exception)
         self.assertEquals(('unit.tests',), load_mock.call_args[0])
 
-        # Non-existant zone doesn't populate anything
+        # Non-existent zone doesn't populate anything
         load_mock.reset_mock()
         load_mock.side_effect = \
             ResourceException('server error: zone not found')
@@ -323,7 +323,7 @@ class TestNs1Provider(TestCase):
             provider.apply(plan)
         self.assertEquals(create_mock.side_effect, ctx.exception)
 
-        # non-existant zone, create
+        # non-existent zone, create
         load_mock.reset_mock()
         create_mock.reset_mock()
         load_mock.side_effect = \

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -41,7 +41,7 @@ with open('./tests/fixtures/powerdns-full-data.json') as fh:
 class TestPowerDnsProvider(TestCase):
 
     def test_provider(self):
-        provider = PowerDnsProvider('test', 'non.existant', 'api-key',
+        provider = PowerDnsProvider('test', 'non.existent', 'api-key',
                                     nameserver_values=['8.8.8.8.',
                                                        '9.9.9.9.'])
 
@@ -63,7 +63,7 @@ class TestPowerDnsProvider(TestCase):
                 provider.populate(zone)
             self.assertEquals(502, ctx.exception.response.status_code)
 
-        # Non-existant zone doesn't populate anything
+        # Non-existent zone doesn't populate anything
         with requests_mock() as mock:
             mock.get(ANY, status_code=422,
                      json={'error': "Could not find domain 'unit.tests.'"})
@@ -163,7 +163,7 @@ class TestPowerDnsProvider(TestCase):
                 provider.apply(plan)
 
     def test_small_change(self):
-        provider = PowerDnsProvider('test', 'non.existant', 'api-key')
+        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
 
         expected = Zone('unit.tests.', [])
         source = YamlProvider('test', join(dirname(__file__), 'config'))
@@ -203,7 +203,7 @@ class TestPowerDnsProvider(TestCase):
 
     def test_existing_nameservers(self):
         ns_values = ['8.8.8.8.', '9.9.9.9.']
-        provider = PowerDnsProvider('test', 'non.existant', 'api-key',
+        provider = PowerDnsProvider('test', 'non.existent', 'api-key',
                                     nameserver_values=ns_values)
 
         expected = Zone('unit.tests.', [])

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -2845,7 +2845,7 @@ class TestDynamicRecords(TestCase):
         self.assertEquals(['rule 1 invalid pool "[]"'],
                           ctx.exception.reasons)
 
-        # rule references non-existant pool
+        # rule references non-existent pool
         a_data = {
             'dynamic': {
                 'pools': {
@@ -2864,7 +2864,7 @@ class TestDynamicRecords(TestCase):
                 },
                 'rules': [{
                     'geos': ['NA-US-CA'],
-                    'pool': 'non-existant',
+                    'pool': 'non-existent',
                 }, {
                     'pool': 'one',
                 }],
@@ -2878,7 +2878,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(["rule 1 undefined pool \"non-existant\""],
+        self.assertEquals(["rule 1 undefined pool \"non-existent\""],
                           ctx.exception.reasons)
 
         # rule with invalid geos


### PR DESCRIPTION
**Fix typos** across OctoDNS

**Fixed Files**
```
octodns/CHANGELOG.md:115:15: "improvments" is a misspelling of "improvements"
octodns/octodns/provider/route53.py:531:35: "targetted" is a misspelling of "targeted"
octodns/octodns/provider/route53.py:533:39: "targetted" is a misspelling of "targeted"
octodns/octodns/provider/route53.py:535:39: "targetted" is a misspelling of "targeted"
octodns/octodns/provider/route53.py:537:39: "targetted" is a misspelling of "targeted"
octodns/octodns/provider/route53.py:1031:22: "equivilent" is a misspelling of "equivalent"
octodns/octodns/provider/route53.py:1083:34: "equivilent" is a misspelling of "equivalent"
octodns/octodns/provider/route53.py:1240:38: "equivilent" is a misspelling of "equivalent"
octodns/tests/test_octodns_provider_cloudflare.py:105:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_cloudflare.py:113:37: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_cloudflare.py:176:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_digitalocean.py:64:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_digitalocean.py:156:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_dnsimple.py:61:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_dnsimple.py:125:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_dnsmadeeasy.py:90:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_dnsmadeeasy.py:133:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_ns1.py:194:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_ns1.py:326:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_provider_powerdns.py:66:14: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_record.py:2848:30: "existant" is a misspelling of "existent"
octodns/tests/test_octodns_record.py:2881:56: "existant" is a misspelling of "existent"
```