### PR TITLE
Pass at adding AI-assisted API documentation

### DIFF
--- a/.changelog/99fb6721f2d340ed933d7407c91622ca.md
+++ b/.changelog/99fb6721f2d340ed933d7407c91622ca.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Pass at adding AI-assisted API documentation

--- a/octodns/processor/base.py
+++ b/octodns/processor/base.py
@@ -4,93 +4,207 @@
 
 
 class ProcessorException(Exception):
+    '''
+    Exception raised when a processor encounters an error during processing.
+
+    A subclass of this exception can be raised by processors when they
+    encounter invalid configurations, unsupported operations, or other
+    processing errors.
+    '''
+
     pass
 
 
 class BaseProcessor(object):
+    '''
+    Base class for all octoDNS processors.
+
+    Processors provide hooks into the octoDNS sync process to modify zones and
+    records at various stages. They can be used to filter, transform, or
+    validate DNS records before planning and applying changes.
+
+    Processors are executed in the order they are configured and can modify:
+
+    - **Source zones** (after sources populate, before planning)
+    - **Target zones** (after target populates, before planning)
+    - **Source and target zones** (just before computing changes)
+    - **Plans** (after planning, before applying)
+
+    Subclasses should override one or more of the ``process_*`` methods to
+    implement custom processing logic.
+
+    Example usage::
+
+      processors:
+        my-processor:
+          class: my.custom.processor.MyProcessor
+          # processor-specific configuration
+
+      zones:
+        example.com.:
+          sources:
+            - config
+          processors:
+            - my-processor
+          targets:
+            - route53
+
+    See Also:
+        - :class:`octodns.processor.filter.TypeAllowlistFilter`
+        - :class:`octodns.processor.ownership.OwnershipProcessor`
+        - :class:`octodns.processor.acme.AcmeMangingProcessor`
+    '''
+
     def __init__(self, name):
