### PR TITLE
Fix 'server error: zone not found' for NS1 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [EtcHostsProvider](/octodns/provider/etc_hosts.py) | | A, AAAA, ALIAS, CNAME | No | |
 | [GoogleCloudProvider](/octodns/provider/googlecloud.py) | google-cloud-dns | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT  | No | |
 | [MythicBeastsProvider](/octodns/provider/mythicbeasts.py) | Mythic Beasts | A, AAAA, ALIAS, CNAME, MX, NS, SRV, SSHFP, CAA, TXT | No | |
-| [Ns1Provider](/octodns/provider/ns1.py) | nsone | All | Partial Geo | No health checking for GeoDNS |
+| [Ns1Provider](/octodns/provider/ns1.py) | ns1-python | All | Partial Geo | No health checking for GeoDNS |
 | [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |
 | [PowerDnsProvider](/octodns/provider/powerdns.py) | | All | No | |
 | [Rackspace](/octodns/provider/rackspace.py) | | A, AAAA, ALIAS, CNAME, MX, NS, PTR, SPF, TXT | No |  |

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -8,8 +8,8 @@ from __future__ import absolute_import, division, print_function, \
 from logging import getLogger
 from itertools import chain
 from collections import OrderedDict, defaultdict
-from nsone import NSONE
-from nsone.rest.errors import RateLimitException, ResourceException
+from ns1 import NS1
+from ns1.rest.errors import RateLimitException, ResourceException
 from incf.countryutils import transformations
 from time import sleep
 
@@ -36,7 +36,7 @@ class Ns1Provider(BaseProvider):
         self.log = getLogger('Ns1Provider[{}]'.format(id))
         self.log.debug('__init__: id=%s, api_key=***', id)
         super(Ns1Provider, self).__init__(id, *args, **kwargs)
-        self._client = NSONE(apiKey=api_key)
+        self._client = NS1(apiKey=api_key)
 
     def _data_for_A(self, _type, record):
         # record meta (which would include geo information is only

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ipaddress==1.0.22
 jmespath==0.9.3
 msrestazure==0.6.0
 natsort==5.5.0
-nsone==0.9.100
+ns1-python==0.12.0
 ovh==0.4.8
 python-dateutil==2.6.1
 requests==2.22.0

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from mock import Mock, call, patch
-from nsone.rest.errors import AuthException, RateLimitException, \
+from ns1.rest.errors import AuthException, RateLimitException, \
     ResourceException
 from unittest import TestCase
 
@@ -171,7 +171,7 @@ class TestNs1Provider(TestCase):
         'domain': 'unit.tests.',
     }]
 
-    @patch('nsone.NSONE.loadZone')
+    @patch('ns1.NS1.loadZone')
     def test_populate(self, load_mock):
         provider = Ns1Provider('test', 'api-key')
 
@@ -290,8 +290,8 @@ class TestNs1Provider(TestCase):
         self.assertEquals(self.expected, zone.records)
         self.assertEquals(('unit.tests',), load_mock.call_args[0])
 
-    @patch('nsone.NSONE.createZone')
-    @patch('nsone.NSONE.loadZone')
+    @patch('ns1.NS1.createZone')
+    @patch('ns1.NS1.loadZone')
     def test_sync(self, load_mock, create_mock):
         provider = Ns1Provider('test', 'api-key')
 


### PR DESCRIPTION
When writing a zone to the NS1 provider, there is the following error message if a zone does not already exist: "ns1.rest.errors.ResourceException: server error: zone not found"
This pull requests migrates from the legacy nsone SDK to the new ns1-python SDK, see README in https://github.com/ns1/nsone-python which fixes this error. 