### PR TITLE
New provider: UniFi Network

### DIFF
--- a/.changelog/d35ad8d992bf4b7bb3c955635cdf6c52.md
+++ b/.changelog/d35ad8d992bf4b7bb3c955635cdf6c52.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Add octodns-unifi provider to documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,9 @@ their own repositories and released as independent modules.
    * - `UltraDNS`_
      - `octodns_ultra`_
      -
+   * - `UniFi Network`_
+     - `netshad0w/octodns-unifi`_
+     -
    * - `YamlProvider`_
      - built-in
      - Supports all record types and core functionality
@@ -251,6 +254,8 @@ their own repositories and released as independent modules.
 .. _octodns_transip: https://github.com/octodns/octodns-transip/
 .. _UltraDNS: https://vercara.com/authoritative-dns
 .. _octodns_ultra: https://github.com/octodns/octodns-ultra/
+.. _UniFi Network: https://ui.com/
+.. _netshad0w/octodns-unifi: https://github.com/netshad0w/octodns-unifi
 .. _YamlProvider: /octodns/provider/yaml.py
 .. _kompetenzbolzen/octodns-custom-provider: https://github.com/kompetenzbolzen/octodns-custom-provider
 


### PR DESCRIPTION
Add [octodns-unifi](https://github.com/netshad0w/octodns-unifi), a provider for [UniFi Network](https://ui.com/), to the providers list.
Created using octodns-template, with 100% code coverage.

Comments welcome!