### PR TITLE
fix Route53Provider to tollerate multiple separators in record values

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -723,7 +723,7 @@ class Route53Provider(BaseProvider):
     def _data_for_CAA(self, rrset):
         values = []
         for rr in rrset['ResourceRecords']:
-            flags, tag, value = rr['Value'].split(' ')
+            flags, tag, value = rr['Value'].split()
             values.append({
                 'flags': flags,
                 'tag': tag,
@@ -761,7 +761,7 @@ class Route53Provider(BaseProvider):
     def _data_for_MX(self, rrset):
         values = []
         for rr in rrset['ResourceRecords']:
-            preference, exchange = rr['Value'].split(' ')
+            preference, exchange = rr['Value'].split()
             values.append({
                 'preference': preference,
                 'exchange': exchange,
@@ -776,7 +776,7 @@ class Route53Provider(BaseProvider):
         values = []
         for rr in rrset['ResourceRecords']:
             order, preference, flags, service, regexp, replacement = \
-                rr['Value'].split(' ')
+                rr['Value'].split()
             flags = flags[1:-1]
             service = service[1:-1]
             regexp = regexp[1:-1]
@@ -804,7 +804,7 @@ class Route53Provider(BaseProvider):
     def _data_for_SRV(self, rrset):
         values = []
         for rr in rrset['ResourceRecords']:
-            priority, weight, port, target = rr['Value'].split(' ')
+            priority, weight, port, target = rr['Value'].split()
             values.append({
                 'priority': priority,
                 'weight': weight,

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -503,7 +503,7 @@ class TestRoute53Provider(TestCase):
                 'ResourceRecords': [{
                     'Value': '10 smtp-1.unit.tests.',
                 }, {
-                    'Value': '20 smtp-2.unit.tests.',
+                    'Value': '20  smtp-2.unit.tests.',
                 }],
                 'TTL': 64,
             }, {


### PR DESCRIPTION
fix split calls in Route53Provider to not specify ' ' parameter so they can tolerate multiple sequential separators