### PR TITLE
NS1 georegion, country, and catchall need to be separate groups

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -455,6 +455,9 @@ class Ns1Provider(BaseProvider):
         return data
 
     def _parse_dynamic_pool_name(self, pool_name):
+        if pool_name.startswith('catchall__'):
+            # Special case for the old-style catchall prefix
+            return pool_name[10:]
         try:
             pool_name, _ = pool_name.rsplit('__', 1)
         except ValueError:

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -237,7 +237,6 @@ class Ns1Provider(BaseProvider):
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
 
     ZONE_NOT_FOUND_MESSAGE = 'server error: zone not found'
-    CATCHALL_PREFIX = 'catchall__'
 
     def _update_filter(self, filter, with_disabled):
         if with_disabled:
@@ -455,6 +454,13 @@ class Ns1Provider(BaseProvider):
         data['geo'] = geo
         return data
 
+    def _parse_dynamic_pool_name(self, pool_name):
+        try:
+            pool_name, _ = pool_name.rsplit('__', 1)
+        except ValueError:
+            pass
+        return pool_name
+
     def _data_for_dynamic_A(self, _type, record):
         # First make sure we have the expected filters config
         if not self._valid_filter_config(record['filters'], record['domain']):
@@ -472,9 +478,8 @@ class Ns1Provider(BaseProvider):
         for answer in record['answers']:
             # region (group name in the UI) is the pool name
             pool_name = answer['region']
-            # Get the actual pool name from the constructed pool name in case
-            # of the catchall
-            pool_name = pool_name.replace(self.CATCHALL_PREFIX, '')
+            # Get the actual pool name by removing the type
+            pool_name = self._parse_dynamic_pool_name(pool_name)
             pool = pools[pool_name]
 
             meta = answer['meta']
@@ -501,14 +506,23 @@ class Ns1Provider(BaseProvider):
         # tied to pools on the NS1 side, e.g. we can only have 1 rule per pool,
         # that may eventually run into problems, but I don't have any use-cases
         # examples currently where it would
-        rules = []
+        rules = {}
         for pool_name, region in sorted(record['regions'].items()):
-            # Rules that refer to the catchall pool would have the
-            # CATCHALL_PREFIX in the pool name. Strip the prefix to get back
-            # the pool name as in the config
-            pool_name = pool_name.replace(self.CATCHALL_PREFIX, '')
+            # Get the actual pool name by removing the type
+            pool_name = self._parse_dynamic_pool_name(pool_name)
+
             meta = region['meta']
             notes = self._parse_notes(meta.get('note', ''))
+
+            rule_order = notes['rule-order']
+            try:
+                rule = rules[rule_order]
+            except KeyError:
+                rule = {
+                    'pool': pool_name,
+                    '_order': rule_order,
+                }
+                rules[rule_order] = rule
 
             # The group notes field in the UI is a `note` on the region here,
             # that's where we can find our pool's fallback.
@@ -560,17 +574,15 @@ class Ns1Provider(BaseProvider):
             for state in meta.get('us_state', []):
                 geos.add('NA-US-{}'.format(state))
 
-            rule = {
-                'pool': pool_name,
-                '_order': notes['rule-order'],
-            }
             if geos:
-                rule['geos'] = sorted(geos)
-            rules.append(rule)
+                # There are geos, combine them with any existing geos for this
+                # pool and recorded the sorted unique set of them
+                rule['geos'] = sorted(set(rule.get('geos', [])) | geos)
 
         # Order and convert to a list
         default = sorted(default)
