### PR TITLE
Cloudflare: Add Support for PTR Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ It is similar to [Netflix/denominator](https://github.com/Netflix/denominator).
 
 ## Table of Contents
 
+- [DNS as code - Tools for managing DNS across multiple providers](#dns-as-code---tools-for-managing-dns-across-multiple-providers)
+- [Table of Contents](#table-of-contents)
 - [Getting started](#getting-started)
   - [Workspace](#workspace)
   - [Config](#config)
@@ -178,7 +180,7 @@ The above command pulled the existing data out of Route53 and placed the results
 |--|--|--|--|--|
 | [AzureProvider](/octodns/provider/azuredns.py) | azure-mgmt-dns | A, AAAA, CAA, CNAME, MX, NS, PTR, SRV, TXT | No | |
 | [Akamai](/octodns/provider/edgedns.py) | edgegrid-python | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT | No | |
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, MX, NS, SPF, SRV, TXT | No | CAA tags restricted |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
 | [ConstellixProvider](/octodns/provider/constellix.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
 | [DigitalOceanProvider](/octodns/provider/digitalocean.py) | | A, AAAA, CAA, CNAME, MX, NS, TXT, SRV | No | CAA tags restricted |
 | [DnsMadeEasyProvider](/octodns/provider/dnsmadeeasy.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |

--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -60,8 +60,8 @@ class CloudflareProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'SRV',
-                    'SPF', 'TXT'))
+    SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR',
+                    'SRV', 'SPF', 'TXT'))
 
     MIN_TTL = 120
     TIMEOUT = 15
@@ -173,6 +173,7 @@ class CloudflareProvider(BaseProvider):
         }
 
     _data_for_ALIAS = _data_for_CNAME
+    _data_for_PTR = _data_for_CNAME
 
     def _data_for_MX(self, _type, records):
         values = []
@@ -338,6 +339,8 @@ class CloudflareProvider(BaseProvider):
 
     def _contents_for_CNAME(self, record):
         yield {'content': record.value}
+
+    _contents_for_PTR = _contents_for_CNAME
 
     def _contents_for_MX(self, record):
         for value in record.values:

--- a/tests/fixtures/cloudflare-dns_records-page-1.json
+++ b/tests/fixtures/cloudflare-dns_records-page-1.json
@@ -180,7 +180,7 @@
     "per_page": 10,
     "total_pages": 2,
     "count": 10,
-    "total_count": 19
+    "total_count": 20
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-dns_records-page-2.json
+++ b/tests/fixtures/cloudflare-dns_records-page-2.json
@@ -158,6 +158,23 @@
       }
     },
     {
+      "id": "fc12ab34cd5611334422ab3322997677",
+      "type": "PTR",
+      "name": "ptr.unit.tests",
+      "content": "foo.bar.com",
+      "proxiable": true,
+      "proxied": false,
+      "ttl": 300,
+      "locked": false,
+      "zone_id": "ff12ab34cd5611334422ab3322997650",
+      "zone_name": "unit.tests",
+      "modified_on": "2017-03-11T18:01:43.940682Z",
+      "created_on": "2017-03-11T18:01:43.940682Z",
+      "meta": {
+        "auto_added": false
+      }
+    },
+    {
       "id": "fc12ab34cd5611334422ab3322997656",
       "type": "SRV",
       "name": "_srv._tcp.unit.tests",
@@ -212,8 +229,8 @@
     "page": 2,
     "per_page": 11,
     "total_pages": 2,
-    "count": 9,
-    "total_count": 21
+    "count": 10,
+    "total_count": 20
   },
   "success": true,
   "errors": [],


### PR DESCRIPTION
We needed this change for synchronizing PTR Records from Reverse Lookup Zones (2.3.4.in-addr.arpa) hosted on Cloudflare.