### PR TITLE
Add CAA record support for OVH provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [GoogleCloudProvider](/octodns/provider/googlecloud.py) | google-cloud-dns | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT  | No | |
 | [MythicBeastsProvider](/octodns/provider/mythicbeasts.py) | Mythic Beasts | A, AAAA, ALIAS, CNAME, MX, NS, SRV, SSHFP, CAA, TXT | No | |
 | [Ns1Provider](/octodns/provider/ns1.py) | ns1-python | All | Yes | No CNAME support, missing `NA` geo target |
-| [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |
+| [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |
 | [PowerDnsProvider](/octodns/provider/powerdns.py) | | All | No | |
 | [Rackspace](/octodns/provider/rackspace.py) | | A, AAAA, ALIAS, CNAME, MX, NS, PTR, SPF, TXT | No |  |
 | [Route53](/octodns/provider/route53.py) | boto3 | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Both | CNAME health checks don't support a Host header |

--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -264,7 +264,8 @@ class OvhProvider(BaseProvider):
     def _params_for_CAA(record):
         for value in record.values:
             yield {
-                'target': '%d %s "%s"' % (value.flags, value.tag, value.value),
+                'target': '{} {} "{}"'.format(value.flags, value.tag,
+                                              value.value),
                 'subDomain': record.name,
                 'ttl': record.ttl,
                 'fieldType': record._type

--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -40,8 +40,8 @@ class OvhProvider(BaseProvider):
 
     # This variable is also used in populate method to filter which OVH record
     # types are supported by octodns
-    SUPPORTS = set(('A', 'AAAA', 'CNAME', 'DKIM', 'MX', 'NAPTR', 'NS', 'PTR',
-                    'SPF', 'SRV', 'SSHFP', 'TXT'))
+    SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'DKIM', 'MX', 'NAPTR', 'NS',
+                    'PTR', 'SPF', 'SRV', 'SSHFP', 'TXT'))
 
     def __init__(self, id, endpoint, application_key, application_secret,
                  consumer_key, *args, **kwargs):
@@ -137,6 +137,22 @@ class OvhProvider(BaseProvider):
             'ttl': record['ttl'],
             'type': _type,
             'value': record['target']
+        }
+
+    @staticmethod
+    def _data_for_CAA(_type, records):
+        values = []
+        for record in records:
+            flags, tag, value = record['target'].split(' ', 2)
+            values.append({
+                'flags': flags,
+                'tag': tag,
+                'value': value[1:-1]
+            })
+        return {
+            'ttl': records[0]['ttl'],
+            'type': _type,
+            'values': values
         }
 
     @staticmethod
@@ -243,6 +259,16 @@ class OvhProvider(BaseProvider):
             'ttl': record.ttl,
             'fieldType': record._type
         }
+
+    @staticmethod
+    def _params_for_CAA(record):
+        for value in record.values:
+            yield {
+                'target': '%d %s "%s"' % (value.flags, value.tag, value.value),
+                'subDomain': record.name,
+                'ttl': record.ttl,
+                'fieldType': record._type
+            }
 
     @staticmethod
     def _params_for_MX(record):

--- a/tests/test_octodns_provider_ovh.py
+++ b/tests/test_octodns_provider_ovh.py
@@ -279,6 +279,24 @@ class TestOvhProvider(TestCase):
         'id': 18
     })
 
+    # CAA
+    api_record.append({
+        'fieldType': 'CAA',
+        'ttl': 1600,
+        'target': '0 issue "ca.unit.tests"',
+        'subDomain': 'caa',
+        'id': 19
+    })
+    expected.add(Record.new(zone, 'caa', {
+        'ttl': 1600,
+        'type': 'CAA',
+        'values': [{
+            'flags': 0,
+            'tag': 'issue',
+            'value': 'ca.unit.tests'
+        }]
+    }))
+
     valid_dkim = [valid_dkim_key,
                   'v=DKIM1 \\; %s' % valid_dkim_key,
                   'h=sha256 \\; %s' % valid_dkim_key,
@@ -404,6 +422,9 @@ class TestOvhProvider(TestCase):
                     call('/domain/zone/unit.tests/record', fieldType='SRV',
                          subDomain='_srv._tcp',
                          target='40 50 60 foo-2.unit.tests.', ttl=800),
+                    call('/domain/zone/unit.tests/record', fieldType='CAA',
+                         subDomain='caa', target='0 issue "ca.unit.tests"',
+                         ttl=1600),
                     call('/domain/zone/unit.tests/record', fieldType='DKIM',
                          subDomain='dkim',
                          target='p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCxLaG'


### PR DESCRIPTION
Implementation is inspired from octodns' other providers commits.