### PR TITLE
Replace assertTrue/assertFalse membership checks with assertIn/assertNotIn

### DIFF
--- a/.changelog/c5c036fe874045bc98c795564739c074.md
+++ b/.changelog/c5c036fe874045bc98c795564739c074.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Fix a few bugged assertTrue in tests, and convert all of them to assertIn's

--- a/tests/test_octodns_idna.py
+++ b/tests/test_octodns_idna.py
@@ -103,19 +103,19 @@ class TestIdnaDict(TestCase):
         self.assertEqual(45, d[idna_encode(self.almost)])
 
         # contains
-        self.assertTrue(self.plain in d)
-        self.assertTrue(self.almost in d)
-        self.assertTrue(idna_encode(self.almost) in d)
-        self.assertTrue(self.utf8 in d)
-        self.assertTrue(idna_encode(self.utf8) in d)
+        self.assertIn(self.plain, d)
+        self.assertIn(self.almost, d)
+        self.assertIn(idna_encode(self.almost), d)
+        self.assertIn(self.utf8, d)
+        self.assertIn(idna_encode(self.utf8), d)
 
         # we can delete with either form
         del d[self.almost]
-        self.assertFalse(self.almost in d)
-        self.assertFalse(idna_encode(self.almost) in d)
+        self.assertNotIn(self.almost, d)
+        self.assertNotIn(idna_encode(self.almost), d)
         del d[idna_encode(self.utf8)]
-        self.assertFalse(self.utf8 in d)
-        self.assertFalse(idna_encode(self.utf8) in d)
+        self.assertNotIn(self.utf8, d)
+        self.assertNotIn(idna_encode(self.utf8), d)
 
         # smoke test of repr
         d.__repr__()

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -51,87 +51,85 @@ class TestManager(TestCase):
     def test_missing_provider_class(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('missing-provider-class.yaml')).sync()
-        self.assertTrue('missing class' in str(ctx.exception))
+        self.assertIn('missing class', str(ctx.exception))
 
     def test_bad_provider_class(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('bad-provider-class.yaml')).sync()