+        '''
+        Initialize the processor.
+
+        :param name: Unique identifier for this processor instance. Used in
+                     logging and configuration references.
+        :type name: str
+
+        .. note::
+           The ``name`` parameter is deprecated and will be removed in
+           version 2.0. Use ``id`` instead.
+        '''
         # TODO: name is DEPRECATED, remove in 2.0
         self.id = self.name = name
 
     def process_source_zone(self, desired, sources):
         '''
+        Process the desired zone after all sources have populated.
+
         Called after all sources have completed populate. Provides an
-        opportunity for the processor to modify the desired `Zone` that targets
+        opportunity for the processor to modify the desired zone that targets
         will receive.
 
-        - Will see `desired` after any modifications done by
-          `Provider._process_desired_zone` and processors configured to run
-          before this one.
-        - May modify `desired` directly.
-        - Must return `desired` which will normally be the `desired` param.
-        - Must not modify records directly, `record.copy` should be called,
-          the results of which can be modified, and then `Zone.add_record` may
-          be used with `replace=True`.
-        - May call `Zone.remove_record` to remove records from `desired`.
-        - Sources may be empty, as will be the case for aliased zones.
+        :param desired: The desired zone state after all sources have populated.
+                        This zone will be used as the target state for planning.
+        :type desired: octodns.zone.Zone
+        :param sources: List of source providers that populated the zone. May be
+                        empty for aliased zones.
+        :type sources: list[octodns.provider.base.BaseProvider]
+
+        :return: The modified desired zone, typically the same object passed in.
+        :rtype: octodns.zone.Zone
+
+        .. important::
+           - Will see ``desired`` after any modifications done by
+             ``Provider._process_desired_zone`` and processors configured to run
+             before this one.
+           - May modify ``desired`` directly.
+           - Must return ``desired`` which will normally be the ``desired`` param.
+           - Must not modify records directly; ``record.copy`` should be called,
+             the results of which can be modified, and then ``Zone.add_record``
+             may be used with ``replace=True``.
+           - May call ``Zone.remove_record`` to remove records from ``desired``.
+           - Sources may be empty, as will be the case for aliased zones.
         '''
         return desired
 
     def process_target_zone(self, existing, target):
         '''
-        Called after a target has completed `populate`, before changes are
-        computed between `existing` and `desired`. This provides an opportunity
-        to modify the `existing` `Zone`.
+        Process the existing zone after the target has populated.
 
-        - Will see `existing` after any modifications done by processors
-          configured to run before this one.
-        - May modify `existing` directly.
-        - Must return `existing` which will normally be the `existing` param.
-        - Must not modify records directly, `record.copy` should be called,
-          the results of which can be modified, and then `Zone.add_record` may
-          be used with `replace=True`.
-        - May call `Zone.remove_record` to remove records from `existing`.
+        Called after a target has completed ``populate``, before changes are
+        computed between ``existing`` and ``desired``. This provides an
+        opportunity to modify the existing zone state.
+
+        :param existing: The current zone state from the target provider.
+        :type existing: octodns.zone.Zone
+        :param target: The target provider that populated the existing zone.
+        :type target: octodns.provider.base.BaseProvider
+
+        :return: The modified existing zone, typically the same object passed in.
+        :rtype: octodns.zone.Zone
+
+        .. important::
+           - Will see ``existing`` after any modifications done by processors
+             configured to run before this one.
+           - May modify ``existing`` directly.
+           - Must return ``existing`` which will normally be the ``existing`` param.
+           - Must not modify records directly; ``record.copy`` should be called,
+             the results of which can be modified, and then ``Zone.add_record``
+             may be used with ``replace=True``.
+           - May call ``Zone.remove_record`` to remove records from ``existing``.
         '''
         return existing
 
     def process_source_and_target_zones(self, desired, existing, target):
         '''
-        Called just prior to computing changes for ``target`` between
-        ``desired`` and `existing`. Provides an opportunity for the processor
-        to modify either the desired or existing ``Zone`` that will be used to
-        compute the changes and create the initial plan.
+        Process both desired and existing zones before computing changes.
 
-        - Will see ``desired`` after any modifications done by
-          ``Provider._process_desired_zone`` and all processors via
-          ``Processor.process_source_zone``
-        - Will see ``existing`` after any modifications done by all processors
-          via ``Processor.process_target_zone``
-        - Will see both ``desired`` and ``existing`` after any modifications
-          done by any processors configured to run before this one via
-          ``Processor.process_source_and_target_zones``.
-        - May modify ``desired`` directly.
-        - Must return ``desired`` which will normally be the ``desired`` param.
-        - May modify ``existing`` directly.
-        - Must return ``existing`` which will normally be the ``existing``
-          param.
-        - Must not modify records directly, ``record.copy`` should be called,
-          the results of which can be modified, and then ``Zone.add_record``
-          may be used with ``replace=True``.
-        - May call ``Zone.remove_record`` to remove records from ``desired``.
-        - May call ``Zone.remove_record`` to remove records from ``existing``.
+        Called just prior to computing changes for the target provider between
+        ``desired`` and ``existing``. Provides an opportunity for the processor
+        to modify either or both zones that will be used to compute the changes
+        and create the initial plan.
+
+        :param desired: The desired zone state after all source processing.
+        :type desired: octodns.zone.Zone
+        :param existing: The existing zone state after all target processing.
+        :type existing: octodns.zone.Zone
+        :param target: The target provider for which changes will be computed.
+        :type target: octodns.provider.base.BaseProvider
+
+        :return: A tuple of (desired, existing) zones, typically the same
+                 objects passed in.
+        :rtype: tuple[octodns.zone.Zone, octodns.zone.Zone]
+
+        .. important::
+           - Will see ``desired`` after any modifications done by
+             ``Provider._process_desired_zone`` and all processors via
+             ``Processor.process_source_zone``.
+           - Will see ``existing`` after any modifications done by all processors
+             via ``Processor.process_target_zone``.
+           - Will see both ``desired`` and ``existing`` after any modifications
+             done by any processors configured to run before this one via
+             ``Processor.process_source_and_target_zones``.
+           - May modify ``desired`` directly.
+           - Must return ``desired`` which will normally be the ``desired`` param.
+           - May modify ``existing`` directly.
+           - Must return ``existing`` which will normally be the ``existing``
+             param.
+           - Must not modify records directly; ``record.copy`` should be called,
+             the results of which can be modified, and then ``Zone.add_record``
+             may be used with ``replace=True``.
+           - May call ``Zone.remove_record`` to remove records from ``desired``.
+           - May call ``Zone.remove_record`` to remove records from ``existing``.
         '''
         return desired, existing
 
     def process_plan(self, plan, sources, target):
         '''
+        Process the plan after it has been computed.
+
         Called after the planning phase has completed. Provides an opportunity
-        for the processors to modify the plan thus changing the actions that
+        for the processor to modify the plan, thus changing the actions that
         will be displayed and potentially applied.
 
-        - `plan` may be None if no changes were detected, if so a `Plan` may
-          still be created and returned.
-        - May modify `plan.changes` directly or create a new `Plan`.
-        - Does not have to modify `plan.desired` and/or `plan.existing` to line
-          up with any modifications made to `plan.changes`.
-        - Should copy over `plan.exists`, `plan.update_pcent_threshold`, and
-          `plan.delete_pcent_threshold` when creating a new `Plan`.
-        - Must return a `Plan` which may be `plan` or can be a newly created
-          one `plan.desired` and `plan.existing` copied over as-is or modified.
+        :param plan: The computed plan containing the changes to be applied.
+                     May be None if no changes were detected.
+        :type plan: octodns.provider.plan.Plan or None
+        :param sources: List of source providers for this zone. May be empty
+                        for aliased zones.
+        :type sources: list[octodns.provider.base.BaseProvider]
+        :param target: The target provider for which the plan was created.
+        :type target: octodns.provider.base.BaseProvider
+
+        :return: The modified plan, which may be the same object passed in,
+                 a newly created Plan, or None if no changes are needed.
+        :rtype: octodns.provider.plan.Plan or None
+
+        .. important::
+           - ``plan`` may be None if no changes were detected; if so, a ``Plan``
+             may still be created and returned.
+           - May modify ``plan.changes`` directly or create a new ``Plan``.
+           - Does not have to modify ``plan.desired`` and/or ``plan.existing`` to
+             line up with any modifications made to ``plan.changes``.
+           - Should copy over ``plan.exists``, ``plan.update_pcent_threshold``,
+             and ``plan.delete_pcent_threshold`` when creating a new ``Plan``.
+           - Must return a ``Plan`` which may be ``plan`` or can be a newly
+             created one with ``plan.desired`` and ``plan.existing`` copied over
+             as-is or modified.
+           - Sources may be empty, as will be the case for aliased zones.
         '''
         # plan may be None if no changes were detected up until now, the
         # process may still create a plan.

