### PR TITLE
Add support for long txt records. Skip Alias records

### DIFF
--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -419,8 +419,9 @@ class AzureProvider(BaseProvider):
 
                 if typ in ['A', 'CNAME']:
                     if self._check_for_alias(azrecord, typ):
-                        self.log.info(
-                            'This entry is an Azure alias. Skipping. zone=%s record=%s, type=%s', zone_name, record_name, typ)
+                        self.log.debug(
+                            'This entry is an Azure alias. Skipping. zone=%s record=%s, type=%s',
+                            zone_name, record_name, typ)
                         continue
 
                 data = getattr(self, '_data_for_{}'.format(typ))
@@ -436,7 +437,8 @@ class AzureProvider(BaseProvider):
         return exists
 
     def _check_for_alias(self, azrecord, typ):
-        if azrecord.target_resource.id and not azrecord.arecords and not azrecord.arecords and not azrecord.cname_record:
+        if (azrecord.target_resource.id and not azrecord.arecords
+                and not azrecord.arecords and not azrecord.cname_record):
             return True
         return False
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -420,7 +420,7 @@ class AzureProvider(BaseProvider):
                 if typ in ['A', 'CNAME']:
                     if self._check_for_alias(azrecord, typ):
                         self.log.debug(
-                            'This entry is an Azure alias. Skipping. zone=%s record=%s, type=%s',
+                            'Skipping - ALIAS. zone=%s record=%s, type=%s',
                             zone_name, record_name, typ)
                         continue
 
@@ -437,8 +437,8 @@ class AzureProvider(BaseProvider):
         return exists
 
     def _check_for_alias(self, azrecord, typ):
-        if (azrecord.target_resource.id and not azrecord.arecords
-                and not azrecord.arecords and not azrecord.cname_record):
+        if (azrecord.target_resource.id and not azrecord.arecords and not
+                azrecord.arecords and not azrecord.cname_record):
             return True
         return False
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -28,14 +28,13 @@ def unescape_semicolon(s):
     return s.replace('\\;', ';')
 
 
-
 def azure_chunked_value(val):
     CHUNK_SIZE = 255
     val_replace = val.replace('"', '\\"')
     value = unescape_semicolon(val_replace)
     if len(val) > CHUNK_SIZE:
         vs = [value[i:i + CHUNK_SIZE]
-                for i in range(0, len(value), CHUNK_SIZE)]
+              for i in range(0, len(value), CHUNK_SIZE)]
     else:
         vs = value
     return vs
@@ -46,6 +45,7 @@ def azure_chunked_values(s):
     for v in s:
         values.append(azure_chunked_value(v))
     return values
+
 
 class _AzureRecord(object):
     '''Wrapper for OctoDNS record for AzureProvider to make dns_client calls.
@@ -111,9 +111,6 @@ class _AzureRecord(object):
         self.params = getattr(self, '_params_for_{}'.format(record._type))
         self.params = self.params(record.data, key_name, azure_class)
         self.params['ttl'] = record.ttl
-
-
-        
 
     def _params_for_A(self, data, key_name, azure_class):
         try:
@@ -185,9 +182,8 @@ class _AzureRecord(object):
             values = [data['value']]
         return {key_name: [azure_class(ptrdname=v) for v in values]}
 
-
     def _params_for_TXT(self, data, key_name, azure_class):
-        
+
         params = []
         try:  # API for TxtRecord has list of str, even for singleton
             values = [v for v in azure_chunked_values(data['values'])]
@@ -200,7 +196,6 @@ class _AzureRecord(object):
             else:
                 params.append(azure_class(value=[v]))
         return {key_name: params}
-
 
     def _equals(self, b):
         '''Checks whether two records are equal by comparing all fields.

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -459,7 +459,7 @@ class TestAzureDnsProvider(TestCase):
         long_txt += " ip4:10.10.19.0/24 ip4:10.10.20.0/24  ~all"
         recordSet = RecordSet(txt_records=[TxtRecord(value='sample value1'),
                                            TxtRecord(value=long_txt)])
