### PR TITLE
Refactor Ns1 client out to implement rate limiting once (for everything)

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -31,17 +31,18 @@ class Ns1Client(object):
 
     def _try(self, method, *args, **kwargs):
         tries = self.retry_count
-        while tries:
+        while True:  # We'll raise to break after our tries expire
             try:
                 return method(*args, **kwargs)
             except RateLimitException as e:
+                if tries <= 1:
+                    raise
                 period = float(e.period)
                 self.log.warn('rate limit encountered, pausing '
                               'for %ds and trying again, %d remaining',
                               period, tries)
                 sleep(period)
                 tries -= 1
-        raise
 
     def zones_retrieve(self, name):
         return self._try(self._zones.retrieve, name)


### PR DESCRIPTION
This should get to a DRY implementation of rate limiting that covers all the client methods and supports multiple sleeps and retries (but not infinite) inline with some of the changes in https://github.com/nsone/octodns/pull/4 which was used as the basis/example for this change.

/cc https://github.com/github/octodns/pull/431 which this builds off of.