### PR TITLE
Fix logging issues in Manager

### DIFF
--- a/.changelog/bec5cc4923da4128b90cd6bc6d66af76.md
+++ b/.changelog/bec5cc4923da4128b90cd6bc6d66af76.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Fix logging issues in Manager: convert generator to list and correct log method prefix

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -570,7 +570,7 @@ class Manager(object):
         ]:
             return None
 
-        self.log.info('sync:     sources=%s', sources)
+        self.log.info('_get_sources:     sources=%s', sources)
 
         try:
             # rather than using a list comprehension, we break this loop
@@ -630,7 +630,7 @@ class Manager(object):
             self.log.info(
                 '_preprocess_zones: dynamic zone=%s, sources=%s',
                 name,
-                (s.id for s in found_sources),
+                list(s.id for s in found_sources),
             )
             candidates = set()
             for source in found_sources:


### PR DESCRIPTION
## Summary

Fixes two minor logging issues in octodns/manager.py:

* Converts generator expression to list in `_preprocess_zones` log statement (line 633) - ensures the sources are properly displayed in logs rather than showing a generator object
* Corrects log method prefix from `sync:` to `_get_sources:` (line 573) - makes it consistent with other log statements in the method

Cherry-picked applicable changes from c980220.