-        self.assertTrue('Unknown provider class' in str(ctx.exception))
+        self.assertIn('Unknown provider class', str(ctx.exception))
 
     def test_bad_provider_class_module(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(
                 get_config_filename('bad-provider-class-module.yaml')
             ).sync()
-        self.assertTrue('Unknown provider class' in str(ctx.exception))
+        self.assertIn('Unknown provider class', str(ctx.exception))
 
     def test_bad_provider_class_no_module(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(
                 get_config_filename('bad-provider-class-no-module.yaml')
             ).sync()
-        self.assertTrue('Unknown provider class' in str(ctx.exception))
+        self.assertIn('Unknown provider class', str(ctx.exception))
 
     def test_missing_provider_config(self):
         # Missing provider config
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('missing-provider-config.yaml')).sync()
-        self.assertTrue('provider config' in str(ctx.exception))
+        self.assertIn('provider config', str(ctx.exception))
 
     def test_missing_env_config(self):
         # details of the EnvironSecrets will be tested in dedicated tests
         with self.assertRaises(EnvironSecretsException) as ctx:
             Manager(get_config_filename('missing-provider-env.yaml')).sync()
-        self.assertTrue('missing env var' in str(ctx.exception))
+        self.assertIn('missing env var', str(ctx.exception))
 
     def test_missing_source(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('provider-problems.yaml')).sync(
                 ['missing.sources.']
             )
-        self.assertTrue('missing sources' in str(ctx.exception))
+        self.assertIn('missing sources', str(ctx.exception))
 
     def test_missing_zone(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('dynamic-config.yaml')).sync(
                 ['missing.zones.']
             )
-        self.assertTrue('Requested zone ' in str(ctx.exception))
+        self.assertIn('Requested zone ', str(ctx.exception))
 
     def test_missing_targets(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('provider-problems.yaml')).sync(
                 ['missing.targets.']
             )
-        self.assertTrue('missing targets' in str(ctx.exception))
+        self.assertIn('missing targets', str(ctx.exception))
 
     def test_unknown_source(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('provider-problems.yaml')).sync(
                 ['unknown.source.']
             )
-        self.assertTrue('unknown source' in str(ctx.exception))
+        self.assertIn('unknown source', str(ctx.exception))
 
     def test_unknown_target(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('provider-problems.yaml')).sync(
                 ['unknown.target.']
             )
-        self.assertTrue('unknown target' in str(ctx.exception))
+        self.assertIn('unknown target', str(ctx.exception))
 
     def test_bad_plan_output_class(self):
         with self.assertRaises(ManagerException) as ctx:
             name = 'bad-plan-output-missing-class.yaml'
             Manager(get_config_filename(name)).sync()
-        self.assertTrue(
-            'plan_output bad is missing class' in str(ctx.exception)
-        )
+        self.assertIn('plan_output bad is missing class', str(ctx.exception))
 
     def test_bad_plan_output_config(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('bad-plan-output-config.yaml')).sync()
-        self.assertTrue(
-            'Incorrect plan_output config for bad' in str(ctx.exception)
+        self.assertIn(
+            'Incorrect plan_output config for bad', str(ctx.exception)
         )
 
     def test_source_only_as_a_target(self):
@@ -139,7 +137,7 @@ class TestManager(TestCase):
             Manager(get_config_filename('provider-problems.yaml')).sync(
                 ['not.targetable.']
             )
-        self.assertTrue('does not support targeting' in str(ctx.exception))
+        self.assertIn('does not support targeting', str(ctx.exception))
 
     def test_always_dry_run(self):
         with TemporaryDirectory() as tmpdir:
@@ -624,27 +622,27 @@ class TestManager(TestCase):
             Manager(
                 get_config_filename('missing-sources.yaml')
             ).validate_configs()
-        self.assertTrue('missing sources' in str(ctx.exception))
+        self.assertIn('missing sources', str(ctx.exception))
 
         with self.assertRaises(ManagerException) as ctx:
             Manager(
                 get_config_filename('unknown-provider.yaml')
             ).validate_configs()
-        self.assertTrue('unknown source' in str(ctx.exception))
+        self.assertIn('unknown source', str(ctx.exception))
 
         # Alias zone using an invalid source zone.
         with self.assertRaises(ManagerException) as ctx:
             Manager(
                 get_config_filename('unknown-source-zone.yaml')
             ).validate_configs()
-        self.assertTrue('does not exist' in str(ctx.exception))
+        self.assertIn('does not exist', str(ctx.exception))
 
         # Alias zone that points to another alias zone.
         with self.assertRaises(ManagerException) as ctx:
             Manager(
                 get_config_filename('alias-zone-loop.yaml')
             ).validate_configs()
-        self.assertTrue('is an alias zone' in str(ctx.exception))
+        self.assertIn('is an alias zone', str(ctx.exception))
 
         # Valid config file using an alias zone.
         Manager(
@@ -655,20 +653,20 @@ class TestManager(TestCase):
             Manager(
                 get_config_filename('unknown-processor.yaml')
             ).validate_configs()
-        self.assertTrue('unknown processor' in str(ctx.exception))
+        self.assertIn('unknown processor', str(ctx.exception))
 
     def test_get_zone(self):
         Manager(get_config_filename('simple.yaml')).get_zone('unit.tests.')
 
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('simple.yaml')).get_zone('unit.tests')
-        self.assertTrue('missing ending dot' in str(ctx.exception))
+        self.assertIn('missing ending dot', str(ctx.exception))
 
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('simple.yaml')).get_zone(
                 'unknown-zone.tests.'
             )
-        self.assertTrue('Unknown zone name' in str(ctx.exception))
+        self.assertIn('Unknown zone name', str(ctx.exception))
 
     def test_populate_lenient_fallback(self):
         with TemporaryDirectory() as tmpdir:
@@ -1187,7 +1185,7 @@ class TestManager(TestCase):
 
         with self.assertRaises(ManagerException) as ctx:
             manager.sync()
-        self.assertTrue('does not support `list_zones`' in str(ctx.exception))
+        self.assertIn('does not support `list_zones`', str(ctx.exception))
 
     def test_build_kwargs(self):
         manager = Manager(get_config_filename('simple.yaml'))
@@ -1325,14 +1323,14 @@ class TestManager(TestCase):
         manager = Manager(get_config_filename('secrets.yaml'))
 
         # dummy was configured
-        self.assertTrue('dummy' in manager.secret_handlers)
+        self.assertIn('dummy', manager.secret_handlers)
         dummy = manager.secret_handlers['dummy']
         self.assertIsInstance(dummy, DummySecrets)
         # and has the prefix value explicitly stated in the yaml
         self.assertEqual('in_config/hello', dummy.fetch('hello', None))
 
         # requires-env was configured
-        self.assertTrue('requires-env' in manager.secret_handlers)
+        self.assertIn('requires-env', manager.secret_handlers)
         requires_env = manager.secret_handlers['requires-env']
         self.assertIsInstance(requires_env, DummySecrets)
         # and successfully pulled a value from env as its prefix
@@ -1341,7 +1339,7 @@ class TestManager(TestCase):
         )
 
         # requires-dummy was created
