### PR TITLE
Add Lexicon provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [DynProvider](/octodns/provider/dyn.py) | dyn | All | Both | |
 | [EtcHostsProvider](/octodns/provider/etc_hosts.py) | | A, AAAA, ALIAS, CNAME | No | |
 | [GoogleCloudProvider](/octodns/provider/googlecloud.py) | google-cloud-dns | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT  | No | |
+| [LexiconProvider](/octodns/provider/lexicon.py) | lexicon | Depends on [Lexicon](https://github.com/AnalogJ/lexicon) module  | No | |
 | [MythicBeastsProvider](/octodns/provider/mythicbeasts.py) | Mythic Beasts | A, AAAA, ALIAS, CNAME, MX, NS, SRV, SSHFP, CAA, TXT | No | |
 | [Ns1Provider](/octodns/provider/ns1.py) | ns1-python | All | Yes | No CNAME support, missing `NA` geo target |
 | [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |

--- a/octodns/provider/lexicon.py
+++ b/octodns/provider/lexicon.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, \
 
 import logging
 import shlex
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 
 from lexicon.client import Client as LexiconClient
 from lexicon.config import ConfigResolver as LexiconConfigResolver, \
@@ -22,6 +22,10 @@ class LexiconProvider(BaseProvider):
 
     lexicon:
         class: octodns.provider.lexicon.LexiconProvicer
+
+        raise_on_unknown: if True, raise RuntimeError on unhandled record
+                        types (default false)
+
         lexicon_config: lexicon config
 
     Configuration added to the lexicon_config block will be injected as a
@@ -30,29 +34,44 @@ class LexiconProvider(BaseProvider):
 
     Example:
 
+        provider:
           gandi:
             class: octodns.provider.lexicon.LexiconProvider
             lexicon_config:
-                provider_name: gandi
-                domain: blodapels.in
-                gandi:
-                    auth_token: "better stored in environment variable"
-                    api_protocol: rest
+              provider_name: gandi
+              domain: blodapels.in
+              gandi:
+                auth_token: "better kept in environment variable"
+                api_protocol: rest
+
+          namecheap:
+            class: octodns.provider.lexicon.LexiconProvider
+            lexicon_config:
+              provider_name: namecheap
+              domain: example.com
+              namecheap:
+                auth_sandbox: True
+                auth_username: foobar
+                auth_client_ip: 127.0.0.1
+                auth_token: "better kept in environment variable"
 
     """
-    SUPPORTS = {'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR',
-                'SPF', 'SRV', 'TXT'}
+    SUPPORTS = {'A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
+                'PTR', 'SPF', 'SRV', 'SSHFP', 'TXT'}
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
 
-    def __init__(self, id, lexicon_config, **kwargs):
+    def __init__(self, id, lexicon_config, raise_on_unhandled=False, **kwargs):
 
         self.log = logging.getLogger('LexiconProvider[{}]'.format(id))
         super(LexiconProvider, self).__init__(id, **kwargs)
 
         self.log.info('__init__: id=%s, token=***, account=%s', id, kwargs)
 
+        self.remembered_ids = RememberedIds()
+
+        self.raise_on_unhandled = raise_on_unhandled
         config = LexiconConfigResolver()
         self.dynamic_config = OnTheFlyLexiconConfigSource()
 
@@ -78,23 +97,58 @@ class LexiconProvider(BaseProvider):
             # No way of knowing for sure whether a zone exists or not,
             # But if it has contents, it is safe to assume that it does.
             exists = True
-            loaded_types[lexicon_record["id"]][lexicon_record["type"]] \
+            self.log.debug("provider listed {!s}".format(lexicon_record))
+
+            loaded_types[lexicon_record["name"]][lexicon_record["type"]] \
                 .append(lexicon_record)
 
-        for record_id, data_by_id in loaded_types.items():
+        for record_by_name, data_by_id in loaded_types.items():
             for record_type, lexicon_records in data_by_id.items():
                 self.log.debug("Got {!s} from above".format(lexicon_records))
 
-                _data_func = getattr(self, '_data_for_{}'.format(record_type))
+                if record_type in self.SUPPORTS:
 
-                data = _data_func(record_type, lexicon_records)
+                    _data_func = getattr(self,
+                                         '_data_for_{}'.format(record_type))
 
-                self.log.debug('populate: adding record {} records: {!s}'
-                               .format(record_id, data))
+                    data = _data_func(record_type, lexicon_records)
 
-                record = Record.new(zone, record_id, data, source=self)
+                    self.log.debug('populate: adding record {} records: {!s}'
+                                   .format(record_by_name, data))
 
-                zone.add_record(record, lenient=lenient)
+                    #         # strip trailing period from fqdn if present
+                    #         record_name = record_name.rstrip('.')
+                    if record_by_name.endswith(zone.name[:-1]):
+                        record_name = record_by_name[:-(len(zone.name))]
+                    else:
+                        record_name = record_by_name
+
+                    record = Record.new(zone, record_name, data, source=self)
+
+                    # Some lexicon operations, specifically 'update',
+                    # requires the 'identifier' to be used.
+                    # Since that information is in the 'id' key, we save it
+                    # in a dict from which it can be retrieved when applying
+                    #
+                    # Furthermore, where octodns saves multi value records as
+                    # single record, lexicon has one record for each value.
+                    # Therefore, the extra 'content' level is needed here, so
+                    # that correct ID for correct record might be retrieved.
+                    for lexicon_record in lexicon_records:
+                        self.remembered_ids.remember(record,
+                                                     lexicon_record['content'],
+                                                     lexicon_record['id'])
+
+                    zone.add_record(record, lenient=lenient)
+
+                else:
+                    err_str = 'encountered unhandled record type: ' \
+                              '"{}" Payload was "{!s}"'.format(record_type,
+                                                               lexicon_records)
+                    self.log.warning(err_str)
+
+                    if self.raise_on_unhandled:
+                        raise RuntimeError(err_str)
 
         self.log.info('populate:   found %s records, exists=%s',
                       len(zone.records) - before, before < len(zone.records))
@@ -114,68 +168,96 @@ class LexiconProvider(BaseProvider):
 
         self.log.debug('_apply: zone=%s, len(changes)=%d', desired.name,
                        len(changes))
-
         self.lexicon_client.provider.authenticate()
 
         for change in changes:
-            action = change.__class__.__name__
             _rrset_func = getattr(
                 self, '_rrset_for_{}'.format(change.record._type))
 
-            record_type = change.record._type
-            contents = _rrset_func(change.record)
-            identifier = change.record.fqdn
-            name = change.record.fqdn
-
+            # Only way to update TTL is to hope that the provider shall read
+            # this one for all operations
             self.dynamic_config.set_ttl(change.record.ttl)
 
-            # a single record might have multiple values, but lexicon seems to
-            # handle them one at a time, thus an A record with two rrsets will
-            # have to be handled like two separate "actions"
-            if action == 'Create':
-                for content in contents:
+            old_vars = _rrset_func(change.existing) \
+                if change.existing else set()
+            new_vars = _rrset_func(change.new) \
+                if change.new else set()
+
+            additions = new_vars - old_vars
+            deletions = old_vars - new_vars
+
+            additions_iter = iter(sorted(additions))
+            deletions_iter = iter(sorted(deletions))
+
+            for i in range(0, min(len(additions), len(deletions))):
+                new_record = next(additions_iter)
+                old_record = next(deletions_iter)
+                identifier = self.remembered_ids.get(change.existing,
+                                                     old_record.content)
+
+                if identifier and self.remembered_ids.has_unique_ids(
+                        change.existing):
+
+                    self.log.info('client update [id:{}] {!s}'.format(
+                        identifier, new_record))
+                    self.lexicon_client.provider.update_record(
+                        identifier=identifier, **new_record.func_args())
+
+                else:
+                    self.log.info(
+                        'client create_record {!s}'.format(new_record))
                     self.lexicon_client.provider.create_record(
-                        record_type, name, content)
+                        **new_record.func_args())
 
-            elif action == 'Update':
+                    self.log.info('client delete_record {!s}'.format(
+                        old_record))
+                    self.lexicon_client.provider.delete_record(
+                        **old_record.func_args())
 
-                # Some providers, such like the powerdns lexicon provider,
-                # handle updates like so:
-                #
-                #         self._delete_record(identifier)
-                #         return self._create_record(rtype, name, content)
-                #
-                # Therefore, for multiple additions to a particular record,
-                # what seems to be the safest way, is to call update once, and
-                # then do "create", because from what I can see in the
-                # providers, create does not seem to delete old records.
+            for new_record in additions_iter:
+                self.log.info('client create_record {!s}'.format(new_record))
+                self.lexicon_client.provider.create_record(
+                    **new_record.func_args())
 
-                content_iterator = iter(contents)
+            for old_record in deletions_iter:
+                self.log.info('client delete_record {!s}'.format(old_record))
+                identifier = self.remembered_ids.get(change.existing,
+                                                     old_record.content)
 
-                self.lexicon_client.provider \
-                    .update_record(identifier, record_type,
-                                   name, next(content_iterator))
+                self.lexicon_client.provider.delete_record(
+                    identifier=identifier, **old_record.func_args())
 
-                for content in content_iterator:
-                    self.lexicon_client.provider \
-                        .create_record(record_type, name, content)
-
-            elif action == 'Delete':
-                self.lexicon_client.provider \
-                    .delete_record(identifier, record_type, name, None)
-
-            else:
-                raise RuntimeError(
-                    "Unknown action {} for {!s}".format(action, change))
-
-    def _data_for_multiple(self, type, lexicon_records):
+    def _data_for_multiple(self, _type, lexicon_records):
         return {
             'ttl': lexicon_records[0]['ttl'],
-            'type': type,
+            'type': _type,
             'values': [r['content'] for r in lexicon_records]
         }
 
-    def _data_for_MX(self, type, lexicon_records):
+    def _data_for_CAA(self, _type, lexicon_records):
+        values = []
+        for record in lexicon_records:
+            flags, tag, value = shlex.split(record["content"])
+            values.append({
+                'flags': flags,
+                'tag': tag,
+                'value': value
+            })
+        return {
+            'ttl': lexicon_records[0]['ttl'],
+            'type': _type,
+            'values': values
+        }
+
+    def _data_for_CNAME(self, _type, lexicon_records):
+        record = lexicon_records[0]
+        return {
+            'ttl': record['ttl'],
+            'type': _type,
+            'value': record['content']
+        }
+
+    def _data_for_MX(self, _type, lexicon_records):
         values = []
         for record in lexicon_records:
             priority, exchange = shlex.split(record["content"])
@@ -183,19 +265,11 @@ class LexiconProvider(BaseProvider):
 
         return {
             'ttl': lexicon_records[0]['ttl'],
-            'type': type,
+            'type': _type,
             'values': values
         }
 
-    def _data_for_CNAME(self, type, lexicon_records):
-        record = lexicon_records[0]
-        return {
-            'ttl': record['ttl'],
-            'type': type,
-            'value': record['content']
-        }
-
-    def _data_for_SRV(self, type, lexicon_records):
+    def _data_for_SRV(self, _type, lexicon_records):
         values = []
         for record in lexicon_records:
             priority, weight, port, target = shlex.split(record['content'])
@@ -207,37 +281,111 @@ class LexiconProvider(BaseProvider):
                 'target': target
             })
         return {
-            'type': type,
+            'type': _type,
             'ttl': lexicon_records[0]['ttl'],
             'values': values
         }
 
+    _data_for_A = _data_for_multiple
+
+    _data_for_AAAA = _data_for_multiple
+
     _data_for_ALIAS = _data_for_CNAME
 
-    _data_for_A = _data_for_multiple
+    _data_for_NS = _data_for_multiple
 
     _data_for_TXT = _data_for_multiple
 
     def _rrset_for_multiple(self, octodns_record):
-        return [content for content in octodns_record.values]
+        return {LexiconRecord(content=c,
+                              ttl=octodns_record.ttl,
+                              rtype=octodns_record._type,
+                              name=octodns_record.fqdn) for
+                c in octodns_record.values}
 
-    def _rrset_for_MX(self, octodns_record):
-        return ['{} {}'.format(c.preference, c.exchange)
-                for c in octodns_record.values]
+    def _rrset_for_CAA(self, octodns_record):
+        return {LexiconRecord(
+            content='{} {} "{}"'.format(c.flags, c.tag, c.value),
+            ttl=octodns_record.ttl,
+            rtype=octodns_record._type,
+            name=octodns_record.fqdn)
+            for c in octodns_record.values}
 
     def _rrset_for_CNAME(self, octodns_record):
-        return [octodns_record.value]
+        return {LexiconRecord(content=octodns_record.value,
+                              ttl=octodns_record.ttl,
+                              rtype=octodns_record._type,
+                              name=octodns_record.fqdn)}
+
+    def _rrset_for_MX(self, octodns_record):
+        return {LexiconRecord(content='{} {}'.format(c.preference, c.exchange),
+                              ttl=octodns_record.ttl,
+                              rtype=octodns_record._type,
+                              name=octodns_record.fqdn)
+                for c in octodns_record.values}
 
     def _rrset_for_SRV(self, octodns_record):
-        return ['{} {} {} {}'.format(
-            c.priority, c.weight, c.port, c.target)
-            for c in octodns_record.values]
-
-    _rrset_for_ALIAS = _rrset_for_CNAME
+        return {LexiconRecord(
+            content='{} {} {} {}'.format(
+                c.priority, c.weight, c.port, c.target),
+            ttl=octodns_record.ttl,
+            rtype=octodns_record._type,
+            name=octodns_record.fqdn)
+            for c in octodns_record.values}
 
     _rrset_for_A = _rrset_for_multiple
 
+    _rrset_for_AAAA = _rrset_for_multiple
+
+    _rrset_for_ALIAS = _rrset_for_CNAME
+
+    _rrset_for_NS = _rrset_for_multiple
+
     _rrset_for_TXT = _rrset_for_multiple
+
+
+class RememberedIds:
+
+    def __init__(self):
+        self.id_by_record_and_value = defaultdict(dict)
+        self.all_ids_for_record = defaultdict(list)
+
+    def remember(self, record, content, _id):
+        self.id_by_record_and_value[record][content] = _id
+        self.all_ids_for_record[record].append(_id)
+
+    def has_unique_ids(self, record):
+        # We *want* to use update op when ever possible, because it is
+        # safer in the sense that some implementations do perform an update
+        # and not a del + add (and what of the time inbetween del and add,
+        # and what if it crashes after successfully removing a record,
+        # and so forth.
+        #
+        # However, some providers do not seem to take multi value records
+        # into account. Gandi provider for example, derives its id from
+        # the records name field, and so to perform an update, it is
+        # unclear which of the existing records such an operation would
+        # replace if there are more than one value.
+        #
+        # Therefore, an update operation (when applicable) can only be
+        # performed either if all the ids encountered are unique, or else
+        # if there are only one value for that record present already, in
+        # which case the id is unique simply by being the only one.
+        return len(self.all_ids_for_record[record]) == \
+            len(set(self.all_ids_for_record[record]))
+
+    def get(self, record, content):
+        try:
+            return self.id_by_record_and_value[record][content]
+        except KeyError:
+            return None
+
+
+class LexiconRecord(namedtuple('LexiconRecord', 'content ttl rtype name')):
+
+    def func_args(self):
+        # TTL no argument for the functions.
+        return {k: getattr(self, k) for k in ['content', 'rtype', 'name']}
 
 
 class OnTheFlyLexiconConfigSource(LexiconConfigSource):

--- a/octodns/provider/lexicon.py
+++ b/octodns/provider/lexicon.py
@@ -1,0 +1,263 @@
+#
+#
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+import logging
+import shlex
+from collections import defaultdict
+
+from lexicon.client import Client as LexiconClient
+from lexicon.config import ConfigResolver as LexiconConfigResolver, \
+    ConfigSource as LexiconConfigSource
+from .base import BaseProvider
+from ..record import Record
+
+
+class LexiconProvider(BaseProvider):
+    """
+    Wrapper to handle LexiconProviders in octodns
+
+    lexicon:
+        class: octodns.provider.lexicon.LexiconProvicer
+        lexicon_config: lexicon config
+
+    Configuration added to the lexicon_config block will be injected as a
+    lexicon DictConfigSource. Further config sources read are the env config
+    source.
+
+    Example:
+
+          gandi:
+            class: octodns.provider.lexicon.LexiconProvider
+            lexicon_config:
+                provider_name: gandi
+                domain: blodapels.in
+                gandi:
+                    auth_token: "better stored in environment variable"
+                    api_protocol: rest
+
+    """
+    SUPPORTS = {'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR',
+                'SPF', 'SRV', 'TXT'}
+
+    SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
+
+    def __init__(self, id, lexicon_config, **kwargs):
+
+        self.log = logging.getLogger('LexiconProvider[{}]'.format(id))
+        super(LexiconProvider, self).__init__(id, **kwargs)
+
+        self.log.info('__init__: id=%s, token=***, account=%s', id, kwargs)
+
+        config = LexiconConfigResolver()
+        self.dynamic_config = OnTheFlyLexiconConfigSource()
+
+        config.with_config_source(self.dynamic_config) \
+            .with_env().with_dict(lexicon_config)
+
+        try:
+            self.lexicon_client = LexiconClient(config)
+        except AttributeError as e:
+            self.log.error('Unable to parse config {!s}'.format(config))
+            raise e
+
+    def populate(self, zone, target=False, lenient=False):
+
+        loaded_types = defaultdict(lambda: defaultdict(list))
+        before = len(zone.records)
+
+        exists = False
+
+        self.lexicon_client.provider.authenticate()
+        for lexicon_record in self.lexicon_client.provider.list_records(
+                None, zone.name, None):
+            # No way of knowing for sure whether a zone exists or not,
+            # But if it has contents, it is safe to assume that it does.
+            exists = True
+            loaded_types[lexicon_record["id"]][lexicon_record["type"]] \
+                .append(lexicon_record)
+
+        for record_id, data_by_id in loaded_types.items():
+            for record_type, lexicon_records in data_by_id.items():
+                self.log.debug("Got {!s} from above".format(lexicon_records))
+
+                _data_func = getattr(self, '_data_for_{}'.format(record_type))
+
+                data = _data_func(record_type, lexicon_records)
+
+                self.log.debug('populate: adding record {} records: {!s}'
+                               .format(record_id, data))
+
+                record = Record.new(zone, record_id, data, source=self)
+
+                zone.add_record(record, lenient=lenient)
+
+        self.log.info('populate:   found %s records, exists=%s',
+                      len(zone.records) - before, before < len(zone.records))
+
+        return exists
+
+    def _apply(self, plan):
+        """Required function of manager.py to actually apply a record change.
+
+            :param plan: Contains the zones and changes to be made
+            :type  plan: octodns.provider.base.Plan
+
+            :type return: void
+        """
+        desired = plan.desired
+        changes = plan.changes
+
+        self.log.debug('_apply: zone=%s, len(changes)=%d', desired.name,
+                       len(changes))
+
+        self.lexicon_client.provider.authenticate()
+
+        for change in changes:
+            action = change.__class__.__name__
+            _rrset_func = getattr(
+                self, '_rrset_for_{}'.format(change.record._type))
+
+            record_type = change.record._type
+            contents = _rrset_func(change.record)
+            identifier = change.record.fqdn
+            name = change.record.fqdn
+
+            self.dynamic_config.set_ttl(change.record.ttl)
+
+            # a single record might have multiple values, but lexicon seems to
+            # handle them one at a time, thus an A record with two rrsets will
+            # have to be handled like two separate "actions"
+            if action == 'Create':
+                for content in contents:
+                    self.lexicon_client.provider.create_record(
+                        record_type, name, content)
+
+            elif action == 'Update':
+
+                # Some providers, such like the powerdns lexicon provider,
+                # handle updates like so:
+                #
+                #         self._delete_record(identifier)
+                #         return self._create_record(rtype, name, content)
+                #
+                # Therefore, for multiple additions to a particular record,
+                # what seems to be the safest way, is to call update once, and
+                # then do "create", because from what I can see in the
+                # providers, create does not seem to delete old records.
+
+                content_iterator = iter(contents)
+
+                self.lexicon_client.provider \
+                    .update_record(identifier, record_type,
+                                   name, next(content_iterator))
+
+                for content in content_iterator:
+                    self.lexicon_client.provider \
+                        .create_record(record_type, name, content)
+
+            elif action == 'Delete':
+                self.lexicon_client.provider \
+                    .delete_record(identifier, record_type, name, None)
+
+            else:
+                raise RuntimeError(
+                    "Unknown action {} for {!s}".format(action, change))
+
+    def _data_for_multiple(self, type, lexicon_records):
+        return {
+            'ttl': lexicon_records[0]['ttl'],
+            'type': type,
+            'values': [r['content'] for r in lexicon_records]
+        }
+
+    def _data_for_MX(self, type, lexicon_records):
+        values = []
+        for record in lexicon_records:
+            priority, exchange = shlex.split(record["content"])
+            values.append({"priority": priority, "exchange": exchange})
+
+        return {
+            'ttl': lexicon_records[0]['ttl'],
+            'type': type,
+            'values': values
+        }
+
+    def _data_for_CNAME(self, type, lexicon_records):
+        record = lexicon_records[0]
+        return {
+            'ttl': record['ttl'],
+            'type': type,
+            'value': record['content']
+        }
+
+    def _data_for_SRV(self, type, lexicon_records):
+        values = []
+        for record in lexicon_records:
+            priority, weight, port, target = shlex.split(record['content'])
+
+            values.append({
+                'priority': priority,
+                'weight': weight,
+                'port': port,
+                'target': target
+            })
+        return {
+            'type': type,
+            'ttl': lexicon_records[0]['ttl'],
+            'values': values
+        }
+
+    _data_for_ALIAS = _data_for_CNAME
+
+    _data_for_A = _data_for_multiple
+
+    _data_for_TXT = _data_for_multiple
+
+    def _rrset_for_multiple(self, octodns_record):
+        return [content for content in octodns_record.values]
+
+    def _rrset_for_MX(self, octodns_record):
+        return ['{} {}'.format(c.preference, c.exchange)
+                for c in octodns_record.values]
+
+    def _rrset_for_CNAME(self, octodns_record):
+        return [octodns_record.value]
+
+    def _rrset_for_SRV(self, octodns_record):
+        return ['{} {} {} {}'.format(
+            c.priority, c.weight, c.port, c.target)
+            for c in octodns_record.values]
+
+    _rrset_for_ALIAS = _rrset_for_CNAME
+
+    _rrset_for_A = _rrset_for_multiple
+
+    _rrset_for_TXT = _rrset_for_multiple
+
+
+class OnTheFlyLexiconConfigSource(LexiconConfigSource):
+
+    def __init__(self, ttl=3600):
+        super(OnTheFlyLexiconConfigSource, self).__init__()
+        self.ttl = ttl
+
+    def set_ttl(self, ttl):
+        self.ttl = ttl
+
+    def resolve(self, config_key):
+        if config_key == "lexicon:ttl":
+            return self.ttl
+        # These two keys below are not used, because actions are handled in
+        # _apply, The config needs to resolve, though, lest the config
+        # validation will fail.
+        elif config_key == 'lexicon:action':
+            return '*'
+        elif config_key == 'lexicon:type':
+            return '*'
+        else:
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ s3transfer==0.3.3
 setuptools==44.1.0
 six==1.14.0
 transip==2.1.2
+dns-lexicon[full]

--- a/script/coverage
+++ b/script/coverage
@@ -28,7 +28,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=
 
 # Lexicon might read any variables prefixed with LEXICON_
 # in the EnvironmentConfigSource class.
-for var in $(grep -o 'LEXICON_[^=]\+' <<< $(env))
+for var in $(env | grep -o 'LEXICON_[^=]\+')
  do
   export $var=
 done

--- a/script/coverage
+++ b/script/coverage
@@ -26,6 +26,13 @@ export DYN_PASSWORD=
 export DYN_USERNAME=
 export GOOGLE_APPLICATION_CREDENTIALS=
 
+# Lexicon might read any variables prefixed with LEXICON_
+# in the EnvironmentConfigSource class.
+for var in $(grep -o 'LEXICON_[^=]\+' <<< $(env))
+ do
+  export $var=
+done
+
 # Don't allow disabling coverage
 grep -r -I --line-number "# pragma: nocover" octodns && {
   echo "Code coverage should not be disabled"

--- a/tests/test_octodns_provider_lexicon.py
+++ b/tests/test_octodns_provider_lexicon.py
@@ -1,0 +1,175 @@
+from unittest import TestCase
+
+import mock
+from mock import Mock
+
+from octodns.provider.lexicon import LexiconProvider, \
+    OnTheFlyLexiconConfigSource
+from octodns.provider.plan import Plan
+from octodns.record import Record, Change, Create, Delete, Update
+from octodns.zone import Zone
+
+LEXICON_DATA = [
+    {'type': 'A', 'name': '@.blodapels.in', 'ttl': 10800, 'content':
+        '192.0.184.38', 'id': '@'},
+    {'type': 'MX', 'name': '@.blodapels.in', 'ttl': 10800, 'content':
+        '10 spool.mail.example.com.', 'id': '@'},
+    {'type': 'MX', 'name': '@.blodapels.in', 'ttl': 10800, 'content':
+        '50 fb.mail.example.com.', 'id': '@'},
+    {'type': 'TXT', 'name': '@.blodapels.in', 'ttl': 10800, 'content':
+        'v=spf1 include:_mailcust.example.com ?all',
+     'id': '@'},
+    {'type': 'CNAME', 'name': 'webmail.blodapels.in', 'ttl': 10800, 'content':
+        'webmail.example.com.', 'id': 'webmail'},
+    {'type': 'CNAME', 'name': 'www.blodapels.in', 'ttl': 10800, 'content':
+        'webredir.vip.example.com.', 'id': 'www'},
+    {'type': 'SRV', 'name': '_imap._tcp.blodapels.in', 'ttl': 10800,
+     'content': '0 0 0   .', 'id': '_imap._tcp'},
+    {'type': 'SRV', 'name': '_imaps._tcp.blodapels.in', 'ttl': 10800,
+     'content': '0 1 993 mail.example.com.',
+     'id': '_imaps._tcp'},
+    {'type': 'SRV', 'name': '_pop3._tcp.blodapels.in', 'ttl': 10800,
+     'content': '0 0 0   .', 'id': '_pop3._tcp'},
+    {'type': 'SRV', 'name': '_pop3s._tcp.blodapels.in', 'ttl': 10800,
+     'content': '10 1 995 mail.example.com.',
+     'id': '_pop3s._tcp'},
+    {'type': 'SRV', 'name': '_submission._tcp.blodapels.in', 'ttl': 10800,
+     'content': '0 1 465 mail.example.com.',
+     'id': '_submission._tcp'}
+]
+
+ZONE = Zone("blodapels.in.", [])
+
+source = Mock()
+
+OCTODNS_DATA = [
+    Record.new(ZONE, '@', {'ttl': 10800, 'type': 'A',
+                           'values': ['192.0.184.38']}, source=source),
+    Record.new(ZONE, '@', {'ttl': 10800, 'type': 'MX',
+                           'values': [{'priority': '10', 'exchange':
+                                      'spool.mail.example.com.'},
+                                      {'priority': '50', 'exchange':
+                                          'fb.mail.example.com.'}]},
+               source=source),
+    Record.new(ZONE, '@', {'ttl': 10800, 'type': 'TXT',
+                           'values':
+                               ['v=spf1 include:_mailcust.example.com ?all']},
+               source=source),
+    Record.new(ZONE, 'webmail', {'ttl': 10800, 'type': 'CNAME', 'value':
+                                 'webmail.example.com.'}, source=source),
+    Record.new(ZONE, 'www', {'ttl': 10800, 'type': 'CNAME', 'value':
+                             'webredir.vip.example.com.'}, source=source),
+    Record.new(ZONE, '_imap._tcp',
+               {'type': 'SRV', 'ttl': 10800, 'values':
+                   [{'priority': '0', 'weight': '0', 'port': '0',
+                     'target': '.'}]},
+               source=source),
+    Record.new(ZONE, '_imaps._tcp', {'type': 'SRV', 'ttl': 10800, 'values': [
+        {'priority': '0', 'weight': '1', 'port': '993',
+         'target': 'mail.example.com.'}]}, source=source),
+    Record.new(ZONE, '_pop3._tcp',
+               {'type': 'SRV', 'ttl': 10800, 'values': [
+                   {'priority': '0', 'weight': '0', 'port': '0',
+                    'target': '.'}]},
+               source=source),
+    Record.new(ZONE, '_pop3s._tcp', {'type': 'SRV', 'ttl': 10800, 'values': [
+        {'priority': '10', 'weight': '1', 'port': '995',
+         'target': 'mail.example.com.'}]}, source=source),
+    Record.new(ZONE, '_submission._tcp',
+               {'type': 'SRV', 'ttl': 10800, 'values': [
+                   {'priority': '0', 'weight': '1', 'port': '465',
+                    'target': 'mail.example.com.'}]}, source=source),
+]
+
+
+class TestLexiconProvider(TestCase):
+    lexicon_config = {
+        "provider_name": "gandi",
+        "domain": 'blodapels.in',
+        "gandi": {
+            "api_protocol": "rest",
+            "auth_token": "X"
+        }
+    }
+
+    @mock.patch('lexicon.providers.gandi.Provider')
+    def test_populate(self, mock_provider):
+        # Given
+        provider = LexiconProvider(id="unittests",
+                                   lexicon_config=self.lexicon_config)
+        zone = Zone("blodapels.in.", [])
+
+        provider.lexicon_client.provider.list_records.side_effect \
+            = lambda *s: iter(LEXICON_DATA)
+
+        # When
+        provider.populate(zone=zone)
+
+        # Then
+        self.assertEqual(zone.records, set(OCTODNS_DATA))
+        self.assertTrue(mock_provider.called, "authenticate was called")
+
+    def test_invalid_config(self):
+        with self.assertRaises(AttributeError):
+            LexiconProvider(id="unittests", lexicon_config={})
+
+    def test_config_resolver(self):
+        # Given
+        config_resolver = OnTheFlyLexiconConfigSource()
+
+        # When
+        config_resolver.set_ttl(666)
+
+        # Then
+        self.assertEqual(config_resolver.resolve("lexicon:ttl"), 666)
+        self.assertEqual(config_resolver.resolve("lexicon:action"), "*")
+        self.assertEqual(config_resolver.resolve("lexicon:type"), "*")
+        self.assertEqual(config_resolver.resolve("lexicon:missing"), None)
+
+    @mock.patch('lexicon.providers.gandi.Provider')
+    def test__apply(self, mock_provider):
+        # Given
+        changeset = [Create(r) for r in OCTODNS_DATA]
+
+        record_to_del = Record.new(ZONE, 'unittest-del',
+                                   {'ttl': 30, 'type': 'CNAME', 'value':
+                                       'www.example.com.'},
+                                   source=source)
+        record_to_update = Record.new(ZONE, 'multi-value-record',
+                                      {'ttl': 360, 'type': 'A', 'values':
+                                          ['92.0.2.0', '192.0.2.1']},
+                                      source=source)
+
+        changeset.append(Delete(record_to_del))
+        changeset.append(Update(record_to_update, record_to_update))
+
+        plan = Plan(ZONE, ZONE, changeset, True)
+
+        provider = LexiconProvider(id="unittests",
+                                   lexicon_config=self.lexicon_config)
+
+        # When
+        provider._apply(plan)
+
+        # Then
+        pass
+
+    @mock.patch('lexicon.providers.gandi.Provider')
+    def test_apply_weird_stuff(self, _):
+        # Given
+        provider = LexiconProvider(id="unittests",
+                                   lexicon_config=self.lexicon_config)
+
+        with self.assertRaises(RuntimeError):
+            provider._apply(BadPlan())
+
+
+class CrashChange(Change):
+
+    def __init__(self, new):
+        super(CrashChange, self).__init__(None, new)
+
+
+class BadPlan:
+    desired = Mock()
+    changes = [CrashChange(OCTODNS_DATA[0])]

--- a/tests/test_octodns_provider_lexicon.py
+++ b/tests/test_octodns_provider_lexicon.py
@@ -6,7 +6,7 @@ from mock import Mock
 from octodns.provider.lexicon import LexiconProvider, \
     OnTheFlyLexiconConfigSource
 from octodns.provider.plan import Plan
-from octodns.record import Record, Change, Create, Delete, Update
+from octodns.record import Record, Create, Delete, Update
 from octodns.zone import Zone
 
 LEXICON_DATA = [
@@ -35,7 +35,13 @@ LEXICON_DATA = [
      'id': '_pop3s._tcp'},
     {'type': 'SRV', 'name': '_submission._tcp.blodapels.in', 'ttl': 10800,
      'content': '0 1 465 mail.example.com.',
-     'id': '_submission._tcp'}
+     'id': '_submission._tcp'},
+    {'type': 'URL', 'name': '@.id.example.com', 'ttl': '1800', 'content':
+        'http://www.example.com/', 'id': '745514'},
+    {'type': 'CAA', 'name': '@.blodapels.in', 'ttl': 10800, 'content':
+        '0 issue ";"', 'id': '@'},
+    {'type': 'CAA', 'name': '@.blodapels.in', 'ttl': 10800, 'content':
+        '0 issuewild "letsencrypt.org"', 'id': '@'}
 ]
 
 ZONE = Zone("blodapels.in.", [])
@@ -79,24 +85,31 @@ OCTODNS_DATA = [
                {'type': 'SRV', 'ttl': 10800, 'values': [
                    {'priority': '0', 'weight': '1', 'port': '465',
                     'target': 'mail.example.com.'}]}, source=source),
+    Record.new(ZONE, '@',
+               {'type': 'CAA', 'ttl': 10800, 'values': [
+                   {'flags': 0, 'tag': 'issue', 'value': ';'},
+                   {'flags': 0, 'tag': 'issuewild',
+                    'value': 'letsencrypt.org'}]},
+               source=source)
 ]
+
+lexicon_config = {
+    "provider_name": "gandi",
+    "domain": 'blodapels.in',
+    "gandi": {
+        "api_protocol": "rest",
+        "auth_token": "X"
+    }
+}
 
 
 class TestLexiconProvider(TestCase):
-    lexicon_config = {
-        "provider_name": "gandi",
-        "domain": 'blodapels.in',
-        "gandi": {
-            "api_protocol": "rest",
-            "auth_token": "X"
-        }
-    }
 
     @mock.patch('lexicon.providers.gandi.Provider')
     def test_populate(self, mock_provider):
         # Given
         provider = LexiconProvider(id="unittests",
-                                   lexicon_config=self.lexicon_config)
+                                   lexicon_config=lexicon_config)
         zone = Zone("blodapels.in.", [])
 
         provider.lexicon_client.provider.list_records.side_effect \
@@ -108,6 +121,46 @@ class TestLexiconProvider(TestCase):
         # Then
         self.assertEqual(zone.records, set(OCTODNS_DATA))
         self.assertTrue(mock_provider.called, "authenticate was called")
+
+    @mock.patch('lexicon.providers.gandi.Provider')
+    def test_populate_crash_on_unknown(self, _):
+        # Given
+        provider = LexiconProvider(id="unittests",
+                                   raise_on_unhandled=True,
+                                   lexicon_config=lexicon_config)
+        zone = Zone("blodapels.in.", [])
+
+        provider.lexicon_client.provider.list_records.side_effect \
+            = lambda *s: iter(LEXICON_DATA)
+
+        with self.assertRaises(RuntimeError):
+            provider.populate(zone=zone)
+
+    @mock.patch('lexicon.providers.gandi.Provider')
+    def test_populate_with_relative_name(self, _):
+        # Given
+        lexicon_data = [{'type': 'A',
+                         'name': '@',
+                         'ttl': 10800,
+                         'content': '192.0.184.38',
+                         'id': '@'}]
+        provider = LexiconProvider(id="unittests",
+                                   lexicon_config=lexicon_config)
+        zone = Zone("blodapels.in.", [])
+
+        expected_record = Record.new(ZONE, '@', {'ttl': 10800, 'type': 'A',
+                                                 'values': ['192.0.184.38']},
+                                     source=source)
+
+        provider.lexicon_client.provider.list_records.side_effect \
+            = lambda *s: iter(lexicon_data)
+
+        # When
+        provider.populate(zone)
+
+        # Then
+        self.assertEqual(zone.records, {expected_record},
+                         "relative names from list are handled correctly")
 
     def test_invalid_config(self):
         with self.assertRaises(AttributeError):
@@ -126,8 +179,46 @@ class TestLexiconProvider(TestCase):
         self.assertEqual(config_resolver.resolve("lexicon:type"), "*")
         self.assertEqual(config_resolver.resolve("lexicon:missing"), None)
 
+
+class TestLexiconProviderApplyScenarios(TestCase):
+
     @mock.patch('lexicon.providers.gandi.Provider')
-    def test__apply(self, mock_provider):
+    def setUp(self, mock_provider):
+        self.zone = Zone("blodapels.in.", [])
+        self.provider = LexiconProvider(id="unittests",
+                                        lexicon_config=lexicon_config)
+        self.lexicon_records_one_octo_record = [
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.1.1', 'id': '747789'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.1.2', 'id': '747790'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.1.5', 'id': '747793'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.2.4', 'id': '747794'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.2.3', 'id': '747795'}]
+
+        self.lexicon_records_non_unique_ids = [
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.1.1', 'id': 'test-many'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.1.2', 'id': 'test-many'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.1.5', 'id': 'test-many'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.2.4', 'id': 'test-many'},
+            {'type': 'A', 'name': 'test-many.blodapels.in', 'ttl': '1337',
+             'content': '192.168.2.3', 'id': 'test-many'}]
+
+        self.octo_record = Record.new(Zone("blodapels.in.", []), 'test-many', {
+            'type': 'A', 'ttl': 1337, 'values': ['192.168.1.1', '192.168.1.2',
+                                                 '192.168.1.5', '192.168.2.4',
+                                                 '192.168.2.3']})
+
+        self.provider_mock = mock_provider.return_value
+
+    def test_apply_create_delete(self):
         # Given
         changeset = [Create(r) for r in OCTODNS_DATA]
 
@@ -145,31 +236,200 @@ class TestLexiconProvider(TestCase):
 
         plan = Plan(ZONE, ZONE, changeset, True)
 
-        provider = LexiconProvider(id="unittests",
-                                   lexicon_config=self.lexicon_config)
+        expected_create_calls = [
+            mock.call(content='192.0.184.38',
+                      rtype='A',
+                      name='@.blodapels.in.'),
+            mock.call(content='10 '
+                              'spool.mail.example.com.',
+                      rtype='MX',
+                      name='@.blodapels.in.'),
+            mock.call(content='50 fb.mail.example.com.',
+                      rtype='MX',
+                      name='@.blodapels.in.'),
+            mock.call(content='v=spf1 include:_mailcus'
+                              't.example.com ?all',
+                      rtype='TXT',
+                      name='@.blodapels.in.'),
+            mock.call(content='0 0 0 .',
+                      rtype='SRV',
+                      name='_imap._tcp.blodapels.in.'),
+            mock.call(content='0 1 993 mail.example.com.',
+                      rtype='SRV',
+                      name='_imaps._tcp.blodapels.in.'),
+            mock.call(content='0 0 0 .',
+                      rtype='SRV',
+                      name='_pop3._tcp.blodapels.in.'),
+            mock.call(content='10 1 995 '
+                              'mail.example.com.',
+                      rtype='SRV',
+                      name='_pop3s._tcp.blodapels.in.'),
+            mock.call(content='0 1 465 mail.example.com.',
+                      rtype='SRV',
+                      name='_submission.'
+                           '_tcp.blodapels.in.'),
+            mock.call(content='webmail.example.com.',
+                      rtype='CNAME',
+                      name='webmail.blodapels.in.'),
+            mock.call(content='webredir.vip'
+                              '.example.com.',
+                      rtype='CNAME',
+                      name='www.blodapels.in.'),
+            mock.call(content='0 issue ";"',
+                      rtype='CAA',
+                      name='@.blodapels.in.'),
+            mock.call(content='0 issuewild "letsencrypt.org"',
+                      rtype='CAA',
+                      name='@.blodapels.in.'),
+        ]
 
         # When
-        provider._apply(plan)
+        self.provider._apply(plan)
 
         # Then
-        pass
+        for exp in expected_create_calls:
+            self.provider_mock.create_record.assert_has_calls([exp])
 
-    @mock.patch('lexicon.providers.gandi.Provider')
-    def test_apply_weird_stuff(self, _):
+        self.assertEqual(len(self.provider_mock.create_record.call_args_list),
+                         len(expected_create_calls),
+                         "no extra calls to create_record recorded")
+
+        self.provider_mock.delete_record.assert_called_once_with(
+            identifier=None,
+            content='www.example.com.',
+            rtype='CNAME',
+            name='unittest-del.blodapels.in.')
+        self.provider_mock.update_record.assert_not_called()
+
+    def test__apply_many_to_one(self):
         # Given
-        provider = LexiconProvider(id="unittests",
-                                   lexicon_config=self.lexicon_config)
+        self.provider.lexicon_client.provider.list_records.side_effect \
+            = lambda *s: iter(self.lexicon_records_one_octo_record)
 
-        with self.assertRaises(RuntimeError):
-            provider._apply(BadPlan())
+        octo_record = self.octo_record
 
+        # When
+        self.provider.populate(self.zone)
 
-class CrashChange(Change):
+        # Then
+        self.assertEqual(self.zone.records, {octo_record})
+        self.assertEqual(
+            self.provider.remembered_ids.get(octo_record, '192.168.1.1'),
+            '747789')
+        self.assertEqual(
+            self.provider.remembered_ids.get(octo_record, '192.168.1.2'),
+            '747790')
+        self.assertEqual(
+            self.provider.remembered_ids.get(octo_record, '192.168.1.5'),
+            '747793')
+        self.assertEqual(
+            self.provider.remembered_ids.get(octo_record, '192.168.2.4'),
+            '747794')
+        self.assertEqual(
+            self.provider.remembered_ids.get(octo_record, '192.168.2.3'),
+            '747795')
+        self.assertEqual(
+            self.provider.remembered_ids.get(octo_record, 'not even valid ip'),
+            None)
+        self.assertEqual(
+            self.provider.remembered_ids.get('', 'not even valid ip'), None)
 
-    def __init__(self, new):
-        super(CrashChange, self).__init__(None, new)
+        self.provider_mock.authenticate.assert_called_once_with()
+        self.provider_mock.list_records. \
+            assert_called_once_with(None, 'blodapels.in.', None)
 
+    def test_apply_many_to_one_without_unique_ids(self):
+        # Given
+        self.provider.lexicon_client.provider.list_records.side_effect \
+            = lambda *s: iter(self.lexicon_records_non_unique_ids)
 
-class BadPlan:
-    desired = Mock()
-    changes = [CrashChange(OCTODNS_DATA[0])]
+        desired_zone = Zone("blodapels.in.", [])
+
+        desired_record = Record.new(Zone("blodapels.in.", []), 'test-many', {
+            'type': 'A', 'ttl': 1337, 'values': ['192.168.1.1', '192.168.1.2',
+                                                 '192.168.1.3', '192.168.1.4',
+                                                 '192.168.1.5', '192.168.7.7']}
+                                    )
+        desired_zone.add_record(desired_record)
+        changes = {Update(existing=self.octo_record,
+                          new=desired_record)}
+        plan = Plan(desired=desired_zone,
+                    existing=self.zone,
+                    exists=True,
+                    changes=changes)
+
+        expected_caslls_for_create = [
+            mock.call(content='192.168.1.3',
+                      rtype='A',
+                      name='test-many.blodapels.in.'),
+            mock.call(content='192.168.1.4',
+                      rtype='A',
+                      name='test-many.blodapels.in.'),
+            mock.call(content='192.168.7.7',
+                      rtype='A',
+                      name='test-many.blodapels.in.')]
+
+        expected_calls_for_delete = [
+            mock.call(content='192.168.2.3',
+                      rtype='A',
+                      name='test-many.blodapels.in.'),
+            mock.call(content='192.168.2.4',
+                      rtype='A',
+                      name='test-many.blodapels.in.')]
+
+        # When
+        self.provider.populate(self.zone)
+        self.provider.apply(plan)
+
+        # Then
+        self.provider_mock.update_record.assert_not_called()
+
+        self.provider_mock.create_record.assert_has_calls(
+            expected_caslls_for_create)
+
+        self.provider_mock.delete_record.assert_has_calls(
+            expected_calls_for_delete)
+
+        self.assertEqual(self.provider_mock.delete_record.call_count, 2,
+                         "Delete is called exactly twice")
+
+    def test_apply_update_mix(self):
+        # given
+        self.provider.lexicon_client.provider.list_records.side_effect \
+            = lambda *s: iter(self.lexicon_records_one_octo_record)
+
+        desired_zone = Zone("blodapels.in.", [])
+
+        desired_record = Record.new(Zone("blodapels.in.", []), 'test-many', {
+            'type': 'A', 'ttl': 1337, 'values': ['192.168.1.1', '192.168.1.2',
+                                                 '192.168.1.3', '192.168.1.4',
+                                                 '192.168.1.5', '192.168.7.7']}
+                                    )
+        desired_zone.add_record(desired_record)
+
+        changes = {Update(existing=self.octo_record,
+                          new=desired_record)}
+
+        plan = Plan(desired=desired_zone,
+                    existing=self.zone,
+                    exists=True,
+                    changes=changes)
+
+        expected_calls = [mock.call(identifier='747795',
+                                    content='192.168.1.3',
+                                    rtype='A',
+                                    name='test-many.blodapels.in.'),
+                          mock.call(identifier='747794',
+                                    content='192.168.1.4',
+                                    rtype='A',
+                                    name='test-many.blodapels.in.')]
+
+        # When
+        self.provider.populate(self.zone)
+        self.provider.apply(plan)
+
+        # Then
+        self.provider_mock.update_record.assert_has_calls(expected_calls)
+        self.provider_mock.delete_record.assert_not_called()
+        self.provider_mock.create_record.assert_called_once_with(
+            content='192.168.7.7', rtype='A', name='test-many.blodapels.in.')


### PR DESCRIPTION
Add Lexicon provider per #534 which could potentially solve gandi
support #476, GoDaddy support #365 and maybe Aliyun(WanWang) #386 to name a few
by using this "wrapper" for Lexicon (which has support for these)

All record types possible are not added yet, and although test coverage is 100%, I have yet to assert enough data is correct between the various transformations, but I figure I'd open this PR up for review, and will complete the rest meanwhile, as they'd not introduce any significant changes.

Another caveat is that I have only tried this one with the gandi Lexicon provider.