### PR TITLE
Add SOA record support

### DIFF
--- a/.changelog/9aa4f11fb22745728912e874483dcb23.md
+++ b/.changelog/9aa4f11fb22745728912e874483dcb23.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add SOA record support

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -22,6 +22,7 @@ from .ns import NsRecord, NsValue
 from .openpgpkey import OpenpgpkeyRecord, OpenpgpkeyValue
 from .ptr import PtrRecord, PtrValue
 from .rr import Rr, RrParseError
+from .soa import SoaRecord, SoaValue
 from .spf import SpfRecord
 from .srv import SrvRecord, SrvValue
 from .sshfp import SshfpRecord, SshfpValue
@@ -70,6 +71,8 @@ Record
 RecordException
 Rr
 RrParseError
+SoaRecord
+SoaValue
 SpfRecord
 SrvRecord
 SrvValue

--- a/octodns/record/soa.py
+++ b/octodns/record/soa.py
@@ -1,0 +1,222 @@
+#
+#
+#
+
+
+from fqdn import FQDN
+
+from ..equality import EqualityTupleMixin
+from .base import Record, ValueMixin
+from .rr import RrParseError
+
+
+class SoaValue(EqualityTupleMixin, dict):
+    @classmethod
+    def parse_rdata_text(cls, value):
+        try:
+            mname, rname, serial, refresh, retry, expire, minimum = value.split(
+                ' '
+            )
+        except ValueError as ve:
+            raise RrParseError('Failed to split SOA rdata value: ' + str(ve))
+        if not FQDN(mname).is_valid:
+            raise RrParseError(f'Failed to parse mname {mname} as FQDN')
+        if not FQDN(rname).is_valid:
+            raise RrParseError(f'Failed to parse rname {rname} as FQDN')
+        try:
+            serial = int(serial)
+        except ValueError as ve:
+            raise RrParseError('Failed to parse serial: ' + str(ve))
+        try:
+            refresh = int(refresh)
+        except ValueError as ve:
+            raise RrParseError('Failed to parse refresh: ' + str(ve))
+        try:
+            retry = int(retry)
+        except ValueError as ve:
+            raise RrParseError('Failed to parse retry: ' + str(ve))
+        try:
+            expire = int(expire)
+        except ValueError as ve:
+            raise RrParseError('Failed to parse expire: ' + str(ve))
+        try:
+            minimum = int(minimum)
+        except ValueError as ve:
+            raise RrParseError('Failed to parse minimum: ' + str(ve))
+        return {
+            'mname': mname,
+            'rname': rname,
+            'serial': serial,
+            'refresh': refresh,
+            'retry': retry,
+            'expire': expire,
+            'minimum': minimum,
+        }
+
+    @classmethod
+    def validate(cls, data, _type):
+        reasons = []
+        try:
+            if not FQDN(data['mname']).is_valid:
+                reasons.append('invalid mname')
+        except KeyError:
+            reasons.append('missing mname')
+        try:
+            if not FQDN(data['rname']).is_valid:
+                reasons.append('invalid rname')
+        except KeyError:
+            reasons.append('missing rname')
+        try:
+            int(data['serial'])
+        except KeyError:
+            reasons.append('missing serial')
+        except ValueError:
+            reasons.append('invalid serial')
+        try:
+            int(data['refresh'])
+        except KeyError:
+            reasons.append('missing refresh')
+        except ValueError:
+            reasons.append('invalid refresh value')
+        try:
+            int(data['retry'])
+        except KeyError:
+            reasons.append('missing retry')
+        except ValueError:
+            reasons.append('invalid retry value')
+        try:
+            int(data['expire'])
+        except KeyError:
+            reasons.append('missing expire')
+        except ValueError:
+            reasons.append('invalid expire value')
+        try:
+            int(data['minimum'])
+        except KeyError:
+            reasons.append('missing minimum')
+        except ValueError:
+            reasons.append('invalid minimum value')
+
+        return reasons
+
+    @classmethod
+    def process(cls, value):
+        return cls(value)
+
+    def __init__(self, value):
+        super().__init__(
+            {
+                'mname': str(value['mname']),
+                'rname': str(value['rname']),
+                'serial': int(value['serial']),
+                'refresh': int(value['refresh']),
+                'retry': int(value['retry']),
+                'expire': int(value['expire']),
+                'minimum': int(value['minimum']),
+            }
+        )
+
+    @property
+    def mname(self):
+        return self['mname']
+
+    @mname.setter
+    def mname(self, value):
+        self['mname'] = value
+
+    @property
+    def rname(self):
+        return self['rname']
+
+    @rname.setter
+    def rname(self, value):
+        self['rname'] = value
+
+    @property
+    def serial(self):
+        return self['serial']
+
+    @serial.setter
+    def serial(self, value):
+        self['serial'] = value
+
+    @property
+    def refresh(self):
+        return self['refresh']
+
+    @refresh.setter
+    def refresh(self, value):
+        self['refresh'] = value
+
+    @property
+    def retry(self):
+        return self['retry']
+
+    @retry.setter
+    def retry(self, value):
+        self['retry'] = value
+
+    @property
+    def expire(self):
+        return self['expire']
+
+    @expire.setter
+    def expire(self, value):
+        self['expire'] = value
+
+    @property
+    def minimum(self):
+        return self['minimum']
+
+    @minimum.setter
+    def minimum(self, value):
+        self['minimum'] = value
+
+    @property
+    def data(self):
+        return self
+
+    @property
+    def rdata_text(self):
+        return f"{self.mname} {self.rname} {self.serial} {self.refresh} {self.retry} {self.expire} {self.minimum}"
+
+    def template(self, params):
+        if '{' not in self.mname + self.rname:
+            return self
+        new = self.__class__(self)
+        new.mname = new.mname.format(**params)
+        new.rname = new.rname.format(**params)
+        return new
+
+    def __hash__(self):
+        return hash(self.__repr__())
+
+    def _equality_tuple(self):
+        return (
+            self.mname,
+            self.rname,
+            self.serial,
+            self.refresh,
+            self.retry,
+            self.expire,
+            self.minimum,
+        )
+
+    def __repr__(self):
+        return f"'{self.rdata_text}'"
+
+
+class SoaRecord(ValueMixin, Record):
+    _type = 'SOA'
+    _value_type = SoaValue
+
+    @classmethod
+    def validate(cls, name, fqdn, data):
+        reasons = []
+        if name != '':
+            reasons.append('non-root SOA not allowed')
+        reasons.extend(super().validate(name, fqdn, data))
+        return reasons
+
+
+Record.register_type(SoaRecord)