-        self.assertTrue('requires-dummy' in manager.secret_handlers)
+        self.assertIn('requires-dummy', manager.secret_handlers)
         requires_dummy = manager.secret_handlers['requires-dummy']
         self.assertIsInstance(requires_dummy, DummySecrets)
         # but failed to fetch a secret from dummy so we just get the configured

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -137,7 +137,7 @@ class TestPlanJson(TestCase):
         PlanJson('json').run(plans, fh=out)
         data = loads(out.getvalue())
         for key in ('test', 'unit.tests.', 'changes'):
-            self.assertTrue(key in data)
+            self.assertIn(key, data)
             data = data[key]
         self.assertEqual(4, len(data))
 
@@ -154,11 +154,11 @@ class TestPlanMarkdown(TestCase):
         out = StringIO()
         PlanMarkdown('markdown').run(plans, fh=out)
         out = out.getvalue()
-        self.assertTrue('## unit.tests.' in out)
-        self.assertTrue('Create | b | CNAME | 60 | foo.unit.tests.' in out)
-        self.assertTrue('Update | a | A | 300 | 1.1.1.1;' in out)
-        self.assertTrue('NA-US: 6.6.6.6 | test' in out)
-        self.assertTrue('Delete | a | A | 300 | 2.2.2.2;' in out)
+        self.assertIn('## unit.tests.', out)
+        self.assertIn('Create | b | CNAME | 60 | foo.unit.tests.', out)
+        self.assertIn('Update | a | A | 300 | 1.1.1.1;', out)
+        self.assertIn('NA-US: 6.6.6.6 | test', out)
+        self.assertIn('Delete | a | A | 300 | 2.2.2.2;', out)
 
 
 class HelperPlan(Plan):
@@ -444,7 +444,7 @@ class TestPlanOutputFilename(TestCase):
             with open(output_filename) as fh:
                 data = loads(fh.read())
             for key in ('test', 'unit.tests.', 'changes'):
-                self.assertTrue(key in data)
+                self.assertIn(key, data)
                 data = data[key]
             self.assertEqual(4, len(data))
 
@@ -454,8 +454,8 @@ class TestPlanOutputFilename(TestCase):
             PlanMarkdown('markdown', output_filename=output_filename).run(plans)
             with open(output_filename) as fh:
                 out = fh.read()
-            self.assertTrue('## unit.tests.' in out)
-            self.assertTrue('Create | b | CNAME | 60 | foo.unit.tests.' in out)
+            self.assertIn('## unit.tests.', out)
+            self.assertIn('Create | b | CNAME | 60 | foo.unit.tests.', out)
 
     def test_plan_html_output_filename(self):
         with TemporaryDirectory() as tmpdir:
@@ -463,9 +463,9 @@ class TestPlanOutputFilename(TestCase):
             PlanHtml('html', output_filename=output_filename).run(plans)
             with open(output_filename) as fh:
                 out = fh.read()
-            self.assertTrue(
-                '    <td colspan=6>Summary: Creates=2, Updates=1, Deletes=1, Existing=0, Meta=False</td>'
-                in out
+            self.assertIn(
+                '    <td colspan=6>Summary: Creates=2, Updates=1, Deletes=1, Existing=0, Meta=False</td>',
+                out,
             )
 
     def test_plan_json_no_output_filename(self):
@@ -474,7 +474,7 @@ class TestPlanOutputFilename(TestCase):
         PlanJson('json', output_filename=None).run(plans, fh=out)
         data = loads(out.getvalue())
         for key in ('test', 'unit.tests.', 'changes'):
-            self.assertTrue(key in data)
+            self.assertIn(key, data)
             data = data[key]
         self.assertEqual(4, len(data))
 

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -456,9 +456,9 @@ class TestBaseProvider(TestCase):
         self.assertNotEqual('two', dynamic.rules[0].data['pool'])
         self.assertEqual(2, len(dynamic.rules))
         # subnets are dropped from subnet+geo rule
-        self.assertFalse('subnets' in dynamic.rules[0].data)
+        self.assertNotIn('subnets', dynamic.rules[0].data)
         # unused pool is dropped
-        self.assertFalse('two' in record2.dynamic.pools)
+        self.assertNotIn('two', record2.dynamic.pools)
 
         # SUPPORTS_ROOT_NS
         provider.SUPPORTS_ROOT_NS = False
@@ -568,7 +568,7 @@ class TestBaseProvider(TestCase):
         with self.assertRaises(UnsafePlan) as ctx:
             Plan(zone, zone, changes, True).raise_if_unsafe()
 
-        self.assertTrue('Too many updates' in str(ctx.exception))
+        self.assertIn('Too many updates', str(ctx.exception))
 
     def test_safe_updates_min_existing_pcent(self):
         # MAX_SAFE_UPDATE_PCENT is safe when more
@@ -618,7 +618,7 @@ class TestBaseProvider(TestCase):
         with self.assertRaises(UnsafePlan) as ctx:
             Plan(zone, zone, changes, True).raise_if_unsafe()
 
-        self.assertTrue('Too many deletes' in str(ctx.exception))
+        self.assertIn('Too many deletes', str(ctx.exception))
 
     def test_safe_deletes_min_existing_pcent(self):
         # MAX_SAFE_DELETE_PCENT is safe when more
@@ -669,7 +669,7 @@ class TestBaseProvider(TestCase):
                 zone, zone, changes, True, update_pcent_threshold=safe_pcent
             ).raise_if_unsafe()
 
