### PR TITLE
v0.9.10 version bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
-## v0.9.10 - ????-??-?? - ???
+## v0.9.10 - 2020-04-20 - Dynamic NS1 and lots of misc
 
 * Added support for dynamic records to Ns1Provider, updated client and rate
   limiting implementation
 * Moved CI to use GitHub Actions
 * Set up dependabot to automatically PR requirements updates
-* Pass at bumping all of the requirements
+* Pass at bumping all of the requirements and Dependabot them going forward
+* Enhanced `dynamic` pool validation rules
+* Delegation set support for Route53 and fix for CNAME/A ordering issues
+* DNSimple sandbox support
+* OVHProvider support for CAA
+* Akamai rename FastDNS to EdgeDNS
+* Transip bumped to 2.1.2 which should get away from its SOAP api which is EOLd
 
 ## v0.9.9 - 2019-11-04 - Python 3.7 Support
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.9'
+__VERSION__ = '0.9.10'


### PR DESCRIPTION
## v0.9.10 - 2020-04-20 - Dynamic NS1 and lots of misc

* Added support for dynamic records to Ns1Provider, updated client and rate
  limiting implementation
* Moved CI to use GitHub Actions
* Set up dependabot to automatically PR requirements updates
* Pass at bumping all of the requirements and Dependabot them going forward
* Enhanced `dynamic` pool validation rules
* Delegation set support for Route53 and fix for CNAME/A ordering issues
* DNSimple sandbox support
* OVHProvider support for CAA
* Akamai rename FastDNS to EdgeDNS
* Transip bumped to 2.1.2 which should get away from its SOAP api which is EOLd

