### PR TITLE
Fix mutable default arguments in Manager.sync() method

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -748,14 +748,21 @@ class Manager(object):
 
     def sync(
         self,
-        eligible_zones=[],
-        eligible_sources=[],
-        eligible_targets=[],
+        eligible_zones=None,
+        eligible_sources=None,
+        eligible_targets=None,
         dry_run=True,
         force=False,
         plan_output_fh=stdout,
         checksum=None,
     ):
+        if eligible_zones is None:
+            eligible_zones = []
+        if eligible_sources is None:
+            eligible_sources = []
+        if eligible_targets is None:
+            eligible_targets = []
+        
         self.log.info(
             'sync: eligible_zones=%s, eligible_targets=%s, dry_run=%s, force=%s, plan_output_fh=%s, checksum=%s',
             eligible_zones,


### PR DESCRIPTION
## Problem

The `Manager.sync()` method uses mutable default arguments (empty lists) for three parameters:
- `eligible_zones=[]`
- `eligible_sources=[]`
- `eligible_targets=[]`

This is a common Python anti-pattern that can lead to unexpected behavior when the same list object is shared across multiple function calls.

## Solution

Replaced mutable default arguments with `None` and added proper initialization to empty lists inside the method body.

## References

- [Python Tutorial: Default Argument Values](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values)
- PEP 8 programming recommendations

This change maintains backward compatibility while following Python best practices.