### PR TITLE
StringIO py3 compatibility

### DIFF
--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -5,8 +5,8 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from StringIO import StringIO
 from logging import DEBUG, ERROR, INFO, WARN, getLogger
+from six import StringIO
 from sys import stdout
 
 

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -5,8 +5,8 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from six import StringIO
 from logging import getLogger
+from six import StringIO
 from unittest import TestCase
 
 from octodns.provider.plan import Plan, PlanHtml, PlanLogger, PlanMarkdown

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from StringIO import StringIO
+from six import StringIO
 from logging import getLogger
 from unittest import TestCase
 

--- a/tests/test_octodns_yaml.py
+++ b/tests/test_octodns_yaml.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from StringIO import StringIO
+from six import StringIO
 from unittest import TestCase
 from yaml.constructor import ConstructorError
 


### PR DESCRIPTION
Hi folks,

Attempting to follow proper porting guidelines and do these in smaller, more digestible pieces. This PR adds StringIO compatibility for python3.