### PR TITLE
PowerDNS: Support pre-release versions

### DIFF
--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -183,7 +183,8 @@ class PowerDnsBaseProvider(BaseProvider):
             version = resp.json()['version']
             self.log.debug('powerdns_version: got version %s from server',
                            version)
-            self._powerdns_version = [int(p) for p in version.split('.')]
+            self._powerdns_version = [
+                int(p.split('-')[0]) for p in version.split('.')[:3]]
 
         return self._powerdns_version
 

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -183,6 +183,8 @@ class PowerDnsBaseProvider(BaseProvider):
             version = resp.json()['version']
             self.log.debug('powerdns_version: got version %s from server',
                            version)
+            # The extra `-` split is to handle pre-release and source built 
+            # versions like 4.5.0-alpha0.435.master.gcb114252b
             self._powerdns_version = [
                 int(p.split('-')[0]) for p in version.split('.')[:3]]
 

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -183,7 +183,7 @@ class PowerDnsBaseProvider(BaseProvider):
             version = resp.json()['version']
             self.log.debug('powerdns_version: got version %s from server',
                            version)
-            # The extra `-` split is to handle pre-release and source built 
+            # The extra `-` split is to handle pre-release and source built
             # versions like 4.5.0-alpha0.435.master.gcb114252b
             self._powerdns_version = [
                 int(p.split('-')[0]) for p in version.split('.')[:3]]

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -82,6 +82,20 @@ class TestPowerDnsProvider(TestCase):
             provider._powerdns_version = None
             self.assertNotEquals(provider.powerdns_version, [4, 1, 10])
 
+        # Test version detection with pre-releases
+        with requests_mock() as mock:
+            # Reset version, so detection will try again
+            provider._powerdns_version = None
+            mock.get('http://non.existent:8081/api/v1/servers/localhost',
+                     status_code=200, json={'version': "4.4.0-alpha1"})
+            self.assertEquals(provider.powerdns_version, [4, 4, 0])
+
+            provider._powerdns_version = None
+            mock.get('http://non.existent:8081/api/v1/servers/localhost',
+                     status_code=200,
+                     json={'version': "4.5.0-alpha0.435.master.gcb114252b"})
+            self.assertEquals(provider.powerdns_version, [4, 5, 0])
+
     def test_provider_version_config(self):
         provider = PowerDnsProvider('test', 'non.existent', 'api-key',
                                     nameserver_values=['8.8.8.8.',


### PR DESCRIPTION
This commit strips any superfluous -alphaN (or beta or rc) from the
version number's minor number so it can be cast to an int. This will
allow octodns to sync to/from PowerDNS pre-releases.

Before, octodns would throw an exception like this:
```
Traceback (most recent call last):
  File "/usr/local/bin/octodns-sync", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/octodns/cmds/sync.py", line 40, in main
    force=args.force)
  File "/usr/local/lib/python3.6/site-packages/octodns/manager.py", line 369, in sync
    ps, d = future.result()
  File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/site-packages/octodns/manager.py", line 262, in _populate_and_plan
    plan = target.plan(zone)
  File "/usr/local/lib/python3.6/site-packages/octodns/provider/base.py", line 51, in plan
    exists = self.populate(existing, target=True, lenient=True)
  File "/usr/local/lib/python3.6/site-packages/octodns/provider/powerdns.py", line 222, in populate
    and self.check_status_not_found:
  File "/usr/local/lib/python3.6/site-packages/octodns/provider/powerdns.py", line 205, in check_status_not_found
    return self.powerdns_version >= [4, 2]
  File "/usr/local/lib/python3.6/site-packages/octodns/provider/powerdns.py", line 186, in powerdns_version
    self._powerdns_version = [int(p) for p in version.split('.')]
  File "/usr/local/lib/python3.6/site-packages/octodns/provider/powerdns.py", line 186, in <listcomp>
    self._powerdns_version = [int(p) for p in version.split('.')]
ValueError: invalid literal for int() with base 10: '0-alpha3'
```