### PR TITLE
Add CAA record support to AxfrSource/ZoneFileSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ The above command pulled the existing data out of Route53 and placed the results
 | [Selectel](/octodns/provider/selectel.py) | | A, AAAA, CNAME, MX, NS, SPF, SRV, TXT | No | |
 | [Transip](/octodns/provider/transip.py) | transip | A, AAAA, CNAME, MX, SRV, SPF, TXT, SSHFP, CAA | No | |
 | [UltraDns](/octodns/provider/ultra.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | |
-| [AxfrSource](/octodns/source/axfr.py) | | A, AAAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
-| [ZoneFileSource](/octodns/source/axfr.py) | | A, AAAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
+| [AxfrSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
+| [ZoneFileSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
 | [TinyDnsFileSource](/octodns/source/tinydns.py) | | A, CNAME, MX, NS, PTR | No | read-only |
 | [YamlProvider](/octodns/provider/yaml.py) | | All | Yes | config |
 

--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -26,7 +26,7 @@ class AxfrBaseSource(BaseSource):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
+    SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
                     'SRV', 'TXT'))
 
     def __init__(self, id):
@@ -42,6 +42,21 @@ class AxfrBaseSource(BaseSource):
     _data_for_A = _data_for_multiple
     _data_for_AAAA = _data_for_multiple
     _data_for_NS = _data_for_multiple
+
+    def _data_for_CAA(self, _type, records):
+        values = []
+        for record in records:
+            flags, tag, value = record['value'].split(' ', 2)
+            values.append({
+                'flags': flags,
+                'tag': tag,
+                'value': value.replace('"', '')
+            })
+        return {
+            'ttl': records[0]['ttl'],
+            'type': _type,
+            'values': values
+        }
 
     def _data_for_MX(self, _type, records):
         values = []

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -34,7 +34,7 @@ class TestAxfrSource(TestCase):
         ]
 
         self.source.populate(got)
-        self.assertEquals(11, len(got.records))
+        self.assertEquals(12, len(got.records))
 
         with self.assertRaises(AxfrSourceZoneTransferFailed) as ctx:
             zone = Zone('unit.tests.', [])
@@ -50,12 +50,12 @@ class TestZoneFileSource(TestCase):
         # Valid zone file in directory
         valid = Zone('unit.tests.', [])
         self.source.populate(valid)
-        self.assertEquals(11, len(valid.records))
+        self.assertEquals(12, len(valid.records))
 
         # 2nd populate does not read file again
         again = Zone('unit.tests.', [])
         self.source.populate(again)
-        self.assertEquals(11, len(again.records))
+        self.assertEquals(12, len(again.records))
 
         # bust the cache
         del self.source._zone_records[valid.name]

--- a/tests/zones/unit.tests.
+++ b/tests/zones/unit.tests.
@@ -13,6 +13,10 @@ $ORIGIN unit.tests.
 under       3600  IN  NS  ns1.unit.tests.
 under       3600  IN  NS  ns2.unit.tests.
 
+; CAA Records
+caa         1800  IN  CAA 0 issue "ca.unit.tests"
+caa         1800  IN  CAA 0 iodef "mailto:admin@unit.tests"
+
 ; SRV Records
 _srv._tcp   600   IN  SRV 10 20 30 foo-1.unit.tests.
 _srv._tcp   600   IN  SRV 10 20 30 foo-2.unit.tests.


### PR DESCRIPTION
Addresses #624

When originally created the AxfrSource/ZoneFileSource did not support CAA records. This change adds support for this record type

/cc @ConscriptMR 