### PR TITLE
Also add Python v3.6, v3.8 on GitHub Actions for test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches, 
+        # with the addition of 2.7 b/c it's still if pretty wide active use.
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@master
       - name: Setup python


### PR DESCRIPTION
Unlike Python v2 as v2.7 is 10 years old, Python v3 has more versions
alive among us, it'll be great if the alive versions will all be tested.

I've tested on Python v3.6 & v3.8 locally and they both passed the tests.