### PR TITLE
Order each batch of Route53 changesets so that delets come before create

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -1395,6 +1395,8 @@ class Route53Provider(BaseProvider):
         self._really_apply(batch, zone_id)
 
     def _really_apply(self, batch, zone_id):
+        # Ensure this batch is ordered (deletes before creates etc.)
+        batch.sort(key=_mod_keyer)
         uuid = uuid4().hex
         batch = {
             'Comment': 'Change: {}'.format(uuid),


### PR DESCRIPTION
This PR fixes the issue with converting CNAMEs to A records reported over in https://github.com/github/octodns/issues/507 and hit a few times now. There's likely a number of situations that can get there.

I'd call this a quick-fix. It just ensures that all of the records within a batch of modications are ordered in a way that Route53 will be OK with. It's still possible for really unlikely edge cases to come up that this wouldn't solve (e.g. if there's a ton of changes and the create landed in the first batch and the delete was going to be in a latter one. 

I have a todo list item for myself to revisit the whole batching process. It's grown and gotten more complicated involved over time as we've handled more of these issues. I think ideally we'd build up the complete list of mods for all changes, order that in one go, and then batch that up if needed.

Note that batching itself isn't great since each one will (maybe) happen atomically within Route53, but changes that span batches won't be made atomically and can have multiple seconds in between them. That's not great, but there's nothing we can do about it. At least Route53 has batch (maybe atomic) support at all. It's essentially the only provider that does. Every other provider does 1 record at a time...

/cc Fixes https://github.com/github/octodns/issues/507
/cc @danhanks @brianeclow @yzguy @thepwagner @brrygrdn  fyi