### PR TITLE
dynamic validation tweak, allow reuse of pool if 2nd occur is a default

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -590,6 +590,11 @@ class _DynamicMixin(object):
                     reasons.append('rule {} missing pool'.format(rule_num))
                     continue
 
+                try:
+                    geos = rule['geos']
+                except KeyError:
+                    geos = []
+
                 if not isinstance(pool, string_types):
                     reasons.append('rule {} invalid pool "{}"'
                                    .format(rule_num, pool))
@@ -598,15 +603,12 @@ class _DynamicMixin(object):
                         reasons.append('rule {} undefined pool "{}"'
                                        .format(rule_num, pool))
                         pools_seen.add(pool)
-                    elif pool in pools_seen:
+                    elif pool in pools_seen and geos:
                         reasons.append('rule {} invalid, target pool "{}" '
                                        'reused'.format(rule_num, pool))
                     pools_seen.add(pool)
 
-                try:
-                    geos = rule['geos']
-                except KeyError:
-                    geos = []
+                if not geos:
                     if seen_default:
                         reasons.append('rule {} duplicate default'
                                        .format(rule_num))

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -3417,6 +3417,7 @@ class TestDynamicRecords(TestCase):
                     'geos': ['AF'],
                     'pool': 'one',
                 }, {
+                    'geos': ['OC'],
                     'pool': 'one',
                 }],
             },
@@ -3431,6 +3432,43 @@ class TestDynamicRecords(TestCase):
             Record.new(self.zone, 'bad', a_data)
         self.assertEquals(['rule 3 invalid, target pool "one" reused'],
                           ctx.exception.reasons)
+
+        # Repeated pool is OK if later one is a default
+        a_data = {
+            'dynamic': {
+                'pools': {
+                    'one': {
+                        'values': [{
+                            'value': '3.3.3.3',
+                        }]
+                    },
+                    'two': {
+                        'values': [{
+                            'value': '4.4.4.4',
+                        }, {
+                            'value': '5.5.5.5',
+                        }]
+                    },
+                },
+                'rules': [{
+                    'geos': ['EU-GB'],
+                    'pool': 'one',
+                }, {
+                    'geos': ['EU'],
+                    'pool': 'two',
+                }, {
+                    'pool': 'one',
+                }],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': [
+                '1.1.1.1',
+                '2.2.2.2',
+            ],
+        }
+        # This should be valid, no exception
+        Record.new(self.zone, 'bad', a_data)
 
     def test_dynamic_lenient(self):
         # Missing pools


### PR DESCRIPTION
Need to allow reuse of a single pool when it's used once with rules and later as a default, e.g. 

```python
                'rules': [{
                    'geos': ['EU-GB'],
                    'pool': 'one',
                }, {
                    'geos': ['EU'],
                    'pool': 'two',
                }, {
                    'pool': 'one',
                }],
```

This is necessary when you want to pull some of a larger region out and send it to a default. All other cases should still be achievable with a single (merged) set of geos afaik. 