### PR TITLE
ConstellixProvider: change ALIAS to CNAME to allow record deletion

### DIFF
--- a/octodns/provider/constellix.py
+++ b/octodns/provider/constellix.py
@@ -148,6 +148,10 @@ class ConstellixClient(object):
         self._request('POST', path, data=params)
 
     def record_delete(self, zone_name, record_type, record_id):
+        # change ALIAS records to ANAME
+        if record_type == 'ALIAS':
+            record_type = 'ANAME'
+
         zone_id = self.domains.get(zone_name, False)
         path = '/{}/records/{}/{}'.format(zone_id, record_type, record_id)
         self._request('DELETE', path)

--- a/tests/test_octodns_provider_constellix.py
+++ b/tests/test_octodns_provider_constellix.py
@@ -187,6 +187,14 @@ class TestConstellixProvider(TestCase):
                 'value': [
                     '3.2.3.4'
                 ]
+            },  {
+                'id': 11189899,
+                'type': 'ALIAS',
+                'name': 'alias',
+                'ttl': 600,
+                'value': [{
+                    'value': 'aname.unit.tests.'
+                }]
             }
         ])
 
@@ -201,8 +209,8 @@ class TestConstellixProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(2, len(plan.changes))
-        self.assertEquals(2, provider.apply(plan))
+        self.assertEquals(3, len(plan.changes))
+        self.assertEquals(3, provider.apply(plan))
 
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
@@ -214,5 +222,6 @@ class TestConstellixProvider(TestCase):
                 'ttl': 300
             }),
             call('DELETE', '/123123/records/A/11189897'),
-            call('DELETE', '/123123/records/A/11189898')
+            call('DELETE', '/123123/records/A/11189898'),
+            call('DELETE', '/123123/records/ANAME/11189899')
         ], any_order=True)


### PR DESCRIPTION
Fixes #409 

Constellix does not have a ALIAS type, but has a ANAME type that works the same. During record retrieval and creation we swap the type (ANAME <-> ALIAS) to create provider compatibility. However as Constellix has the record type in the URL, we also need to make sure to swap from ALIAS back to ANAME on deletion.

This adds the conversion to the `record_delete` method on the ConstellixClient to allow this to happen.