-        recordSet.name, recordSet.ttl, recordSet.type = 'txt2', 18, 'TXT'
+        recordSet.name, recordSet.ttl, recordSet.type = 'txt3', 18, 'TXT'
         recordSet.target_resource = SubResource()
         rs.append(recordSet)
 

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -13,7 +13,7 @@ from octodns.provider.base import Plan
 
 from azure.mgmt.dns.models import ARecord, AaaaRecord, CaaRecord, \
     CnameRecord, MxRecord, SrvRecord, NsRecord, PtrRecord, TxtRecord, \
-    RecordSet, SoaRecord, Zone as AzureZone
+    RecordSet, SoaRecord, SubResource, Zone as AzureZone
 from msrestazure.azure_exceptions import CloudError
 
 from unittest import TestCase
@@ -358,19 +358,23 @@ class TestAzureDnsProvider(TestCase):
         rs = []
         recordSet = RecordSet(arecords=[ARecord(ipv4_address='1.1.1.1')])
         recordSet.name, recordSet.ttl, recordSet.type = 'a1', 0, 'A'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         recordSet = RecordSet(arecords=[ARecord(ipv4_address='1.1.1.1'),
                                         ARecord(ipv4_address='2.2.2.2')])
         recordSet.name, recordSet.ttl, recordSet.type = 'a2', 1, 'A'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         aaaa1 = AaaaRecord(ipv6_address='1:1ec:1::1')
         recordSet = RecordSet(aaaa_records=[aaaa1])
         recordSet.name, recordSet.ttl, recordSet.type = 'aaaa1', 2, 'AAAA'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         aaaa2 = AaaaRecord(ipv6_address='1:1ec:1::2')
         recordSet = RecordSet(aaaa_records=[aaaa1,
                                             aaaa2])
         recordSet.name, recordSet.ttl, recordSet.type = 'aaaa2', 3, 'AAAA'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         recordSet = RecordSet(caa_records=[CaaRecord(flags=0,
                                                      tag='issue',
@@ -388,9 +392,11 @@ class TestAzureDnsProvider(TestCase):
         cname1 = CnameRecord(cname='cname.unit.test.')
         recordSet = RecordSet(cname_record=cname1)
         recordSet.name, recordSet.ttl, recordSet.type = 'cname1', 5, 'CNAME'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         recordSet = RecordSet(cname_record=None)
         recordSet.name, recordSet.ttl, recordSet.type = 'cname2', 6, 'CNAME'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         recordSet = RecordSet(mx_records=[MxRecord(preference=10,
                                                    exchange='mx1.unit.test.')])
@@ -434,10 +440,12 @@ class TestAzureDnsProvider(TestCase):
         rs.append(recordSet)
         recordSet = RecordSet(txt_records=[TxtRecord(value='sample text1')])
         recordSet.name, recordSet.ttl, recordSet.type = 'txt1', 15, 'TXT'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         recordSet = RecordSet(txt_records=[TxtRecord(value='sample text1'),
                                            TxtRecord(value='sample text2')])
         recordSet.name, recordSet.ttl, recordSet.type = 'txt2', 16, 'TXT'
+        recordSet.target_resource = SubResource()
         rs.append(recordSet)
         recordSet = RecordSet(soa_record=[SoaRecord()])
         recordSet.name, recordSet.ttl, recordSet.type = '', 17, 'SOA'

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -452,11 +452,11 @@ class TestAzureDnsProvider(TestCase):
         rs.append(recordSet)
         long_txt = "v=spf1 ip4:10.10.0.0/24 ip4:10.10.1.0/24 ip4:10.10.2.0/24"
         long_txt += " ip4:10.10.3.0/24 ip4:10.10.4.0/24 ip4:10.10.5.0/24 "
-        long_txt += " 10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 ip4:10.10.9.0/24"
+        long_txt += " 10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 "
         long_txt += " ip4:10.10.10.0/24 ip4:10.10.11.0/24 ip4:10.10.12.0/24"
         long_txt += " ip4:10.10.13.0/24 ip4:10.10.14.0/24 ip4:10.10.15.0/24"
         long_txt += " ip4:10.10.16.0/24 ip4:10.10.17.0/24 ip4:10.10.18.0/24"
-        long_txt += " ip4:10.10.19.0/24 ip4:10.10.20.0/24 ip4:10.10.21.0/24 ~all"
+        long_txt += " ip4:10.10.19.0/24 ip4:10.10.20.0/24  ~all"
         recordSet = RecordSet(txt_records=[TxtRecord(value='sample value1'),
                                            TxtRecord(value=long_txt)])
         recordSet.name, recordSet.ttl, recordSet.type = 'txt2', 18, 'TXT'

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -450,6 +450,18 @@ class TestAzureDnsProvider(TestCase):
         recordSet = RecordSet(soa_record=[SoaRecord()])
         recordSet.name, recordSet.ttl, recordSet.type = '', 17, 'SOA'
         rs.append(recordSet)
+        long_txt = "v=spf1 ip4:10.10.0.0/24 ip4:10.10.1.0/24 ip4:10.10.2.0/24"
+        long_txt += " ip4:10.10.3.0/24 ip4:10.10.4.0/24 ip4:10.10.5.0/24 "
+        long_txt += " 10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 ip4:10.10.9.0/24"
+        long_txt += " ip4:10.10.10.0/24 ip4:10.10.11.0/24 ip4:10.10.12.0/24"
+        long_txt += " ip4:10.10.13.0/24 ip4:10.10.14.0/24 ip4:10.10.15.0/24"
+        long_txt += " ip4:10.10.16.0/24 ip4:10.10.17.0/24 ip4:10.10.18.0/24"
+        long_txt += " ip4:10.10.19.0/24 ip4:10.10.20.0/24 ip4:10.10.21.0/24 ~all"
+        recordSet = RecordSet(txt_records=[TxtRecord(value='sample value1'),
+                                           TxtRecord(value=long_txt)])
+        recordSet.name, recordSet.ttl, recordSet.type = 'txt2', 18, 'TXT'
+        recordSet.target_resource = SubResource()
+        rs.append(recordSet)
 
         record_list = provider._dns_client.record_sets.list_by_dns_zone
         record_list.return_value = rs

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -469,7 +469,7 @@ class TestAzureDnsProvider(TestCase):
         exists = provider.populate(zone)
         self.assertTrue(exists)
 
-        self.assertEquals(len(zone.records), 18)
+        self.assertEquals(len(zone.records), 19)
 
     def test_populate_zone(self):
         provider = self._get_provider()


### PR DESCRIPTION
Current azuredns provider has two issues:

- When in the DNS is present A/CNAME ALIAS record pointing to Azure resource provider throws an error

`File "/home/piotrek/.cache/pypoetry/virtualenvs/octodns-py3.5/lib/python3.5/site-packages/octodns/provider/azuredns.py", line 402, in _data_for_A
    return {'values': [ar.ipv4_address for ar in azrecord.arecords]}
TypeError: 'NoneType' object is not iterable`

Here I've implemented a workaround that is checking if a record has id value pointing to other resources.
Additionally, when ALIAS is used eg. arecords is None

-  Too long TXT record - SFP. Records longer than 255 needs to be chunked  #361 

`https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/network/azure-mgmt-dns
msrestazure.azure_exceptions.CloudError: 400 Client Error: Bad Request for url: https://management.azure.com/subscriptions/xxxxx/resourceGroups/RESGRP-xxx/providers/Microsoft.Network/dnsZones/test123.com/TXT/@?api-version=2018-05-01`

I 've tested fix on several entries

Responses from the Azure DNS server
`testtxt1.test123.com descriptive text "singlevalue"

testtxt2.test123.com descriptive text "multi"
testtxt2.test123.com descriptive text "value"

testtxt3.test123.com descriptive text "single val as list"

testtxt4.test123.com descriptive text "MS=ms123456"
testtxt4.test123.com descriptive text "v=spf1 ip4:10.10.0.0/24 ip4:10.10.1.0/24 ip4:10.10.2.0/24 ip4:10.10.3.0/24 ip4:10.10.4.0/24 ip4:10.10.5.0/24 ip4:10.10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 ip4:10.10.9.0/24 ip4:10.10.10.0/24 ip4:10.10.11.0/24 ip4:10.10.12.0/24 ip4:10.10.13.0/24 ip4:10" ".10.14.0/24 ip4:10.10.15.0/24 ip4:10.10.16.0/24 ip4:10.10.17.0/24 ip4:10.10.18.0/24 ip4:10.10.19.0/24 ip4:10.10.20.0/24 ip4:10.10.21.0/24 ~all"

testtxt5.test123.com descriptive text "v=spf1 ip4:10.10.0.0/24 ip4:10.10.1.0/24 ip4:10.10.2.0/24 ip4:10.10.3.0/24 ip4:10.10.4.0/24 ip4:10.10.5.0/24 ip4:10.10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 ip4:10.10.9.0/24 ip4:10.10.10.0/24 ip4:10.10.11.0/24 ip4:10.10.12.0/24 ip4:10.10.13.0/24 ip4:10" ".10.14.0/24 ip4:10.10.15.0/24 ip4:10.10.16.0/24 ip4:10.10.17.0/24 ip4:10.10.18.0/24 ip4:10.10.19.0/24 ip4:10.10.20.0/24 ip4:10.10.21.0/24 ~all"`

`********************************************************************************
* test123.com.
********************************************************************************
* azuredns (AzureProvider)
*   Create <TxtRecord TXT 3600, testtxt1.test123.com., ['singlevalue']> (config)
*   Create <TxtRecord TXT 3600, testtxt2.test123.com., ['multi', 'value']> (config)
*   Create <TxtRecord TXT 3600, testtxt3.test123.com., ['single val as list']> (config)
*   Create <TxtRecord TXT 3600, testtxt4.test123.com., ['MS=ms123456', 'v=spf1 ip4:10.10.0.0/24 ip4:10.10.1.0/24 ip4:10.10.2.0/24 ip4:10.10.3.0/24 ip4:10.10.4.0/24 ip4:10.10.5.0/24 ip4:10.10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 ip4:10.10.9.0/24 ip4:10.10.10.0/24 ip4:10.10.11.0/24 ip4:10.10.12.0/24 ip4:10.10.13.0/24 ip4:10.10.14.0/24 ip4:10.10.15.0/24 ip4:10.10.16.0/24 ip4:10.10.17.0/24 ip4:10.10.18.0/24 ip4:10.10.19.0/24 ip4:10.10.20.0/24 ip4:10.10.21.0/24 ~all']> (config)
*   Create <TxtRecord TXT 3600, testtxt5.test123.com., ['v=spf1 ip4:10.10.0.0/24 ip4:10.10.1.0/24 ip4:10.10.2.0/24 ip4:10.10.3.0/24 ip4:10.10.4.0/24 ip4:10.10.5.0/24 ip4:10.10.6.0/24 ip4:10.10.7.0/24 ip4:10.10.8.0/24 ip4:10.10.9.0/24 ip4:10.10.10.0/24 ip4:10.10.11.0/24 ip4:10.10.12.0/24 ip4:10.10.13.0/24 ip4:10.10.14.0/24 ip4:10.10.15.0/24 ip4:10.10.16.0/24 ip4:10.10.17.0/24 ip4:10.10.18.0/24 ip4:10.10.19.0/24 ip4:10.10.20.0/24 ip4:10.10.21.0/24 ~all']> (config)
*   Summary: Creates=5, Updates=0, Deletes=0, Existing Records=8
********************************************************************************`


