### PR TITLE
Write a test that demonstrates quotation mark breakage

### DIFF
--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -749,11 +749,11 @@ class TestRecord(TestCase):
         txt = Record.new(self.zone, 'txt', {
             'ttl': 44,
             'type': 'TXT',
-            'value': 'some text',
+            'value': '"some" "text"',
         })
         self.assertIsInstance(txt, TxtRecord)
         self.assertEquals('TXT', txt._type)
-        self.assertEquals(['some text'], txt.values)
+        self.assertEquals(['"some" "text"'], txt.values)
 
         # Missing type
         with self.assertRaises(Exception) as ctx:


### PR DESCRIPTION
@cfunkhouser I believe this demonstrates the quotation-marks issue we've been seeing with octodns.

My python is not very good, but if you want to pair on understanding and fixing this at some point, I'd be game :).