-        self.assertTrue('Too many updates' in str(ctx.exception))
+        self.assertIn('Too many updates', str(ctx.exception))
 
     def test_safe_deletes_min_existing_override(self):
         safe_pcent = 0.4
@@ -697,7 +697,7 @@ class TestBaseProvider(TestCase):
                 zone, zone, changes, True, delete_pcent_threshold=safe_pcent
             ).raise_if_unsafe()
 
-        self.assertTrue('Too many deletes' in str(ctx.exception))
+        self.assertIn('Too many deletes', str(ctx.exception))
 
     def test_root_ns_warnings(self):
         class PopulateProvider(HelperProvider):

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -106,32 +106,32 @@ class TestYamlProvider(TestCase):
 
                 # '' has some of both
                 roots = sorted(data.pop(''), key=lambda r: r['type'])
-                self.assertTrue('values' in roots[0])  # A
-                self.assertTrue('geo' in roots[0])  # geo made the trip
-                self.assertTrue('value' in roots[1])  # CAA
-                self.assertTrue('values' in roots[2])  # SSHFP
+                self.assertIn('values', roots[0])  # A
+                self.assertIn('geo', roots[0])  # geo made the trip
+                self.assertIn('value', roots[1])  # CAA
+                self.assertIn('values', roots[2])  # SSHFP
 
                 # these are stored as plural 'values'
-                self.assertTrue('values' in data.pop('_srv._tcp'))
-                self.assertTrue('values' in data.pop('mx'))
-                self.assertTrue('values' in data.pop('naptr'))
-                self.assertTrue('values' in data.pop('sub'))
-                self.assertTrue('values' in data.pop('txt'))
-                self.assertTrue('values' in data.pop('loc'))
-                self.assertTrue('values' in data.pop('urlfwd'))
-                self.assertTrue('values' in data.pop('sub.txt'))
-                self.assertTrue('values' in data.pop('subzone'))
+                self.assertIn('values', data.pop('_srv._tcp'))
+                self.assertIn('values', data.pop('mx'))
+                self.assertIn('values', data.pop('naptr'))
+                self.assertIn('values', data.pop('sub'))
+                self.assertIn('values', data.pop('txt'))
+                self.assertIn('values', data.pop('loc'))
+                self.assertIn('values', data.pop('urlfwd'))
+                self.assertIn('values', data.pop('sub.txt'))
+                self.assertIn('values', data.pop('subzone'))
                 # these are stored as singular 'value'
-                self.assertTrue('value' in data.pop('_imap._tcp'))
-                self.assertTrue('value' in data.pop('_pop3._tcp'))
-                self.assertTrue('value' in data.pop('aaaa'))
-                self.assertTrue('value' in data.pop('cname'))
-                self.assertTrue('value' in data.pop('dname'))
-                self.assertTrue('value' in data.pop('included'))
-                self.assertTrue('value' in data.pop('ptr'))
-                self.assertTrue('value' in data.pop('spf'))
-                self.assertTrue('value' in data.pop('www'))
-                self.assertTrue('value' in data.pop('www.sub'))
+                self.assertIn('value', data.pop('_imap._tcp'))
+                self.assertIn('value', data.pop('_pop3._tcp'))
+                self.assertIn('value', data.pop('aaaa'))
+                self.assertIn('value', data.pop('cname'))
+                self.assertIn('value', data.pop('dname'))
+                self.assertIn('value', data.pop('included'))
+                self.assertIn('value', data.pop('ptr'))
+                self.assertIn('value', data.pop('spf'))
+                self.assertIn('value', data.pop('www'))
+                self.assertIn('value', data.pop('www.sub'))
 
                 # make sure nothing is left
                 self.assertEqual([], list(data.keys()))
