### PR TITLE
Add output_path parameter to plan output classes

### DIFF
--- a/.changelog/349c38308f6447868d49615d824e82c6.md
+++ b/.changelog/349c38308f6447868d49615d824e82c6.md
@@ -1,4 +1,4 @@
 ---
 type: minor
 ---
-Add output_path parameter to plan output classes for writing to individual files
+Add output_filename parameter to plan output classes for writing to individual files

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -436,62 +436,62 @@ class TestPlanSafety(TestCase):
         self.assertEqual(update.new.data, update_data['new'])
 
 
-class TestPlanOutputPath(TestCase):
-    def test_plan_json_output_path(self):
+class TestPlanOutputFilename(TestCase):
+    def test_plan_json_output_filename(self):
         with TemporaryDirectory() as tmpdir:
-            output_path = join(tmpdir, 'plan.json')
-            PlanJson('json', output_path=output_path).run(plans)
-            with open(output_path) as fh:
+            output_filename = join(tmpdir, 'plan.json')
+            PlanJson('json', output_filename=output_filename).run(plans)
+            with open(output_filename) as fh:
                 data = loads(fh.read())
             for key in ('test', 'unit.tests.', 'changes'):
                 self.assertTrue(key in data)
                 data = data[key]
             self.assertEqual(4, len(data))
 
-    def test_plan_markdown_output_path(self):
+    def test_plan_markdown_output_filename(self):
         with TemporaryDirectory() as tmpdir:
-            output_path = join(tmpdir, 'plan.md')
-            PlanMarkdown('markdown', output_path=output_path).run(plans)
-            with open(output_path) as fh:
+            output_filename = join(tmpdir, 'plan.md')
+            PlanMarkdown('markdown', output_filename=output_filename).run(plans)
+            with open(output_filename) as fh:
                 out = fh.read()
             self.assertTrue('## unit.tests.' in out)
             self.assertTrue('Create | b | CNAME | 60 | foo.unit.tests.' in out)
 
-    def test_plan_html_output_path(self):
+    def test_plan_html_output_filename(self):
         with TemporaryDirectory() as tmpdir:
-            output_path = join(tmpdir, 'plan.html')
-            PlanHtml('html', output_path=output_path).run(plans)
-            with open(output_path) as fh:
+            output_filename = join(tmpdir, 'plan.html')
+            PlanHtml('html', output_filename=output_filename).run(plans)
+            with open(output_filename) as fh:
                 out = fh.read()
             self.assertTrue(
                 '    <td colspan=6>Summary: Creates=2, Updates=1, Deletes=1, Existing=0, Meta=False</td>'
                 in out
             )
 
-    def test_plan_json_no_output_path(self):
+    def test_plan_json_no_output_filename(self):
         # Verify default behavior still works (writes to provided fh)
         out = StringIO()
-        PlanJson('json', output_path=None).run(plans, fh=out)
+        PlanJson('json', output_filename=None).run(plans, fh=out)
         data = loads(out.getvalue())
         for key in ('test', 'unit.tests.', 'changes'):
             self.assertTrue(key in data)
             data = data[key]
         self.assertEqual(4, len(data))
 
-    def test_plan_markdown_empty_output_path(self):
-        # Verify empty plans work with output_path
+    def test_plan_markdown_empty_output_filename(self):
+        # Verify empty plans work with output_filename
         with TemporaryDirectory() as tmpdir:
-            output_path = join(tmpdir, 'plan.md')
-            PlanMarkdown('markdown', output_path=output_path).run([])
-            with open(output_path) as fh:
+            output_filename = join(tmpdir, 'plan.md')
+            PlanMarkdown('markdown', output_filename=output_filename).run([])
+            with open(output_filename) as fh:
                 out = fh.read()
             self.assertEqual('## No changes were planned\n', out)
 
-    def test_plan_html_empty_output_path(self):
-        # Verify empty plans work with output_path
+    def test_plan_html_empty_output_filename(self):
+        # Verify empty plans work with output_filename
         with TemporaryDirectory() as tmpdir:
-            output_path = join(tmpdir, 'plan.html')
-            PlanHtml('html', output_path=output_path).run([])
-            with open(output_path) as fh:
+            output_filename = join(tmpdir, 'plan.html')
+            PlanHtml('html', output_filename=output_filename).run([])
+            with open(output_filename) as fh:
                 out = fh.read()
             self.assertEqual('<b>No changes were planned</b>', out)


### PR DESCRIPTION
## Summary

Adds an optional `output_path` parameter to `PlanJson`, `PlanMarkdown`, and `PlanHtml` classes that allows each plan output to write to its own file instead of all outputs going to the same file handle.

This addresses the feature request in #1340 where users want to output JSON plan to a file while still showing the logger output to stdout/stderr.

## Changes

- Added `output_path` parameter to `_PlanOutput` base class
- Added `_fh()` helper method that returns the appropriate file handle
- Updated `PlanJson`, `PlanMarkdown`, and `PlanHtml` to support `output_path`
- Added comprehensive tests for the new functionality
- 100% code coverage maintained

## Example Usage

```yaml
manager:
  plan_outputs:
    logger:
      class: 'octodns.provider.plan.PlanLogger'
      level: 'info'
    json:
      class: octodns.provider.plan.PlanJson
      output_path: /tmp/plan.json
      indent: 2
```

With this configuration, the logger output goes to stdout while the JSON output is written to `/tmp/plan.json`.

## Test plan

- [x] Added tests for `PlanJson` with `output_path`
- [x] Added tests for `PlanMarkdown` with `output_path`
- [x] Added tests for `PlanHtml` with `output_path`
- [x] Added tests for empty plans with `output_path`
- [x] Verified default behavior (no `output_path`) still works
- [x] All 388 tests pass
- [x] 100% code coverage maintained

Fixes #1340