### PR TITLE
Validate SSHFP fingerprint length matches fingerprint_type

### DIFF
--- a/.changelog/8fbdc64c7fb641c087dbcafe9bf2fcb4.md
+++ b/.changelog/8fbdc64c7fb641c087dbcafe9bf2fcb4.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Validate SSHFP fingerprint length matches fingerprint_type

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -10,6 +10,10 @@ from .rr import RrParseError
 class SshfpValue(EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
+    # Expected fingerprint hex-string length per fingerprint_type, from RFC
+    # 4255/6594: type 1 = SHA-1 (160 bits, 40 hex chars), type 2 = SHA-256
+    # (256 bits, 64 hex chars).
+    FINGERPRINT_LENGTHS = {1: 40, 2: 64}
 
     @classmethod
     def parse_rdata_text(self, value):
@@ -44,6 +48,9 @@ class SshfpValue(EqualityTupleMixin, dict):
                 reasons.append('missing algorithm')
             except ValueError:
                 reasons.append(f'invalid algorithm "{value["algorithm"]}"')
+            # Start unset so the length check below can tell the difference
+            # between a known-good fingerprint_type and a missing/invalid one.
+            fingerprint_type = None
             try:
                 fingerprint_type = int(value['fingerprint_type'])
                 if fingerprint_type not in cls.VALID_FINGERPRINT_TYPES:
@@ -58,6 +65,19 @@ class SshfpValue(EqualityTupleMixin, dict):
                 )
             if 'fingerprint' not in value:
                 reasons.append('missing fingerprint')
+            # Only length-check when we have both a known fingerprint_type and
+            # an actual fingerprint; unknown types and missing fingerprints
+            # are already reported above and we don't want to stack a
+            # confusing secondary error on top of them.
+            elif fingerprint_type in cls.FINGERPRINT_LENGTHS:
+                expected = cls.FINGERPRINT_LENGTHS[fingerprint_type]
+                actual = len(value['fingerprint'])
+                if actual != expected:
+                    reasons.append(
+                        f'fingerprint length {actual} does not match '
+                        f'fingerprint_type {fingerprint_type} '
+                        f'(expected {expected})'
+                    )
         return reasons
 
     @classmethod

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -403,7 +403,7 @@ class TestManager(TestCase):
                 'value': {
                     'algorithm': 1,
                     'fingerprint_type': 1,
-                    'fingerprint': 'abcdefg',
+                    'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73',
                 },
             },
         )

--- a/tests/test_octodns_record_sshfp.py
+++ b/tests/test_octodns_record_sshfp.py
@@ -243,7 +243,7 @@ class TestRecordSshfp(TestCase):
                     'ttl': 600,
                     'value': {
                         'algorithm': 'nope',
-                        'fingerprint_type': 2,
+                        'fingerprint_type': 1,
                         'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73',
                     },
                 },
@@ -333,6 +333,71 @@ class TestRecordSshfp(TestCase):
                 },
             )
         self.assertEqual(['missing fingerprint'], ctx.exception.reasons)
+
+        # SHA-1 fingerprint_type with a too-long (64-char) fingerprint
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone,
+                '',
+                {
+                    'type': 'SSHFP',
+                    'ttl': 600,
+                    'value': {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': 'a' * 64,
+                    },
+                },
+            )
+        self.assertEqual(
+            [
+                'fingerprint length 64 does not match fingerprint_type 1 '
+                '(expected 40)'
+            ],
+            ctx.exception.reasons,
+        )
+
+        # SHA-256 fingerprint_type with a 40-char SHA-1 fingerprint — the
+        # scenario reported in issue #1371
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone,
+                '',
+                {
+                    'type': 'SSHFP',
+                    'ttl': 600,
+                    'value': {
+                        'algorithm': 1,
+                        'fingerprint_type': 2,
+                        'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73',
+                    },
+                },
+            )
+        self.assertEqual(
+            [
+                'fingerprint length 40 does not match fingerprint_type 2 '
+                '(expected 64)'
+            ],
+            ctx.exception.reasons,
+        )
+
+        # Valid SHA-256 — happy path, no reasons
+        Record.new(
+            self.zone,
+            '',
+            {
+                'type': 'SSHFP',
+                'ttl': 600,
+                'value': {
+                    'algorithm': 1,
+                    'fingerprint_type': 2,
+                    'fingerprint': (
+                        '1111111111111111111111111111111111111111'
+                        '111111111111111111111111'
+                    ),
+                },
+            },
+        )
 
 
 class TestSshFpValue(TestCase):

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -185,13 +185,13 @@ class TestTinyDnsFileSource(TestCase):
                     'values': [
                         {
                             'algorithm': 1,
-                            'fingerprint_type': 2,
-                            'fingerprint': '00479b27',
+                            'fingerprint_type': 1,
+                            'fingerprint': '000000000000000000000000000000000047b270',
                         },
                         {
                             'algorithm': 2,
-                            'fingerprint_type': 2,
-                            'fingerprint': '00479a28',
+                            'fingerprint_type': 1,
+                            'fingerprint': '000000000000000000000000000000000047a280',
                         },
                     ],
                 },

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -74,8 +74,8 @@ S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999
 S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999
 
 # arbitrary multi-value non-spec record
-:arbitrary-sshfp.example.com:SSHFP:2 2 00479a28
-:arbitrary-sshfp.example.com:SSHFP:1 2 00479b27:45
+:arbitrary-sshfp.example.com:SSHFP:2 1 000000000000000000000000000000000047a280
+:arbitrary-sshfp.example.com:SSHFP:1 1 000000000000000000000000000000000047b270:45
 # does not make sense to do an A this way, but it'll work
 :arbitrary-a.example.com:a:80.81.82.83
 # this should just be inored b/c the type is unknown


### PR DESCRIPTION
## Summary
- Add length validation to `SshfpValue.validate`: SHA-1 (type 1) must be 40 hex chars, SHA-256 (type 2) must be 64, per RFC 4255/6594
- Check is gated on a known `fingerprint_type` and a present `fingerprint` so it doesn't stack redundant errors onto existing missing/invalid cases
- Updated a handful of test fixtures that were using arbitrary short fingerprints

Fixes #1371

## Test plan
- [x] `./script/test`
- [x] `./script/coverage` (100% branch coverage)
- [x] `./script/lint`
- [x] `./script/format --check`