### PR TITLE
Bump upper limit on weights

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -557,7 +557,7 @@ class _DynamicMixin(object):
                     try:
                         weight = value['weight']
                         weight = int(weight)
-                        if weight < 1 or weight > 15:
+                        if weight < 1 or weight > 100:
                             reasons.append(f'invalid weight "{weight}" in '
                                            f'pool "{_id}" value {value_num}')
                     except KeyError:

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -3895,7 +3895,7 @@ class TestDynamicRecords(TestCase):
                             'weight': 1,
                             'value': '6.6.6.6',
                         }, {
-                            'weight': 16,
+                            'weight': 101,
                             'value': '7.7.7.7',
                         }],
                     },
@@ -3919,7 +3919,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['invalid weight "16" in pool "three" value 2'],
+        self.assertEquals(['invalid weight "101" in pool "three" value 2'],
                           ctx.exception.reasons)
 
         # invalid non-int weight


### PR DESCRIPTION
The current upper limit of 15 on weights prevent from small participants in pools. For eg, the lowest percent distribution I can have for a pool value is 6.25% (value1 at weight=1 and value2 at weight=15 equates to 6.25% responses with value1). Its nice to provide the ability to go lower than that. For eg, if I want to ramp a new endpoint and start with 1%, it is impossible with current weight boundaries.

Allowing 1-100 weights also makes it easier to use percentage values (1% ramp can be done with ramp=1 / control=99).

Provider support:
* NS1 doesn't have a documented limit that I could find, I was able to set a weight of 999999999.
* Route53 allows 0-255 https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-weighted-alias.html#rrsets-values-weighted-alias-weight
* Azure DNS allows 1-1000 https://docs.microsoft.com/en-us/azure/traffic-manager/traffic-manager-configure-weighted-routing-method#configure-the-weighted-traffic-routing-method
* Dyn's traffic director allows 1-255. Traffic manager OTOH can only do up to 15. But it shouldn't matter at this point? 
* EDIT: Constellix allows 1-1000000 https://api-docs.constellix.com/#11766a7d-5a3e-4e1e-b19f-1de40cff4095