### PR TITLE
Support DNSimple sandbox

### DIFF
--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -30,13 +30,16 @@ class DnsimpleClientUnauthorized(DnsimpleClientException):
 
 
 class DnsimpleClient(object):
-    BASE = 'https://api.dnsimple.com/v2/'
 
-    def __init__(self, token, account):
+    def __init__(self, token, account, sandbox):
         self.account = account
         sess = Session()
         sess.headers.update({'Authorization': 'Bearer {}'.format(token)})
         self._sess = sess
+        if sandbox:
+            self.BASE = 'https://api.sandbox.dnsimple.com/v2/'
+        else:
+            self.BASE = 'https://api.dnsimple.com/v2/'
 
     def _request(self, method, path, params=None, data=None):
         url = '{}{}{}'.format(self.BASE, self.account, path)
@@ -89,17 +92,19 @@ class DnsimpleProvider(BaseProvider):
         token: letmein
         # Your account number (required)
         account: 42
+        # Use sandbox (optional)
+        sandbox: true
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
                     'PTR', 'SPF', 'SRV', 'SSHFP', 'TXT'))
 
-    def __init__(self, id, token, account, *args, **kwargs):
+    def __init__(self, id, token, account, sandbox=False, *args, **kwargs):
         self.log = logging.getLogger('DnsimpleProvider[{}]'.format(id))
         self.log.debug('__init__: id=%s, token=***, account=%s', id, account)
         super(DnsimpleProvider, self).__init__(id, *args, **kwargs)
-        self._client = DnsimpleClient(token, account)
+        self._client = DnsimpleClient(token, account, sandbox)
 
         self._zone_records = {}
 

--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -37,12 +37,12 @@ class DnsimpleClient(object):
         sess.headers.update({'Authorization': 'Bearer {}'.format(token)})
         self._sess = sess
         if sandbox:
-            self.BASE = 'https://api.sandbox.dnsimple.com/v2/'
+            self.base = 'https://api.sandbox.dnsimple.com/v2/'
         else:
-            self.BASE = 'https://api.dnsimple.com/v2/'
+            self.base = 'https://api.dnsimple.com/v2/'
 
     def _request(self, method, path, params=None, data=None):
-        url = '{}{}{}'.format(self.BASE, self.account, path)
+        url = '{}{}{}'.format(self.base, self.account, path)
         resp = self._sess.request(method, url, params=params, json=data)
         if resp.status_code == 401:
             raise DnsimpleClientUnauthorized()

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -38,6 +38,10 @@ class TestDnsimpleProvider(TestCase):
             break
 
     def test_populate(self):
+
+        # Sandbox
+        provider = DnsimpleProvider('test', 'token', 42, 'true')
+
         provider = DnsimpleProvider('test', 'token', 42)
 
         # Bad auth

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -44,6 +44,7 @@ class TestDnsimpleProvider(TestCase):
         self.assertTrue('sandbox' in provider._client.base)
 
         provider = DnsimpleProvider('test', 'token', 42)
+        self.assertFalse('sandbox' in provider._client.base)
 
         # Bad auth
         with requests_mock() as mock:

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -41,6 +41,7 @@ class TestDnsimpleProvider(TestCase):
 
         # Sandbox
         provider = DnsimpleProvider('test', 'token', 42, 'true')
+        self.assertTrue('sandbox' in provider._client.base)
 
         provider = DnsimpleProvider('test', 'token', 42)
 


### PR DESCRIPTION
An optional parameter 'sandbox' can be used to select the base URL
for the Sandbox API (see https://developer.dnsimple.com/sandbox ).