@@ -141,29 +141,29 @@ class TestYamlProvider(TestCase):
 
                 # make sure dynamic records made the trip
                 dyna = data.pop('a')
-                self.assertTrue('values' in dyna)
-                self.assertTrue('dynamic' in dyna)
+                self.assertIn('values', dyna)
+                self.assertIn('dynamic', dyna)
 
                 # make sure dynamic records made the trip
                 dyna = data.pop('aaaa')
-                self.assertTrue('values' in dyna)
-                self.assertTrue('dynamic' in dyna)
+                self.assertIn('values', dyna)
+                self.assertIn('dynamic', dyna)
 
                 dyna = data.pop('cname')
-                self.assertTrue('value' in dyna)
-                self.assertTrue('dynamic' in dyna)
+                self.assertIn('value', dyna)
+                self.assertIn('dynamic', dyna)
 
                 dyna = data.pop('real-ish-a')
-                self.assertTrue('values' in dyna)
-                self.assertTrue('dynamic' in dyna)
+                self.assertIn('values', dyna)
+                self.assertIn('dynamic', dyna)
 
                 dyna = data.pop('simple-weighted')
-                self.assertTrue('value' in dyna)
-                self.assertTrue('dynamic' in dyna)
+                self.assertIn('value', dyna)
+                self.assertIn('dynamic', dyna)
 
                 dyna = data.pop('pool-only-in-fallback')
-                self.assertTrue('value' in dyna)
-                self.assertTrue('dynamic' in dyna)
+                self.assertIn('value', dyna)
+                self.assertIn('dynamic', dyna)
 
                 # make sure nothing is left
                 self.assertEqual([], list(data.keys()))
@@ -219,8 +219,8 @@ xn--dj-kia8a:
             with open(join(td.dirname, filename), 'r') as fh:
                 content = fh.read()
                 # verify that the non-ascii records were written out in utf-8
-                self.assertTrue('déjà:' in content)
-                self.assertTrue('これはテストです:' in content)
+                self.assertIn('déjà:', content)
+                self.assertIn('これはテストです:', content)
 
             # recreate the idna version of the file
             with open(idna_filename, 'w') as fh:
@@ -229,7 +229,7 @@ xn--dj-kia8a:
             with self.assertRaises(ProviderException) as ctx:
                 provider.populate(zone)
             msg = str(ctx.exception)