--- a/octodns/source/base.py
+++ b/octodns/source/base.py
@@ -4,6 +4,48 @@
 
 
 class BaseSource(object):
+    '''
+    Base class for all octoDNS sources and providers.
+
+    Sources are responsible for loading DNS records from various backends into
+    octoDNS zones. They implement the ``populate`` method to read DNS data from
+    their respective data stores (YAML files, APIs, databases, etc.) and add
+    records to the provided zone.
+
+    Subclasses must define the following class attributes either statically or
+    prior to calling ``super().__init__``:
+
+    - **SUPPORTS**: Set of supported record types (e.g., ``{'A', 'AAAA', 'CNAME'}``)
+    - **SUPPORTS_GEO**: Boolean indicating if the source supports GeoDNS records
+    - **log**: Logger instance for the source
+
+    Optional class attributes:
+
+    - **SUPPORTS_MULTIVALUE_PTR**: Support for multiple PTR records (default: False)
+    - **SUPPORTS_POOL_VALUE_STATUS**: Support for pool value status flags (default: False)
+    - **SUPPORTS_ROOT_NS**: Support for root NS records (default: False)
+    - **SUPPORTS_DYNAMIC_SUBNETS**: Support for dynamic subnet-based routing (default: False)
+
+    Example usage::
+
+      sources:
+        config:
+          class: octodns.provider.yaml.YamlProvider
+          directory: ./config
+
+      zones:
+        example.com.:
+          sources:
+            - config
+          targets:
+            - route53
+
+    See Also:
+        - :class:`octodns.provider.yaml.YamlProvider`
+        - :class:`octodns.source.tinydns.TinyDnsFileSource`
+        - :class:`octodns.source.envvar.EnvVarSource`
+    '''
+
     SUPPORTS_MULTIVALUE_PTR = False
     SUPPORTS_POOL_VALUE_STATUS = False
     SUPPORTS_ROOT_NS = False
