### PR TITLE
Transip v2.1.1, back out test skips and coverage omits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ requests==2.23.0
 s3transfer==0.3.3
 setuptools==44.0.0
 six==1.14.0
-transip==2.0.0
+transip==2.1.1

--- a/script/coverage
+++ b/script/coverage
@@ -26,10 +26,7 @@ export DYN_PASSWORD=
 export DYN_USERNAME=
 export GOOGLE_APPLICATION_CREDENTIALS=
 
-
-OMIT_PATHS="octodns/cmds/*,octodns/provider/transip*.py" # FIXME Transip tests are failing. Omitting them until they are fixed
-
-coverage run --branch --source=octodns --omit=${OMIT_PATHS} "$(command -v nosetests)" --with-xunit "$@"
+coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v nosetests)" --with-xunit "$@"
 coverage html
 coverage xml
 coverage report --show-missing

--- a/tests/test_octodns_provider_transip.py
+++ b/tests/test_octodns_provider_transip.py
@@ -11,7 +11,6 @@ from six import text_type
 from suds import WebFault
 
 from unittest import TestCase
-from unittest import skip
 
 from octodns.provider.transip import TransipProvider
 from octodns.provider.yaml import YamlProvider
@@ -98,9 +97,7 @@ class MockDomainService(DomainService):
         document = {}
         raise WebFault(fault, document)
 
-# FIXME Skipping broken tests for now. Revert this once they are found to
-# be working again
-@skip("Skipping broken transip tests")
+
 class TestTransipProvider(TestCase):
 
     bogus_key = str("""-----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION


/cc https://github.com/github/octodns/pull/513 which this reverses
/cc Fixes https://github.com/github/octodns/issues/512