### PR TITLE
Bkane/ns1 monitor tcp timeouts

### DIFF
--- a/docs/dynamic_records.md
+++ b/docs/dynamic_records.md
@@ -198,3 +198,20 @@ Sonar check regions (sonar_regions) possible values:
         - EUROPE
         sonar_type: TCP
 ```
+
+#### NS1 Health Check Options
+
+| Key  | Description | Default |
+|--|--|--|
+| connect_timeout | Timeout (in seconds) before we give up trying to connect | 2 |
+| response_timeout | Timeout (in seconds) after connecting to wait for output. | 10 |
+
+```yaml
+
+---
+  octodns:
+    ns1:
+      healthcheck:
+        connect_timeout: 2
+        response_timeout: 10
+```

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -1053,15 +1053,15 @@ class Ns1Provider(BaseProvider):
 
         return monitor_id, self._feed_create(monitor)
 
-    def _healthcheck_tcp_connect_timeout(self, record):
+    def _healthcheck_connect_timeout(self, record):
         return record._octodns.get('ns1', {}) \
             .get('healthcheck', {}) \
-            .get('tcp_connect_timeout', 2000)
+            .get('connect_timeout', 2)
 
-    def _healthcheck_tcp_response_timeout(self, record):
+    def _healthcheck_response_timeout(self, record):
         return record._octodns.get('ns1', {}) \
             .get('healthcheck', {}) \
-            .get('tcp_response_timeout', 10000)
+            .get('response_timeout', 10)
 
     def _monitor_gen(self, record, value):
         host = record.fqdn[:-1]
@@ -1075,11 +1075,15 @@ class Ns1Provider(BaseProvider):
             'active': True,
             'config': {
                 'connect_timeout':
-                    self._healthcheck_tcp_connect_timeout(record),
+                    # TCP monitors use milliseconds, so convert from
+                    # seconds to milliseconds
+                    self._healthcheck_connect_timeout(record) * 1000,
                 'host': value,
                 'port': record.healthcheck_port,
                 'response_timeout':
-                    self._healthcheck_tcp_response_timeout(record),
+                    # TCP monitors use milliseconds, so convert from
+                    # seconds to milliseconds
+                    self._healthcheck_response_timeout(record) * 1000,
                 'ssl': record.healthcheck_protocol == 'HTTPS',
             },
             'frequency': 60,

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -602,8 +602,8 @@ class TestNs1ProviderDynamic(TestCase):
                 },
                 'ns1': {
                     'healthcheck': {
-                        'tcp_connect_timeout': 5000,
-                        'tcp_response_timeout': 6000,
+                        'connect_timeout': 5,
+                        'response_timeout': 6,
                     },
                 },
             },
@@ -925,13 +925,13 @@ class TestNs1ProviderDynamic(TestCase):
         # No http response expected
         self.assertFalse('rules' in monitor)
 
-        record._octodns['ns1']['healthcheck']['tcp_connect_timeout'] = 1234
+        record._octodns['ns1']['healthcheck']['connect_timeout'] = 1
         monitor = provider._monitor_gen(record, value)
-        self.assertEquals(1234, monitor['config']['connect_timeout'])
+        self.assertEquals(1000, monitor['config']['connect_timeout'])
 
-        record._octodns['ns1']['healthcheck']['tcp_response_timeout'] = 5678
+        record._octodns['ns1']['healthcheck']['response_timeout'] = 2
         monitor = provider._monitor_gen(record, value)
-        self.assertEquals(5678, monitor['config']['response_timeout'])
+        self.assertEquals(2000, monitor['config']['response_timeout'])
 
     def test_monitor_gen_AAAA(self):
         provider = Ns1Provider('test', 'api-key')


### PR DESCRIPTION
Ok - it turns out there are a couple different types of NS1 monitor timeouts. Here are the descriptions for the TCP and HTTP/S ones (octoDNS doesn't expose NS1's other monitor types - DNS and ping).

```
$ cat ~/tmpjobtypes.json| gron | rg '(http|tcp).*timeout.desc'
json.http.config.connect_timeout.desc = "Timeout (in seconds) sending query to wait for output.";
json.http.config.idle_timeout.desc = "Timeout (in seconds) waiting for expected data before closing the connection.";
json.tcp.config.connect_timeout.desc = "Timeout (in ms) before we give up trying to connect.";
json.tcp.config.response_timeout.desc = "Timeout (in ms) after connecting to wait for output.";
```

This PR abstracts over these two options by offering one set - `connect_timeout` and `response_timeout` (each in seconds) for a more streamlined user experience. As NS1Provider creates HTTP timeouts by creating a TCP monitor and sending HTTP-formatted text over it, these timeouts ultimately become tcp timeouts.

This abstraction *does* mean that users are forced to use seconds for their TCP healthchecks when the underlying API offers milliseconds, and to be honest, I'm not sure if an HTTP `idle_timeout` * 1000 (to convert to ms) is equivalent to a TCP `response_timeout` in the NS1 internal infrastructure, but it's a reasonable guess :)

If you prefer, as an alternative to this PR, I can not abstract these timeouts and offer them more directly:

```yaml
    ns1:
      healthcheck:
        tcp_connect_timeout: 7000  # in milliseconds, only used when octodns.healthcheck.protocol is TCP
        tcp_response_timeout: 8000  # in milliseconds, only used when octodns.healthcheck.protocol is TCP
        http_connect_timeout: 7  # in seconds, only used when octodns.healthcheck.protocol is HTTP/S
        http_idle_timeout: 8  # in seconds, only used when octodns.healthcheck.protocol is HTTP/S
```

But, up to you. Do you prefer a simpler and less powerful user experience or a more complicated and more powerful user experience here?  CC @viranch and @meghashyamps - we've been chatting on our company Slack on the best way to do this  - they prefer the friendlier abstracted approach in this PR, I prefer the less friendly more powerful approach mentioned above. What do you think @ross ?