### PR TITLE
Register UriRecord and UriValue

### DIFF
--- a/.changelog/307ee403c7a54c5889257159c30c731a.md
+++ b/.changelog/307ee403c7a54c5889257159c30c731a.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Register UriRecord and UriValue

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -28,6 +28,7 @@ from .sshfp import SshfpRecord, SshfpValue
 from .svcb import SvcbRecord, SvcbValue
 from .tlsa import TlsaRecord, TlsaValue
 from .txt import TxtRecord, TxtValue
+from .uri import UriRecord, UriValue
 from .urlfwd import UrlfwdRecord, UrlfwdValue
 
 # quell warnings
@@ -82,6 +83,8 @@ TlsaValue
 TxtRecord
 TxtValue
 Update
+UriRecord
+UriValue
 UrlfwdRecord
 UrlfwdValue
 ValidationError


### PR DESCRIPTION
Oversight back when the type was added. Including them in the octodns.record will ensure they're correctly loaded and registered. 