### PR TITLE
Add OPENPGPKEY record support (RFC 7929)

### DIFF
--- a/.changelog/ed5204479415488ca4adbcb7a1413942.md
+++ b/.changelog/ed5204479415488ca4adbcb7a1413942.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add OPENPGPKEY record support (RFC 7929)

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -19,6 +19,7 @@ from .loc import LocRecord, LocValue
 from .mx import MxRecord, MxValue
 from .naptr import NaptrRecord, NaptrValue
 from .ns import NsRecord, NsValue
+from .openpgpkey import OpenpgpkeyRecord, OpenpgpkeyValue
 from .ptr import PtrRecord, PtrValue
 from .rr import Rr, RrParseError
 from .spf import SpfRecord
@@ -61,6 +62,8 @@ NaptrRecord
 NaptrValue
 NsRecord
 NsValue
+OpenpgpkeyRecord
+OpenpgpkeyValue
 PtrRecord
 PtrValue
 Record

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -1,0 +1,46 @@
+#
+#
+#
+
+from .base import Record, ValuesMixin
+
+
+class OpenpgpkeyValue(str):
+    '''
+    OPENPGPKEY value - base64-encoded OpenPGP public key
+
+    RFC 7929 - DANE Bindings for OpenPGP
+    '''
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        # Strip whitespace that may appear in zone files (base64 data may be
+        # split across lines)
+        return value.replace(' ', '')
+
+    @classmethod
+    def validate(cls, data, _type):
+        if not data or all(not d for d in data):
+            return ['missing value(s)']
+        return []
+
+    @classmethod
+    def process(cls, values):
+        return [cls(v) for v in values]
+
+    @property
+    def rdata_text(self):
+        return self
+
+    def template(self, params):
+        if '{' not in self:
+            return self
+        return self.__class__(self.format(**params))
+
+
+class OpenpgpkeyRecord(ValuesMixin, Record):
+    _type = 'OPENPGPKEY'
+    _value_type = OpenpgpkeyValue
+
+
+Record.register_type(OpenpgpkeyRecord)

--- a/tests/test_octodns_record_openpgpkey.py
+++ b/tests/test_octodns_record_openpgpkey.py
@@ -1,0 +1,115 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from helpers import SimpleProvider
+
+from octodns.record import Record
+from octodns.record.exception import ValidationError
+from octodns.record.openpgpkey import OpenpgpkeyRecord, OpenpgpkeyValue
+from octodns.zone import Zone
+
+
+class TestRecordOpenpgpkey(TestCase):
+    zone = Zone('unit.tests.', [])
+
+    def test_openpgpkey(self):
+        a_values = ['mQINBF...base64...==', 'mQINBG...base64...==']
+        a_data = {'ttl': 30, 'values': a_values}
+        a = OpenpgpkeyRecord(self.zone, 'a', a_data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values, a.values)
+        self.assertEqual(a_data, a.data)
+
+        b_value = 'mQINBF...single...=='
+        b_data = {'ttl': 30, 'value': b_value}
+        b = OpenpgpkeyRecord(self.zone, 'b', b_data)
+        self.assertEqual([b_value], b.values)
+        self.assertEqual(b_data, b.data)
+
+    def test_openpgpkey_value_rdata_text(self):
+        # parse_rdata_text strips spaces (zone files may split base64)
+        self.assertEqual('abc123', OpenpgpkeyValue.parse_rdata_text('abc 123'))
+        self.assertEqual(
+            'abc123def', OpenpgpkeyValue.parse_rdata_text('abc 123 def')
+        )
+        self.assertEqual(
+            'nospaces', OpenpgpkeyValue.parse_rdata_text('nospaces')
+        )
+
+        zone = Zone('unit.tests.', [])
+        a = OpenpgpkeyRecord(
+            zone, 'a', {'ttl': 42, 'value': 'mQINBF...base64...=='}
+        )
+        self.assertEqual('mQINBF...base64...==', a.values[0].rdata_text)
+
+    def test_validation(self):
+        # doesn't blow up
+        Record.new(
+            self.zone,
+            '',
+            {
+                'type': 'OPENPGPKEY',
+                'ttl': 600,
+                'values': ['key1base64==', 'key2base64=='],
+            },
+        )
+
+        # single value works
+        Record.new(
+            self.zone,
+            '',
+            {'type': 'OPENPGPKEY', 'ttl': 600, 'value': 'keybase64=='},
+        )
+
+        # missing value
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {'type': 'OPENPGPKEY', 'ttl': 600})
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
+
+        # empty values list
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone, '', {'type': 'OPENPGPKEY', 'ttl': 600, 'values': []}
+            )
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
+
+    def test_changes(self):
+        target = SimpleProvider()
+
+        # test change detection - same record
+        a = OpenpgpkeyRecord(
+            self.zone, 'a', {'ttl': 30, 'value': 'mQINBF...base64...=='}
+        )
+        self.assertFalse(a.changes(a, target))
+
+        # different value
+        b = OpenpgpkeyRecord(
+            self.zone, 'a', {'ttl': 30, 'value': 'different...base64...=='}
+        )
+        self.assertTrue(a.changes(b, target))
+
+        # different ttl
+        c = OpenpgpkeyRecord(
+            self.zone, 'a', {'ttl': 60, 'value': 'mQINBF...base64...=='}
+        )
+        self.assertTrue(a.changes(c, target))
+
+
+class TestOpenpgpkeyValue(TestCase):
+
+    def test_template(self):
+        s = 'this.has.no.templating'
+        value = OpenpgpkeyValue(s)
+        got = value.template({'needle': 42})
+        self.assertIs(value, got)
+
+        s = 'this.does.{needle}.have.templating'
+        value = OpenpgpkeyValue(s)
+        got = value.template({'needle': 42})
+        self.assertIsNot(value, got)
+        self.assertEqual('this.does.42.have.templating', got)


### PR DESCRIPTION
## Summary
- Adds support for OPENPGPKEY DNS records as specified in RFC 7929
- Implements base64-encoded value type with whitespace stripping for zone file compatibility
- Supports both single and multiple values per record

Fixes #1346

## Test plan
- [x] New unit tests for record creation, validation, change detection, and templating
- [x] All 382 tests pass
- [x] 100% code coverage maintained