### PR TITLE
v0.9.14 version bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.14 - 2021-??-?? - A new supports system
+## v0.9.14 - 2021-10-10 - A new supports system
 
 #### Noteworthy changes
 
@@ -24,6 +24,26 @@
 * TransipProvider removed as it currently relies on `suds` which is broken in
   new python versions and hasn't seen a release since 2010. May return with
   https://github.com/octodns/octodns/pull/762
+
+#### Stuff
+
+* Fully remove python 2.7 support & sims
+* Dynamic record pool status flag: up/down/obey added w/provider support as
+  possible.
+* Support for multi-value PTRs where providers allow them
+* Normalize IPv6 addresses to avoid false changes and simplify providers
+* Include pure-python wheel distirubtions in release builds
+* Improvements and updates to AzureProvider, especially w/respect to dynamic
+  records.
+* NS1Provider support for IPv6 monitors and general caching/performance
+  improvements
+* Route53Provider.get_zones_by_name option to avoid paging through huge lists
+  and hitting rate limits
+* Misc Route53Provider
+* Ensure no network access during testing (helps with runtime)
+* Sped up the long pole unit tests
+* Misc. ConstellixProvider, DigitalOceanProvider, GCoreProvider, and
+  Route53Provider fixes & improvements
 
 ## v0.9.13 - 2021-07-18 - Processors Alpha
 

--- a/README.md
+++ b/README.md
@@ -357,4 +357,4 @@ GitHub® and its stylized versions and the Invertocat mark are GitHub's Trademar
 
 ## Authors
 
-OctoDNS was designed and authored by [Ross McFarland](https://github.com/ross) and [Joe Williams](https://github.com/joewilliams). It is now maintained, reviewed, and tested by Traffic Engineering team at GitHub.
+OctoDNS was designed and authored by [Ross McFarland](https://github.com/ross) and [Joe Williams](https://github.com/joewilliams). See https://github.com/octodns/octodns/graphs/contributors for a complete list of people who've contributed.

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.13'
+__VERSION__ = '0.9.14'


### PR DESCRIPTION
## v0.9.14 - 2021-10-10 - A new supports system

#### Noteworthy changes

* Provider `strict_supports` param added, currently defaults to `false`, along
  with Provider._process_desired_zone this forms the foundations of a new
  "supports" system where providers will warn or error (depending on the value
  of `strict_supports`) during planning about their inability to do what
  they're being asked. When `false` they will warn and "adjust" the desired
  records. When true they will abort with an error indicating the problem. Over
  time it is expected that all "supports" checking/handling will move into this
  paradigm and `strict_supports` will likely be changed to default to `true`.
* Zone shallow copy support, reworking of Processors (alpha) semantics
* NS1 NA target now includes `SX` and `UM`. If `NA` continent is in use in
  dynamic records care must be taken to upgrade/downgrade to v0.9.13.
* Ns1Provider now supports a new parameter, shared_notifylist, which results in
  all dynamic record monitors using a shared notify list named 'octoDNS NS1
  Notify List'. Only newly created record values will use the shared notify
  list. It should be safe to enable this functionality, but existing records
  will not be converted. Note: Once this option is enabled downgrades to
  previous versions of octoDNS are discouraged and may result in undefined
  behavior and broken records. See https://github.com/octodns/octodns/pull/749
  for related discussion.
* TransipProvider removed as it currently relies on `suds` which is broken in
  new python versions and hasn't seen a release since 2010. May return with
  https://github.com/octodns/octodns/pull/762

#### Stuff

* Fully remove python 2.7 support & sims
* Dynamic record pool status flag: up/down/obey added w/provider support as
  possible.
* Support for multi-value PTRs where providers allow them
* Normalize IPv6 addresses to avoid false changes and simplify providers
* Include pure-python wheel distirubtions in release builds
* Improvements and updates to AzureProvider, especially w/respect to dynamic
  records.
* NS1Provider support for IPv6 monitors and general caching/performance
  improvements
* Route53Provider.get_zones_by_name option to avoid paging through huge lists
  and hitting rate limits
* Misc Route53Provider
* Ensure no network access during testing (helps with runtime)
* Sped up the long pole unit tests
* Misc. ConstellixProvider, DigitalOceanProvider, GCoreProvider, and
  Route53Provider fixes & improvements

/cc Fixes https://github.com/octodns/octodns/issues/789 @parkr