-            self.assertTrue('Both UTF-8' in msg)
+            self.assertIn('Both UTF-8', msg)
 
     def test_empty(self):
         source = YamlProvider(
@@ -350,11 +350,11 @@ www:
             _value_type = NsValue
 
         # don't know anything about a yaml type
-        self.assertTrue('YAML' not in source.SUPPORTS)
+        self.assertNotIn('YAML', source.SUPPORTS)
         # register it
         Record.register_type(YamlRecord)
         # when asked again we'll now include it in our list of supports
-        self.assertTrue('YAML' in source.SUPPORTS)
+        self.assertIn('YAML', source.SUPPORTS)
 
     def test_supports(self):
         source = YamlProvider('test', join(dirname(__file__), 'config'))
@@ -499,7 +499,7 @@ www:
             with self.assertRaises(ProviderException) as ctx:
                 list(provider._split_sources(zone))
             msg = str(ctx.exception)
-            self.assertTrue('Both UTF-8' in msg)
+            self.assertIn('Both UTF-8', msg)
 
             # delete the utf8 version
             rmtree(zone_utf8)
@@ -526,7 +526,7 @@ www:
             with self.assertRaises(ProviderException) as ctx:
                 provider._zone_sources(zone)
             msg = str(ctx.exception)
-            self.assertTrue('Both UTF-8' in msg)
+            self.assertIn('Both UTF-8', msg)
 
             # delete the utf8 version
             remove(utf8)
@@ -577,11 +577,11 @@ www:
 
             with open(yaml_file) as fh:
                 content = fh.read()
-            self.assertTrue('value: This has a semi-colon; that' in content)
-            self.assertTrue(
-                "- This has a semi-colon too; that isn't escaped." in content
+            self.assertIn('value: This has a semi-colon; that', content)
+            self.assertIn(
+                "- This has a semi-colon too; that isn't escaped.", content
             )
-            self.assertTrue('- ;' in content)
+            self.assertIn('- ;', content)
 
 
 class TestSplitYamlProvider(TestCase):
@@ -718,10 +718,10 @@ class TestSplitYamlProvider(TestCase):
             with open(yaml_file) as fh:
                 data = safe_load(fh.read())
                 roots = sorted(data.pop(''), key=lambda r: r['type'])
-                self.assertTrue('values' in roots[0])  # A
-                self.assertTrue('geo' in roots[0])  # geo made the trip
-                self.assertTrue('value' in roots[1])  # CAA
-                self.assertTrue('values' in roots[2])  # SSHFP
+                self.assertIn('values', roots[0])  # A
+                self.assertIn('geo', roots[0])  # geo made the trip
+                self.assertIn('value', roots[1])  # CAA
+                self.assertIn('values', roots[2])  # SSHFP
 
             # These records are stored as plural "values." Check each file to
             # ensure correctness.
@@ -737,7 +737,7 @@ class TestSplitYamlProvider(TestCase):
                 self.assertTrue(isfile(yaml_file))
                 with open(yaml_file) as fh:
                     data = safe_load(fh.read())
-                    self.assertTrue('values' in data.pop(record_name))
+                    self.assertIn('values', data.pop(record_name))
 
             # These are stored as singular "value." Again, check each file.
             for record_name in (
@@ -754,7 +754,7 @@ class TestSplitYamlProvider(TestCase):
                 self.assertTrue(isfile(yaml_file))
                 with open(yaml_file) as fh:
                     data = safe_load(fh.read())
-                    self.assertTrue('value' in data.pop(record_name))
+                    self.assertIn('value', data.pop(record_name))
 
             # Again with the plural, this time checking dynamic.tests.
             for record_name in ('a', 'aaaa', 'real-ish-a'):
@@ -763,8 +763,8 @@ class TestSplitYamlProvider(TestCase):
                 with open(yaml_file) as fh:
                     data = safe_load(fh.read())
                     dyna = data.pop(record_name)
-                    self.assertTrue('values' in dyna)
-                    self.assertTrue('dynamic' in dyna)
+                    self.assertIn('values', dyna)
+                    self.assertIn('dynamic', dyna)
 
             # Singular again.
             for record_name in ('cname', 'simple-weighted'):
@@ -773,8 +773,8 @@ class TestSplitYamlProvider(TestCase):
                 with open(yaml_file) as fh:
                     data = safe_load(fh.read())
                     dyna = data.pop(record_name)
-                    self.assertTrue('value' in dyna)
-                    self.assertTrue('dynamic' in dyna)
+                    self.assertIn('value', dyna)
+                    self.assertIn('dynamic', dyna)
 
     def test_empty(self):
         source = SplitYamlProvider(
@@ -924,9 +924,9 @@ class TestOverridingYamlProvider(TestCase):
         got = {r.name: r for r in zone.records}
         self.assertEqual(6, len(got))
         # We get the "dynamic" A from the base config
-        self.assertTrue('dynamic' in got['a'].data)
+        self.assertIn('dynamic', got['a'].data)
         # No added
-        self.assertFalse('added' in got)
+        self.assertNotIn('added', got)
 
         # Load the overrides, should replace one and add 1
         override.populate(zone)
@@ -937,4 +937,4 @@ class TestOverridingYamlProvider(TestCase):
             {'ttl': 3600, 'values': ['4.4.4.4', '5.5.5.5']}, got['a'].data
         )
         # And we have the new one
-        self.assertTrue('added' in got)
+        self.assertIn('added', got)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -42,7 +42,7 @@ class TestRecord(TestCase):
             _type = 'AA'
             _value_type = NsValue
 
-        self.assertTrue('AA' not in Record.registered_types())
+        self.assertNotIn('AA', Record.registered_types())
 
         Record.register_type(AaRecord)
         aa = Record.new(
@@ -52,7 +52,7 @@ class TestRecord(TestCase):
         )
         self.assertEqual(AaRecord, aa.__class__)
 
-        self.assertTrue('AA' in Record.registered_types())
+        self.assertIn('AA', Record.registered_types())
 
     def test_lowering(self):
         record = ARecord(
@@ -244,12 +244,12 @@ class TestRecord(TestCase):
         # Missing type
         with self.assertRaises(Exception) as ctx:
             Record.new(self.zone, 'unknown', {})
-        self.assertTrue('missing type' in str(ctx.exception))
+        self.assertIn('missing type', str(ctx.exception))
 
         # Unknown type
         with self.assertRaises(Exception) as ctx:
             Record.new(self.zone, 'unknown', {'type': 'XXX'})
-        self.assertTrue('Unknown record type' in str(ctx.exception))
+        self.assertIn('Unknown record type', str(ctx.exception))
 
     def test_record_new_with_values_and_value(self):
         a = Record.new(
@@ -799,7 +799,7 @@ class TestRecordValidation(TestCase):
             Record.new(
                 self.zone, 'www', {'type': 'A', 'ttl': -1, 'value': '1.2.3.4'}
             )
-        self.assertFalse(', line' in str(ctx.exception))
+        self.assertNotIn(', line', str(ctx.exception))
 
         # fails validation, with context
         with self.assertRaises(ValidationError) as ctx:
@@ -811,7 +811,7 @@ class TestRecordValidation(TestCase):
                     context='needle',
                 ),
             )
-        self.assertTrue('needle' in str(ctx.exception))
+        self.assertIn('needle', str(ctx.exception))
 
     def test_invalid_type_context(self):
         # fails validation, no context
@@ -819,7 +819,7 @@ class TestRecordValidation(TestCase):
             Record.new(
                 self.zone, 'www', {'type': 'X', 'ttl': 42, 'value': '1.2.3.4'}
             )
-        self.assertFalse(', line' in str(ctx.exception))
+        self.assertNotIn(', line', str(ctx.exception))
 
         # fails validation, with context
         with self.assertRaises(Exception) as ctx:
@@ -831,13 +831,13 @@ class TestRecordValidation(TestCase):
                     context='needle',
                 ),
             )
-        self.assertTrue('needle' in str(ctx.exception))
+        self.assertIn('needle', str(ctx.exception))
 
     def test_missing_type_context(self):
         # fails validation, no context
         with self.assertRaises(Exception) as ctx:
             Record.new(self.zone, 'www', {'ttl': 42, 'value': '1.2.3.4'})
-        self.assertFalse(', line' in str(ctx.exception))
+        self.assertNotIn(', line', str(ctx.exception))
 
         # fails validation, with context
         with self.assertRaises(Exception) as ctx:
@@ -846,7 +846,7 @@ class TestRecordValidation(TestCase):
                 'www',
                 ContextDict({'ttl': 42, 'value': '1.2.3.4'}, context='needle'),
             )
