### PR TITLE
lenient param to populate needs to be optoinal

### DIFF
--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -278,6 +278,29 @@ class TestManager(TestCase):
                 .validate_configs()
         self.assertTrue('unknown source' in text_type(ctx.exception))
 
+    def test_populate_lenient_fallback(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+            # Only allow a target that doesn't exist
+            manager = Manager(get_config_filename('simple.yaml'))
+
+            class NoLenient(SimpleProvider):
+
+                def populate(self, zone, source=False):
+                    pass
+
+            # This should be ok, we'll fall back to not passing it
+            manager._populate_and_plan('unit.tests.', [NoLenient()], [])
+
+            class NoZone(SimpleProvider):
+
+                def populate(self, lenient=False):
+                    pass
+
+            # This will blow up, we don't fallback for source
+            with self.assertRaises(TypeError):
+                manager._populate_and_plan('unit.tests.', [NoZone()], [])
+
 
 class TestMainThreadExecutor(TestCase):
 


### PR DESCRIPTION
Missed an issue with 3rd party/external providers, namely that they won't necessarily be set up to accept the `lenient` parameter added in https://github.com/github/octodns/pull/567. 

Rather than force them all to update by breaking them this works around the problem by trying without the parameter if there's a problem with passing it. 

