### PR TITLE
Overwrite invalid NS1 dynamic records

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -576,7 +576,7 @@ class Ns1Provider(BaseProvider):
         if not self._notes_exist(record):
             self.log.warn('_data_for_dynamic: %s %s is missing the metadata '
                           'notes required to parse it, will attempt to '
-                          'overwrite the record')
+                          'overwrite the record', record['domain'], _type)
             return self._invalid_record(_type)
 
         # All regions (pools) will include the list of default values


### PR DESCRIPTION
Prevent octoDNS from aborting plan phase when it runs into an invalid/unparsable record, and instead treat it as an invalid record to let octoDNS overwrite it with proper filter configs and answer+region notes. This can happen if the record was created outside of octoDNS, by hand or with independent scripts.