-        self.assertTrue('needle' in str(ctx.exception))
+        self.assertIn('needle', str(ctx.exception))
 
     def test_context_copied_to_record(self):
         record = Record.new(

--- a/tests/test_octodns_record_a.py
+++ b/tests/test_octodns_record_a.py
@@ -70,10 +70,10 @@ class TestRecordA(TestCase):
         # Hashing
         records = set()
         records.add(a)
-        self.assertTrue(a in records)
-        self.assertFalse(b in records)
+        self.assertIn(a, records)
+        self.assertNotIn(b, records)
         records.add(b)
-        self.assertTrue(b in records)
+        self.assertIn(b, records)
 
         # __repr__ doesn't blow up
         a.__repr__()

--- a/tests/test_octodns_record_loc.py
+++ b/tests/test_octodns_record_loc.py
@@ -354,10 +354,10 @@ class TestRecordLoc(TestCase):
         # Hash
         values = set()
         values.add(a)
-        self.assertTrue(a in values)
-        self.assertFalse(b in values)
+        self.assertIn(a, values)
+        self.assertNotIn(b, values)
         values.add(b)
-        self.assertTrue(b in values)
+        self.assertIn(b, values)
 
     def test_validation(self):
         # doesn't blow up

--- a/tests/test_octodns_record_naptr.py
+++ b/tests/test_octodns_record_naptr.py
@@ -277,10 +277,10 @@ class TestRecordNaptr(TestCase):
         )
         values = set()
         values.add(v)
-        self.assertTrue(v in values)
-        self.assertFalse(o in values)
+        self.assertIn(v, values)
+        self.assertNotIn(o, values)
         values.add(o)
-        self.assertTrue(o in values)
+        self.assertIn(o, values)
 
         self.assertEqual(30, o.order)
         o.order = o.order + 1

--- a/tests/test_octodns_record_srv.py
+++ b/tests/test_octodns_record_srv.py
@@ -224,10 +224,10 @@ class TestRecordSrv(TestCase):
         # Hash
         values = set()
         values.add(a)
-        self.assertTrue(a in values)
-        self.assertFalse(b in values)
+        self.assertIn(a, values)
+        self.assertNotIn(b, values)
         values.add(b)
-        self.assertTrue(b in values)
+        self.assertIn(b, values)
 
     def test_valiation(self):
         # doesn't blow up

--- a/tests/test_octodns_record_sshfp.py
+++ b/tests/test_octodns_record_sshfp.py
@@ -196,10 +196,10 @@ class TestRecordSshfp(TestCase):
         # Hash
         values = set()
         values.add(a)
