### PR TITLE
six.moves.urllib compatibility for python3

### DIFF
--- a/octodns/provider/fastdns.py
+++ b/octodns/provider/fastdns.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from requests import Session
 from akamai.edgegrid import EdgeGridAuth
-from urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 from collections import defaultdict
 
 from logging import getLogger

--- a/tests/test_octodns_provider_rackspace.py
+++ b/tests/test_octodns_provider_rackspace.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, division, print_function, \
 
 import json
 import re
+from six.moves.urllib.parse import urlparse
 from unittest import TestCase
-from urlparse import urlparse
 
 from requests import HTTPError
 from requests_mock import ANY, mock as requests_mock


### PR DESCRIPTION
Another small update to add urllib compatibility for python3. If these are incredibly silly, just let me know and I'll merge to my fork and leave you good people to it.