### PR TITLE
NS1 provider: support rate-limiting strategy

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -205,6 +205,9 @@ class Ns1Provider(BaseProvider):
     ns1:
         class: octodns.provider.ns1.Ns1Provider
         api_key: env/NS1_API_KEY
+        # Optional, to avoid 429s from rate-limiting. Try setting to the
+        # value of max_workers.
+        parallelism: 11
         # Only required if using dynamic records
         monitor_regions:
           - lga

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -1394,21 +1394,28 @@ class TestNs1Client(TestCase):
 
     def test_client_config(self):
         with self.assertRaises(TypeError):
-            client = Ns1Client()
+            Ns1Client()
 
         client = Ns1Client('dummy-key')
         self.assertEquals(
-            client._config.get('keys'),
-            {'default': {'key': u'dummy-key', 'desc': 'imported API key'}}
-        )
-        self.assertEquals(client._config.get('rate_limit_strategy'), None)
-        self.assertEquals(client._config.get('parallelism'), None)
+            client._client.config.get('keys'),
+            {'default': {'key': u'dummy-key', 'desc': 'imported API key'}})
+        self.assertEquals(client._client.config.get('follow_pagination'), True)
+        self.assertEquals(
+            client._client.config.get('rate_limit_strategy'), None)
+        self.assertEquals(client._client.config.get('parallelism'), None)
 
         client = Ns1Client('dummy-key', parallelism=11)
         self.assertEquals(
-            client._config.get('rate_limit_strategy'), 'concurrent'
-        )
-        self.assertEquals(client._config.get('parallelism'), 11)
+            client._client.config.get('rate_limit_strategy'), 'concurrent')
+        self.assertEquals(client._client.config.get('parallelism'), 11)
+
+        client = Ns1Client('dummy-key', client_config={
+            'endpoint': 'my.endpoint.com', 'follow_pagination': False})
+        self.assertEquals(
+            client._client.config.get('endpoint'), 'my.endpoint.com')
+        self.assertEquals(
+            client._client.config.get('follow_pagination'), False)
 
     @patch('ns1.rest.data.Source.list')
     @patch('ns1.rest.data.Source.create')

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -1392,6 +1392,24 @@ class TestNs1Client(TestCase):
             client.zones_retrieve('unit.tests')
         self.assertEquals('last', text_type(ctx.exception))
 
+    def test_client_config(self):
+        with self.assertRaises(TypeError):
+            client = Ns1Client()
+
+        client = Ns1Client('dummy-key')
+        self.assertEquals(
+            client._config.get('keys'),
+            {'default': {'key': u'dummy-key', 'desc': 'imported API key'}}
+        )
+        self.assertEquals(client._config.get('rate_limit_strategy'), None)
+        self.assertEquals(client._config.get('parallelism'), None)
+
+        client = Ns1Client('dummy-key', parallelism=11)
+        self.assertEquals(
+            client._config.get('rate_limit_strategy'), 'concurrent'
+        )
+        self.assertEquals(client._config.get('parallelism'), 11)
+
     @patch('ns1.rest.data.Source.list')
     @patch('ns1.rest.data.Source.create')
     def test_datasource_id(self, datasource_create_mock, datasource_list_mock):


### PR DESCRIPTION
Adds a "parallelism" argument to the NS1 Provider. If set, we analyze
response headers and attempt to avoid 429 responses.