### PR TITLE
Version 1.15.0 bump & changelog update

### DIFF
--- a/.changelog/05f9b507087a4140932dd6a554c9d61d.md
+++ b/.changelog/05f9b507087a4140932dd6a554c9d61d.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-Add merge syntax support to !include tag, `<<: !include file.yaml`

--- a/.changelog/416cf8fe31c341adb1264feb7ef7be1e.md
+++ b/.changelog/416cf8fe31c341adb1264feb7ef7be1e.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Drop required sphinx version a bit to support 3.10

--- a/.changelog/45575dea1d2949f58fc7989a5a57d4b5.md
+++ b/.changelog/45575dea1d2949f58fc7989a5a57d4b5.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use WARNING instead of deprecated WARN, fix log level alignment

--- a/.changelog/7964691076224439b4c8b9bcef2e4bb6.md
+++ b/.changelog/7964691076224439b4c8b9bcef2e4bb6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Script to update .ci-config.json with current python versions

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/b146c7e36d3142c7ad5cac2518c43178.md
+++ b/.changelog/b146c7e36d3142c7ad5cac2518c43178.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/be3a5f7895c84e7a829da3e9d57f8f99.md
+++ b/.changelog/be3a5f7895c84e7a829da3e9d57f8f99.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Use dedicated Checksum logger so that checksum is visible in --quiet mode

--- a/.changelog/fbd3d292e2be485fb0e005d97b41c994.md
+++ b/.changelog/fbd3d292e2be485fb0e005d97b41c994.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.15.0 - 2025-11-23
+
+Minor:
+* Use dedicated Checksum logger so that checksum is visible in --quiet mode - [#1333](https://github.com/octodns/octodns/pull/1333)
+* Add merge syntax support to !include tag, `<<: !include file.yaml` - [#1315](https://github.com/octodns/octodns/pull/1315)
+
+Patch:
+* Use WARNING instead of deprecated WARN, fix log level alignment - [#1333](https://github.com/octodns/octodns/pull/1333)
+
 ## 1.14.0 - 2025-10-24
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.14.0'
+__version__ = __VERSION__ = '1.15.0'


### PR DESCRIPTION
## 1.15.0 - 2025-11-23

Minor:
* Use dedicated Checksum logger so that checksum is visible in --quiet mode - [#1333](https://github.com/octodns/octodns/pull/1333)
* Add merge syntax support to !include tag, `<<: !include file.yaml` - [#1315](https://github.com/octodns/octodns/pull/1315)

Patch:
* Use WARNING instead of deprecated WARN, fix log level alignment - [#1333](https://github.com/octodns/octodns/pull/1333)