-        self.assertTrue(a in values)
-        self.assertFalse(b in values)
+        self.assertIn(a, values)
+        self.assertNotIn(b, values)
         values.add(b)
-        self.assertTrue(b in values)
+        self.assertIn(b, values)
 
     def test_validation(self):
         # doesn't blow up

--- a/tests/test_octodns_record_svcb.py
+++ b/tests/test_octodns_record_svcb.py
@@ -267,10 +267,10 @@ class TestRecordSvcb(TestCase):
         # Hash
         values = set()
         values.add(a)
-        self.assertTrue(a in values)
-        self.assertFalse(b in values)
+        self.assertIn(a, values)
+        self.assertNotIn(b, values)
         values.add(b)
-        self.assertTrue(b in values)
+        self.assertIn(b, values)
 
     def test_validation(self):
         # doesn't blow up

--- a/tests/test_octodns_record_uri.py
+++ b/tests/test_octodns_record_uri.py
@@ -200,10 +200,10 @@ class TestRecordUri(TestCase):
         # Hash
         values = set()
         values.add(a)
-        self.assertTrue(a in values)
-        self.assertFalse(b in values)
+        self.assertIn(a, values)
+        self.assertNotIn(b, values)
         values.add(b)
-        self.assertTrue(b in values)
+        self.assertIn(b, values)
 
     def test_valiation(self):
         # doesn't blow up

--- a/tests/test_octodns_record_urlfwd.py
+++ b/tests/test_octodns_record_urlfwd.py
@@ -127,10 +127,10 @@ class TestRecordUrlfwd(TestCase):
         )
         values = set()
         values.add(v)
-        self.assertTrue(v in values)
-        self.assertFalse(o in values)
+        self.assertIn(v, values)
+        self.assertNotIn(o, values)
         values.add(o)
-        self.assertTrue(o in values)
+        self.assertIn(o, values)
 
         # __repr__ doesn't blow up
         a.__repr__()

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -262,21 +262,21 @@ class TestZone(TestCase):
     def test_missing_dot(self):
         with self.assertRaises(InvalidNameError) as ctx:
             Zone('not.allowed', [])
-        self.assertTrue('missing ending dot' in str(ctx.exception))
+        self.assertIn('missing ending dot', str(ctx.exception))
 
     def test_double_dot(self):
         with self.assertRaises(InvalidNameError) as ctx:
             Zone('ending.double.dot..', [])
-        self.assertTrue('double dot not allowed' in str(ctx.exception))
+        self.assertIn('double dot not allowed', str(ctx.exception))
 
         with self.assertRaises(InvalidNameError) as ctx:
             Zone('mid.double..dot.', [])
-        self.assertTrue('double dot not allowed' in str(ctx.exception))
+        self.assertIn('double dot not allowed', str(ctx.exception))
 
     def test_whitespace(self):
         with self.assertRaises(InvalidNameError) as ctx:
             Zone('space not allowed.', [])
-        self.assertTrue('whitespace not allowed' in str(ctx.exception))
+        self.assertIn('whitespace not allowed', str(ctx.exception))
 
     def test_owns(self):
         zone = Zone('unit.tests.', set(['sub']))
@@ -500,7 +500,7 @@ class TestZone(TestCase):
         zone.add_record(a)
         with self.assertRaises(InvalidNodeException) as ctx:
             zone.add_record(cname)
-        self.assertTrue(', has some context' in str(ctx.exception))
+        self.assertIn(', has some context', str(ctx.exception))
         self.assertEqual(set([a]), zone.records)
         zone.add_record(cname, lenient=True)
         self.assertEqual(set([a, cname]), zone.records)
@@ -529,7 +529,7 @@ class TestZone(TestCase):
         zone.add_record(a)
         with self.assertRaises(InvalidNodeException) as ctx:
             zone.add_record(cname)
-        self.assertTrue(', has some context' in str(ctx.exception))
+        self.assertIn(', has some context', str(ctx.exception))
         self.assertEqual(set([a]), zone.records)
 
         # add lenient a to cname


### PR DESCRIPTION
## Summary
- Fix 7 cases where `assertTrue(string_literal, str(ctx.exception))` was used instead of `assertIn`, causing the assertion to always pass (non-empty string is truthy)
- Convert all `assertTrue(x in y)` → `assertIn(x, y)`, `assertTrue(x not in y)` → `assertNotIn(x, y)`, and `assertFalse(x in y)` → `assertNotIn(x, y)` across the test suite for better failure messages

## Test plan
- [x] All 388 tests pass
- [x] Lint passes

/cc https://github.com/octodns/octodns/pull/1353 which I asked Claude to review and it noticed these unrelated problems