### PR TITLE
Support reuse of default pool in rules in Ns1Provider

### DIFF
--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -553,6 +553,11 @@ class TestNs1ProviderDynamic(TestCase):
                 ],
                 'pool': 'lhr',
             }, {
+                'geos': [
+                    'AF-ZW',
+                ],
+                'pool': 'iad',
+            }, {
                 'pool': 'iad',
             }],
         },
@@ -961,13 +966,17 @@ class TestNs1ProviderDynamic(TestCase):
         ]
 
         rule0 = self.record.data['dynamic']['rules'][0]
-        saved_geos = rule0['geos']
+        rule1 = self.record.data['dynamic']['rules'][1]
+        rule0_saved_geos = rule0['geos']
+        rule1_saved_geos = rule1['geos']
         rule0['geos'] = ['AF', 'EU']
+        rule1['geos'] = ['NA']
         ret, _ = provider._params_for_A(self.record)
         self.assertEquals(ret['filters'],
                           Ns1Provider._FILTER_CHAIN_WITH_REGION(provider,
                                                                 True))
-        rule0['geos'] = saved_geos
+        rule0['geos'] = rule0_saved_geos
+        rule1['geos'] = rule1_saved_geos
 
     @patch('octodns.provider.ns1.Ns1Provider._monitor_sync')
     @patch('octodns.provider.ns1.Ns1Provider._monitors_for')
@@ -1123,6 +1132,21 @@ class TestNs1ProviderDynamic(TestCase):
                     'note': 'from:--default--',
                 },
                 'region': 'iad',
+            }, {
+                'answer': ['2.3.4.5'],
+                'meta': {
+                    'priority': 1,
+                    'weight': 12,
+                    'note': 'from:iad_shadow',
+                },
+                'region': 'iad_shadow',
+            }, {
+                'answer': ['1.2.3.4'],
+                'meta': {
+                    'priority': 2,
+                    'note': 'from:--default--',
+                },
+                'region': 'iad_shadow',
             }],
             'domain': 'unit.tests',
             'filters': filters,
@@ -1135,9 +1159,15 @@ class TestNs1ProviderDynamic(TestCase):
                         'us_state': ['OR'],
                     },
                 },
-                'iad': {
+                'iad_shadow': {
                     'meta': {
                         'note': 'rule-order:2',
+                        'country': ['ZW'],
+                    },
+                },
+                'iad': {
+                    'meta': {
+                        'note': 'rule-order:3',
                     },
                 }
             },
@@ -1173,6 +1203,12 @@ class TestNs1ProviderDynamic(TestCase):
                     'pool': 'lhr',
                 }, {
                     '_order': '2',
+                    'geos': [
+                        'AF-ZW',
+                    ],
+                    'pool': 'iad',
+                }, {
+                    '_order': '3',
                     'pool': 'iad',
                 }],
             },

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -528,7 +528,7 @@ class TestNs1Provider(TestCase):
 class TestNs1ProviderDynamic(TestCase):
     zone = Zone('unit.tests.', [])
 
-    record = Record.new(zone, '', {
+    record_data = {
         'dynamic': {
             'pools': {
                 'lhr': {
@@ -573,7 +573,8 @@ class TestNs1ProviderDynamic(TestCase):
         'type': 'A',
         'value': '1.2.3.4',
         'meta': {},
-    })
+    }
+    record = Record.new(zone, '', record_data)
 
     def test_notes(self):
         provider = Ns1Provider('test', 'api-key')
@@ -978,6 +979,34 @@ class TestNs1ProviderDynamic(TestCase):
         rule0['geos'] = rule0_saved_geos
         rule1['geos'] = rule1_saved_geos
 
+        # Test record with no reuse of the catchall
+        monitors_for_mock.reset_mock()
+        monitor_sync_mock.reset_mock()
+        monitors_for_mock.side_effect = [{
+            '3.4.5.6': 'mid-3',
+        }]
+        monitor_sync_mock.side_effect = [
+            ('mid-1', 'fid-1'),
+            ('mid-2', 'fid-2'),
+            ('mid-3', 'fid-3'),
+        ]
+        # Modify the record data before creating the Record object
+        rule0 = self.record_data['dynamic']['rules'][0]
+        rule0_saved_geos = rule0['geos']
+        rule0['geos'] = ['AF', 'EU']
+        rule1 = self.record_data['dynamic']['rules'].pop(1)
+
+        # Create a local record object without reuse of catchall
+        zone = Zone('unit.tests.', [])
+        record = Record.new(zone, '', self.record_data)
+        ret, _ = provider._params_for_A(record)
+        self.assertEquals(ret['filters'],
+                          Ns1Provider._FILTER_CHAIN_WITH_REGION(provider,
+                                                                True))
+        # Restore record_data
+        rule0['geos'] = rule0_saved_geos
+        self.record_data['dynamic']['rules'].insert(1, rule1)
+
     @patch('octodns.provider.ns1.Ns1Provider._monitor_sync')
     @patch('octodns.provider.ns1.Ns1Provider._monitors_for')
     def test_params_for_dynamic_oceania(self, monitors_for_mock,
@@ -1137,16 +1166,16 @@ class TestNs1ProviderDynamic(TestCase):
                 'meta': {
                     'priority': 1,
                     'weight': 12,
-                    'note': 'from:iad_shadow',
+                    'note': 'from:catchall_iad',
                 },
-                'region': 'iad_shadow',
+                'region': 'catchall_iad',
             }, {
                 'answer': ['1.2.3.4'],
                 'meta': {
                     'priority': 2,
                     'note': 'from:--default--',
                 },
-                'region': 'iad_shadow',
+                'region': 'catchall_iad',
             }],
             'domain': 'unit.tests',
             'filters': filters,
@@ -1159,13 +1188,13 @@ class TestNs1ProviderDynamic(TestCase):
                         'us_state': ['OR'],
                     },
                 },
-                'iad_shadow': {
+                'iad': {
                     'meta': {
                         'note': 'rule-order:2',
                         'country': ['ZW'],
                     },
                 },
-                'iad': {
+                'catchall_iad': {
                     'meta': {
                         'note': 'rule-order:3',
                     },


### PR DESCRIPTION
The NS1 provider does not handle reuse of pool names in the rules well. Reuse of pool names is in-general disallowed in the OctoDNS config but for one exception. It is allowed when one of the rules uses the default pool. For an example/rationale for this exception, see https://github.com/github/octodns/pull/530#issue-397730162

/cc #530 
/cc @ross 
