### PR TITLE
Implement octodns-sync --source

### DIFF
--- a/octodns/cmds/sync.py
+++ b/octodns/cmds/sync.py
@@ -25,18 +25,19 @@ def main():
     parser.add_argument('zone', nargs='*', default=[],
                         help='Limit sync to the specified zone(s)')
 
-    # --sources isn't an option here b/c filtering sources out would be super
-    # dangerous since you could easily end up with an empty zone and delete
-    # everything, or even just part of things when there are multiple sources
-
+    parser.add_argument('--source', default=[], action='append',
+                        help='Limit sync to zones with the specified '
+                        'source(s) (all sources will be synchronized for the '
+                        'selected zones)')
     parser.add_argument('--target', default=[], action='append',
                         help='Limit sync to the specified target(s)')
 
     args = parser.parse_args()
 
     manager = Manager(args.config_file)
-    manager.sync(eligible_zones=args.zone, eligible_targets=args.target,
-                 dry_run=not args.doit, force=args.force)
+    manager.sync(eligible_zones=args.zone, eligible_sources=args.source,
+                 eligible_targets=args.target, dry_run=not args.doit,
+                 force=args.force)
 
 
 if __name__ == '__main__':

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -255,8 +255,8 @@ class Manager(object):
 
         return plans
 
-    def sync(self, eligible_zones=[], eligible_targets=[], dry_run=True,
-             force=False):
+    def sync(self, eligible_zones=[], eligible_sources=[], eligible_targets=[],
+             dry_run=True, force=False):
         self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
                       'dry_run=%s, force=%s', eligible_zones, eligible_targets,
                       dry_run, force)
@@ -280,6 +280,12 @@ class Manager(object):
             except KeyError:
                 raise ManagerException('Zone {} is missing targets'
                                        .format(zone_name))
+
+            if (eligible_sources and not
+                    [s for s in sources if s in eligible_sources]):
+                self.log.info('sync:   no eligible sources, skipping')
+                continue
+
             if eligible_targets:
                 targets = [t for t in targets if t in eligible_targets]
 

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -151,6 +151,14 @@ class TestManager(TestCase):
                 .sync(dry_run=False, force=True)
             self.assertEquals(25, tc)
 
+    def test_eligible_sources(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+            # Only allow a target that doesn't exist
+            tc = Manager(get_config_filename('simple.yaml')) \
+                .sync(eligible_sources=['foo'])
+            self.assertEquals(0, tc)
+
     def test_eligible_targets(self):
         with TemporaryDirectory() as tmpdir:
             environ['YAML_TMP_DIR'] = tmpdir.dirname


### PR DESCRIPTION
It can be useful to only synchronize zones that use a certain source. For example, in a situation where some zones use a dynamic source and others don't, you probably want to synchronize those with a dynamic source regularly, and only synchronize the others when a change is made.

Although we only synchronize the zones that use a given source, we still want to synchronize all sources to avoid deleting records that would live in another source of the zone.