### PR TITLE
Add support for wildcard SRV records, as shown in RFC 2782

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -1209,7 +1209,7 @@ class SrvValue(EqualityTupleMixin):
 class SrvRecord(_ValuesMixin, Record):
     _type = 'SRV'
     _value_type = SrvValue
-    _name_re = re.compile(r'^_[^\.]+\.[^\.]+')
+    _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
     @classmethod
     def validate(cls, name, fqdn, data):

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -2155,6 +2155,18 @@ class TestRecordValidation(TestCase):
             }
         })
 
+        # permit wildcard entries
+        Record.new(self.zone, '*._tcp', {
+            'type': 'SRV',
+            'ttl': 600,
+            'value': {
+                'priority': 1,
+                'weight': 2,
+                'port': 3,
+                'target': 'food.bar.baz.'
+            }
+        })
+
         # invalid name
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'neup', {


### PR DESCRIPTION
The regex for SRV records currently requires that SRV records be in the form _proto., which precludes wildcards. Given that the example shown in RFC 2782 expressly acknowledges the possible existence of wildcards, the regex has been updated here to support them, and the tests updated to test this case. 