-        # Order
+        # Convert to list and order
+        rules = list(rules.values())
         rules.sort(key=lambda r: (r['_order'], r['pool']))
 
         return {
@@ -1050,29 +1062,34 @@ class Ns1Provider(BaseProvider):
             meta = {
                 'note': self._encode_notes(notes),
             }
+
             if georegion:
-                meta['georegion'] = sorted(georegion)
-            if country:
-                meta['country'] = sorted(country)
-            if us_state:
-                meta['us_state'] = sorted(us_state)
+                georegion_meta = dict(meta)
+                georegion_meta['georegion'] = sorted(georegion)
+                regions['{}__georegion'.format(pool_name)] = {
+                    'meta': georegion_meta,
+                }
+
+            if country or us_state:
+                # If there's country and/or states its a country pool,
+                # countries and states can coexist as they're handled by the
+                # same step in the filterchain (countries and georegions
+                # cannot as they're seperate stages and run the risk of
+                # eliminating all options)
+                country_state_meta = dict(meta)
+                if country:
+                    country_state_meta['country'] = sorted(country)
+                if us_state:
+                    country_state_meta['us_state'] = sorted(us_state)
+                regions['{}__country'.format(pool_name)] = {
+                    'meta': country_state_meta,
+                }
 
             if not georegion and not country and not us_state:
-                # This is the catchall pool. Modify the pool name in the record
-                # being pushed
-                # NS1 regions are indexed by pool names. Any reuse of pool
-                # names in the rules will result in overwriting of the pool.
-                # Reuse of pools is in general disallowed but for the case of
-                # the catchall pool - to allow legitimate usecases.
-                # The pool name renaming is done to accommodate for such a
-                # reuse.
-                # (We expect only one catchall per record. Any associated
-                # validation is expected to covered under record validation)
-                pool_name = '{}{}'.format(self.CATCHALL_PREFIX, pool_name)
-
-            regions[pool_name] = {
-                'meta': meta,
-            }
+                # If there's no targeting it's a catchall
+                regions['{}__catchall'.format(pool_name)] = {
+                    'meta': meta,
+                }
 
         existing_monitors = self._monitors_for(record)
         active_monitors = set()
@@ -1102,15 +1119,14 @@ class Ns1Provider(BaseProvider):
         # Build our list of answers
         # The regions dictionary built above already has the required pool
         # names. Iterate over them and add answers.
-        # In the case of the catchall, original pool name can be obtained
-        # by stripping the CATCHALL_PREFIX from the pool name
         answers = []
         for pool_name in sorted(regions.keys()):
             priority = 1
 
             # Dynamic/health checked
             pool_label = pool_name
-            pool_name = pool_name.replace(self.CATCHALL_PREFIX, '')
+            # Remove the pool type from the end of the name
+            pool_name = self._parse_dynamic_pool_name(pool_name)
             self._add_answers_for_pool(answers, default_answers, pool_name,
                                        pool_label, pool_answers, pools,
                                        priority)

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -1311,7 +1311,7 @@ class TestNs1ProviderDynamic(TestCase):
                 'answer': ['3.4.5.6'],
                 'meta': {
                     'priority': 1,
-                    'note': 'from:lhr',
+                    'note': 'from:lhr__country',
                 },
                 'region': 'lhr',
             }, {
@@ -1363,14 +1363,24 @@ class TestNs1ProviderDynamic(TestCase):
             'domain': 'unit.tests',
             'filters': filters,
             'regions': {
-                'lhr': {
+                # lhr will use the new-split style names (and that will require
+                # combining in the code to produce the expected answer
+                'lhr__georegion': {
+                    'meta': {
+                        'note': 'rule-order:1 fallback:iad',
+                        'georegion': ['AFRICA'],
+                    },
+                },
+                'lhr__country': {
                     'meta': {
                         'note': 'rule-order:1 fallback:iad',
                         'country': ['CA'],
-                        'georegion': ['AFRICA'],
                         'us_state': ['OR'],
                     },
                 },
+                # iad will use the old style "plain" region naming. We won't
+                # see mixed names like this in practice, but this should
+                # exercise both paths
                 'iad': {
                     'meta': {
                         'note': 'rule-order:2',
@@ -1437,13 +1447,15 @@ class TestNs1ProviderDynamic(TestCase):
         # Oceania test cases
         # 1. Full list of countries should return 'OC' in geos
         oc_countries = Ns1Provider._CONTINENT_TO_LIST_OF_COUNTRIES['OC']
-        ns1_record['regions']['lhr']['meta']['country'] = list(oc_countries)
+        ns1_record['regions']['lhr__country']['meta']['country'] = \
+            list(oc_countries)
         data3 = provider._data_for_A('A', ns1_record)
         self.assertTrue('OC' in data3['dynamic']['rules'][0]['geos'])
 
         # 2. Partial list of countries should return just those
         partial_oc_cntry_list = list(oc_countries)[:5]
-        ns1_record['regions']['lhr']['meta']['country'] = partial_oc_cntry_list
+        ns1_record['regions']['lhr__country']['meta']['country'] = \
+            partial_oc_cntry_list
         data4 = provider._data_for_A('A', ns1_record)
         for c in partial_oc_cntry_list:
             self.assertTrue(

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -1305,7 +1305,7 @@ class TestNs1ProviderDynamic(TestCase):
         # Test out a small, but realistic setup that covers all the options
         # We have country and region in the test config
         filters = provider._get_updated_filter_chain(True, True)
-        catchall_pool_name = '{}__catchall'.format('iad')
+        catchall_pool_name = 'iad__catchall'
         ns1_record = {
             'answers': [{
                 'answer': ['3.4.5.6'],
@@ -1442,6 +1442,16 @@ class TestNs1ProviderDynamic(TestCase):
         # Same answer if we go through _data_for_A which out sources the job to
         # _data_for_dynamic_A
         data2 = provider._data_for_A('A', ns1_record)
+        self.assertEquals(data, data2)
+
+        # Same answer if we have an old-style catchall name
+        old_style_catchall_pool_name = 'catchall__iad'
+        ns1_record['answers'][-2]['region'] = old_style_catchall_pool_name
+        ns1_record['answers'][-1]['region'] = old_style_catchall_pool_name
+        ns1_record['regions'][old_style_catchall_pool_name] = \
+            ns1_record['regions'][catchall_pool_name]
+        del ns1_record['regions'][catchall_pool_name]
+        data3 = provider._data_for_dynamic_A('A', ns1_record)
         self.assertEquals(data, data2)
 
         # Oceania test cases

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -981,16 +981,12 @@ class TestNs1ProviderDynamic(TestCase):
         record = self.record()
         rule0 = record.data['dynamic']['rules'][0]
         rule1 = record.data['dynamic']['rules'][1]
-        rule0_saved_geos = rule0['geos']
-        rule1_saved_geos = rule1['geos']
         rule0['geos'] = ['AF', 'EU']
         rule1['geos'] = ['NA']
         ret, _ = provider._params_for_A(record)
         self.assertEquals(ret['filters'],
                           Ns1Provider._FILTER_CHAIN_WITH_REGION(provider,
                                                                 True))
-        rule0['geos'] = rule0_saved_geos
-        rule1['geos'] = rule1_saved_geos
 
     @patch('octodns.provider.ns1.Ns1Provider._monitor_sync')
     @patch('octodns.provider.ns1.Ns1Provider._monitors_for')
@@ -1022,16 +1018,12 @@ class TestNs1ProviderDynamic(TestCase):
         record = self.record()
         rule0 = record.data['dynamic']['rules'][0]
         rule1 = record.data['dynamic']['rules'][1]
-        rule0_saved_geos = rule0['geos']
-        rule1_saved_geos = rule1['geos']
         rule0['geos'] = ['AF', 'EU']
         rule1['geos'] = ['NA-US-CA']
         ret, _ = provider._params_for_A(record)
         exp = Ns1Provider._FILTER_CHAIN_WITH_REGION_AND_COUNTRY(provider,
                                                                 True)
         self.assertEquals(ret['filters'], exp)
-        rule0['geos'] = rule0_saved_geos
-        rule1['geos'] = rule1_saved_geos
 
     @patch('octodns.provider.ns1.Ns1Provider._monitor_sync')
     @patch('octodns.provider.ns1.Ns1Provider._monitors_for')
@@ -1064,7 +1056,6 @@ class TestNs1ProviderDynamic(TestCase):
         # Check returned dict has list of countries under 'OC'
         record = self.record()
         rule0 = record.data['dynamic']['rules'][0]
-        saved_geos = rule0['geos']
         rule0['geos'] = ['OC']
         ret, _ = provider._params_for_A(record)
         got = set(ret['regions']['lhr__country']['meta']['country'])
@@ -1075,7 +1066,6 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertEquals(ret['filters'],
                           Ns1Provider._FILTER_CHAIN_WITH_COUNTRY(provider,
                                                                  True))
-        rule0['geos'] = saved_geos
 
     @patch('octodns.provider.ns1.Ns1Provider._monitor_sync')
     @patch('octodns.provider.ns1.Ns1Provider._monitors_for')


### PR DESCRIPTION
Filter chains with both country and georegion can't cope with both being applied to a single group. Instead we need to break up things that target both into separate groups, one for each. 


* [x] Much more thorough testing needs to be added to verify the results, not just that the code doesn't blow up and has the right filter chain
* [x] Need to verify that this is able to round trip cleanly with prior revisions. 
* [x] Thoroughly test a with global scans to validate targeting works as expected
