### PR TITLE
Fix _is_valid_dkim_key for Python 3.9 compatibility in OVH provider

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.7]
+        python-version: [2.7, 3.7, 3.9]
     steps:
       - uses: actions/checkout@master
       - name: Setup python

--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -370,11 +370,16 @@ class OvhProvider(BaseProvider):
 
     @staticmethod
     def _is_valid_dkim_key(key):
+        result = True
         try:
-            base64.decodestring(bytearray(key, 'utf-8'))
+            decode = base64.decodestring
+        except AttributeError:
+            decode = base64.decodebytes
+        try:
+            result = decode(bytearray(key, 'utf-8'))
         except binascii.Error:
-            return False
-        return True
+            result = False
+        return result
 
     def get_records(self, zone_name):
         """

--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -371,12 +371,11 @@ class OvhProvider(BaseProvider):
     @staticmethod
     def _is_valid_dkim_key(key):
         result = True
+        base64_decode = getattr(base64, 'decodestring', None)
+        base64_decode = getattr(base64, 'decodebytes', base64_decode)
+
         try:
-            decode = base64.decodestring
-        except AttributeError:
-            decode = base64.decodebytes
-        try:
-            result = decode(bytearray(key, 'utf-8'))
+            result = base64_decode(bytearray(key, 'utf-8'))
         except binascii.Error:
             result = False
         return result


### PR DESCRIPTION
base64.decodestring was deprecated and removed in Python 3.9 in favour of
decodebytes (See https://bugs.python.org/issue39351 )