@@ -11,8 +53,15 @@ class BaseSource(object):
 
     def __init__(self, id):
         '''
-        :param id: unique identifier for the provider or source
+        Initialize the source.
+
+        :param id: Unique identifier for this source instance. Used in logging
+                   and configuration references.
         :type id: str
+
+        :raises NotImplementedError: If required class attributes (``log``,
+                                     ``SUPPORTS_GEO``, or ``SUPPORTS``) are not
+                                     defined in the subclass.
         '''
 
         self.id = id
@@ -31,29 +80,75 @@ class BaseSource(object):
 
     @property
     def SUPPORTS_DYNAMIC(self):
+        '''
+        Indicates whether this source supports dynamic records.
+
+        Dynamic records include advanced routing features like GeoDNS pools,
+        health checks, and weighted responses. Most sources do not support
+        dynamic records.
+
+        :return: True if dynamic records are supported, False otherwise.
+        :rtype: bool
+        '''
         return False
 
     def populate(self, zone, target=False, lenient=False):
         '''
-        Loads all records the provider knows about for the provided zone
+        Load DNS records from the source into the provided zone.
 
-        When `target` is True the populate call is being made to load the
-        current state of the provider.
+        This method is responsible for reading DNS data from the source's
+        backend and adding records to the zone using ``zone.add_record()``.
+        Subclasses must implement this method.
 
-        When `lenient` is True the populate call may skip record validation and
-        do a "best effort" load of data. That will allow through some common,
-        but not best practices stuff that we otherwise would reject. E.g. no
-        trailing . or missing escapes for ;.
+        :param zone: The zone to populate with records from this source.
+        :type zone: octodns.zone.Zone
+        :param target: If True, the populate call is loading the current state
+                       from a target provider (for comparison during sync). If
+                       False, loading desired state from a source.
+        :type target: bool
+        :param lenient: If True, skip strict record validation and do a "best
+                        effort" load of data. This allows some non-best-practice
+                        configurations through (e.g., missing trailing dots or
+                        unescaped semicolons).
+        :type lenient: bool
 
-        When target is True (loading current state) this method should return
-        True if the zone exists or False if it does not.
+        :return: When ``target`` is True (loading current state), should return
+                 True if the zone exists in the target or False if it does not.
+                 When ``target`` is False (loading desired state), return value
+                 is ignored and may be None.
+        :rtype: bool or None
+
+        :raises NotImplementedError: This base class method must be overridden
+                                     by subclasses.
+
+        .. important::
+           - Must use ``zone.add_record()`` to add records to the zone.
+           - Should not modify the zone name or other zone properties.
+           - When ``target=True``, must return a boolean indicating zone existence.
+           - When ``lenient=True``, should relax validation to handle common
+             non-standard configurations.
         '''
         raise NotImplementedError(
             'Abstract base class, populate method missing'
         )
 
     def supports(self, record):
+        '''
+        Check if this source supports the given record type.
+
+        :param record: The DNS record to check for support.
+        :type record: octodns.record.base.Record
+
+        :return: True if the record type is supported, False otherwise.
+        :rtype: bool
+        '''
         return record._type in self.SUPPORTS
 
     def __repr__(self):
+        '''
+        Return a string representation of this source.
+
+        :return: The class name of this source instance.
+        :rtype: str
+        '''
         return self.__class__.__name__


### PR DESCRIPTION
So far this is by FAR the best use of AI I've run across. It requires a pass through reading things over, but gets things pretty close to :ship:able on first try. I think having it do the zone-lifecycle doc first, which required a lot more back and forth/corrections, helped out with this stuff as it had more context on what it's documenting and how it all fits together. 