--- a/tests/test_octodns_record_soa.py
+++ b/tests/test_octodns_record_soa.py
@@ -1,0 +1,321 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from helpers import SimpleProvider
+
+from octodns.record import Record
+from octodns.record.exception import ValidationError
+from octodns.record.rr import RrParseError
+from octodns.record.soa import SoaRecord, SoaValue
+from octodns.zone import Zone
+
+
+class TestSoaRecord(TestCase):
+    zone = Zone('unit.tests.', [])
+
+    def test_soa(self):
+        a_value = SoaValue(
+            {
+                'mname': 'ns0.unit.tests.',
+                'rname': 'hostmaster.unit.tests.',
+                'serial': 10,
+                'refresh': 86400,
+                'retry': 7200,
+                'expire': 2419200,
+                'minimum': 3600,
+            }
+        )
+        a_data = {'ttl': 3600, 'value': a_value}
+        a = SoaRecord(self.zone, '', a_data)
+        self.assertEqual('', a.name)
+        self.assertEqual('unit.tests.', a.fqdn)
+        self.assertEqual(3600, a.ttl)
+        self.assertEqual(a_value['mname'], a.value.mname)
+        self.assertEqual(a_value['rname'], a.value.rname)
+        self.assertEqual(a_value['serial'], a.value.serial)
+        self.assertEqual(a_value['refresh'], a.value.refresh)
+        self.assertEqual(a_value['retry'], a.value.retry)
+        self.assertEqual(a_value['expire'], a.value.expire)
+        self.assertEqual(a_value['minimum'], a.value.minimum)
+        self.assertEqual(a_data, a.data)
+
+        target = SimpleProvider()
+        # No changes with self
+        self.assertFalse(a.changes(a, target))
+
+        other = SoaRecord(self.zone, '', {'ttl': 3600, 'value': a_value})
+
+        # Diff in mname causes change
+        other.value.mname = 'ns1.unit.tests'
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.mname = a.value.mname
+
+        # Diff in rname causes change
+        other.value.rname = 'admin.unit.tests'
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.rname = a.value.rname
+
+        # Diff in serial causes change
+        other.value.serial += 1
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.serial = a.value.serial
+
+        # Diff in refresh causes change
+        other.value.refresh += 1
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.refresh = a.value.refresh
+
+        # Diff in retry causes change
+        other.value.retry += 1
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.retry = a.value.retry
+
+        # Diff in expire causes change
+        other.value.expire += 1
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.expire = a.value.expire
+
+        # Diff in minimum causes change
+        other.value.minimum += 1
+        change = a.changes(other, target)
+        self.assertEqual(change.existing, a)
+        self.assertEqual(change.new, other)
+        other.value.minimum = a.value.minimum
+
+        # __repr__ doesn't blow up
+        a.__repr__()
+
+    def test_soa_value_rdata_text(self):
+        # empty string won't parse
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('')
+
+        # invalid number of words won't parse, SOA needs 7
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('foo')
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('1 2')
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('1 2 3')
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('1 2 3 4')
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('1 2 3 4 5')
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('1 2 3 4 5 6')
+        with self.assertRaises(RrParseError):
+            SoaValue.parse_rdata_text('1 2 3 4 5 6 7 8')
+
+        # Incrementally check each field
+        with self.assertRaisesRegex(RrParseError, 'mname.*FQDN'):
+            SoaValue.parse_rdata_text('foo 2 3 4 5 6 7')
+        with self.assertRaisesRegex(RrParseError, 'rname.*FQDN'):
+            SoaValue.parse_rdata_text('ns0.unit.tests. 2 3 4 5 6 7')
+        with self.assertRaisesRegex(RrParseError, 'serial'):
+            SoaValue.parse_rdata_text(
+                'ns0.unit.tests. hostmaster.unit.tests. nope 4 5 6 7'
+            )
+        with self.assertRaisesRegex(RrParseError, 'refresh'):
+            SoaValue.parse_rdata_text(
+                'ns0.unit.tests. hostmaster.unit.tests. 3 nope 5 6 7'
+            )
+        with self.assertRaisesRegex(RrParseError, 'retry'):
+            SoaValue.parse_rdata_text(
+                'ns0.unit.tests. hostmaster.unit.tests. 3 4 nope 6 7'
+            )
+        with self.assertRaisesRegex(RrParseError, 'expire'):
+            SoaValue.parse_rdata_text(
+                'ns0.unit.tests. hostmaster.unit.tests. 3 4 5 nope 7'
+            )
+        with self.assertRaisesRegex(RrParseError, 'minimum'):
+            SoaValue.parse_rdata_text(
+                'ns0.unit.tests. hostmaster.unit.tests. 3 4 5 6 nope'
+            )
+
+        self.assertEqual(
+            {
+                'mname': 'ns0.unit.tests.',
+                'rname': 'hostmaster.unit.tests.',
+                'serial': 10,
+                'refresh': 86400,
+                'retry': 7200,
+                'expire': 2419200,
+                'minimum': 3600,
+            },
+            SoaValue.parse_rdata_text(
+                'ns0.unit.tests. hostmaster.unit.tests. 10 86400 7200 2419200 3600'
+            ),
+        )
+
+    def test_soa_value(self):
+        a = SoaValue(
+            {
+                'mname': 'ns0.unit.tests.',
+                'rname': 'hostmaster.unit.tests.',
+                'serial': 10,
+                'refresh': 86400,
+                'retry': 7200,
+                'expire': 2419200,
+                'minimum': 3600,
+            }
+        )
+        b = SoaValue(
+            {
+                'mname': 'ns0.test.units.',
+                'rname': 'hostmaster.test.units.',
+                'serial': 20,
+                'refresh': 186400,
+                'retry': 17200,
+                'expire': 12419200,
+                'minimum': 13600,
+            }
+        )
+
+        self.assertEqual(a, a)
+        self.assertEqual(b, b)
+
+        self.assertNotEqual(a, b)
+
+        # Hash
+        values = set()
+        values.add(a)
+        self.assertTrue(a in values)
+        self.assertFalse(b in values)
+        values.add(b)
+        self.assertTrue(b in values)
+
+    def test_validation(self):
+        Record.new(
+            self.zone,
+            '',
+            {
+                'type': 'SOA',
+                'ttl': 3600,
+                'value': {
+                    'mname': 'ns0.unit.tests.',
+                    'rname': 'hostmaster.unit.tests.',
+                    'serial': 10,
+                    'refresh': 86400,
+                    'retry': 7200,
+                    'expire': 2419200,
+                    'minimum': 3600,
+                },
+            },
+        )
+
+        # root only
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone,
+                'nope',
+                {
+                    'type': 'SOA',
+                    'ttl': 3600,
+                    'value': {
+                        'mname': 'ns0.unit.tests.',
+                        'rname': 'hostmaster.unit.tests.',
+                        'serial': 10,
+                        'refresh': 86400,
+                        'retry': 7200,
+                        'expire': 2419200,
+                        'minimum': 3600,
+                    },
+                },
+            )
+        self.assertEqual(['non-root SOA not allowed'], ctx.exception.reasons)
+
+        # missing everything
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, '', {'type': 'SOA', 'ttl': 3600, 'value': {}})
+        self.assertEqual(
+            [
+                'missing mname',
+                'missing rname',
+                'missing serial',
+                'missing refresh',
+                'missing retry',
+                'missing expire',
+                'missing minimum',
+            ],
+            ctx.exception.reasons,
+        )
+
+        # invalid values
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone,
+                '',
+                {
+                    'type': 'SOA',
+                    'ttl': 3600,
+                    'value': {
+                        'mname': 'a',
+                        'rname': 'b',
+                        'serial': 'c',
+                        'refresh': 'd',
+                        'retry': 'e',
+                        'expire': 'f',
+                        'minimum': 'g',
+                    },
+                },
+            )
+        self.assertEqual(
+            [
+                'invalid mname',
+                'invalid rname',
+                'invalid serial',
+                'invalid refresh value',
+                'invalid retry value',
+                'invalid expire value',
+                'invalid minimum value',
+            ],
+            ctx.exception.reasons,
+        )
+
+
+class TestSoaValue(TestCase):
+
+    def test_template(self):
+        value = SoaValue(
+            {
+                'mname': 'ns0.unit.tests.',
+                'rname': 'hostmaster.unit.tests.',
+                'serial': 10,
+                'refresh': 86400,
+                'retry': 7200,
+                'expire': 2419200,
+                'minimum': 3600,
+            }
+        )
+        got = value.template({'needle': 42})
+        self.assertIs(value, got)
+
+        value = SoaValue(
+            {
+                'mname': 'ns0.unit.tests.',
+                'rname': '{needle}.unit.tests.',
+                'serial': 10,
+                'refresh': 86400,
+                'retry': 7200,
+                'expire': 2419200,
+                'minimum': 3600,
+            }
+        )
+        got = value.template({'needle': 'hostmaster'})
+        self.assertIsNot(value, got)
+        self.assertEqual('hostmaster.unit.tests.', got.rname)


### PR DESCRIPTION
This more or less a resurrection of #45.

I have patches for octodns-bind and octodns-netbox-dns to add support there as well, but those are currently just in a "works on my machine" state. Nevertheless, I was already able to update a zone from netbox to both a zone file and a running bind.

I also intend to add support for pdns, if possible.

I have read #149 but I think it makes sense to add support. While some providers might not support management of SOA records, it's plain necessary for people self-hosting their infrastructure.