### PR TITLE
Publish JSON Schema on Read the Docs

### DIFF
--- a/.changelog/dccef96101c244afa311fa0f28e316c6.md
+++ b/.changelog/dccef96101c244afa311fa0f28e316c6.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Publish JSON Schema to Read the Docs under `_static/octodns.schema.json` for each built version

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage.json
 coverage.xml
 dist/
 docs/_build/
+docs/_static/octodns.schema.json
 docs/api/cmds/
 docs/api/helpers/
 docs/api/processors/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
 print(f"SYS.PATH={sys.path}")
 
 from octodns.__init__ import __version__
+from octodns.schema import build_zone_schema
 
 ### sphinx config ###
 
@@ -183,6 +185,28 @@ def _rewrite_repo_local_links(app, doctree, _docname):
             node["refuri"] = f"{source_base}{refuri}"
 
 
+### json schema ###
+# Generate the zone YAML JSON Schema at docs-build time so Read the Docs
+# serves a per-version copy under _static. External consumers (SchemaStore,
+# yaml-language-server modelines, editor `yaml.schemas` config) point at
+# https://octodns.readthedocs.io/en/<version>/_static/octodns.schema.json.
+#
+# The schema is a build artifact — it is regenerated on every build from the
+# currently registered record types, so it can't drift from the code.
+_SCHEMA_FILENAME = "octodns.schema.json"
+
+
+def _write_zone_schema(app):
+    out_dir = Path(app.srcdir) / "_static"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    target = out_dir / _SCHEMA_FILENAME
+    target.write_text(
+        json.dumps(build_zone_schema(), indent=2, sort_keys=True) + "\n"
+    )
+    print(f"wrote {target}")
+
+
 def setup(app):
     app.add_config_value("octodns_source_base_url", _source_base, "env")
     app.connect("doctree-resolved", _rewrite_repo_local_links)
+    app.connect("builder-inited", _write_zone_schema)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -181,3 +181,64 @@ Automatic PTR generation
 octoDNS supports automatically generating PTR records from the ``A``/``AAAA``
 records it manages. For more information see the :doc:`auto_arpa`
 documentation.
+
+JSON Schema for zone YAML files
+-------------------------------
+
+octoDNS publishes a JSON Schema (Draft 2020-12) describing its zone YAML
+file format. It is generated from the currently registered record types on
+every docs build, so the schema matches the code in that release.
+
+The schema is intended for editors and CI linters. octoDNS's own validation
+is unchanged — it continues to handle error reporting with source context.
+
+Stable URLs
+...........
+
+Read the Docs serves a copy of the schema under each version's ``_static``
+directory:
+
+- Latest release (recommended for most users):
+  ``https://octodns.readthedocs.io/en/stable/_static/octodns.schema.json``
+- Development (tracks ``main``):
+  ``https://octodns.readthedocs.io/en/latest/_static/octodns.schema.json``
+- A specific release, e.g. ``v2.0.0``:
+  ``https://octodns.readthedocs.io/en/v2.0.0/_static/octodns.schema.json``
+
+Opting in with a modeline
+.........................
+
+The `yaml-language-server`_ (used by the ``redhat.vscode-yaml`` extension and
+other editors) honors a modeline at the top of a YAML file:
+
+.. code-block:: yaml
+
+   # yaml-language-server: $schema=https://octodns.readthedocs.io/en/stable/_static/octodns.schema.json
+   ---
+   www:
+     type: A
+     ttl: 300
+     value: 1.2.3.4
+
+Editor configuration
+....................
+
+In VS Code (or any editor that uses ``yaml-language-server``) you can instead
+associate the schema with a file pattern via ``yaml.schemas``::
+
+  "yaml.schemas": {
+    "https://octodns.readthedocs.io/en/stable/_static/octodns.schema.json": [
+      "zones/*.yaml"
+    ]
+  }
+
+Generating locally
+..................
+
+The ``octodns-schema`` CLI prints or writes the same schema:
+
+.. code-block:: sh
+
+   octodns-schema --output octodns.schema.json
+
+.. _yaml-language-server: https://github.com/redhat-developer/yaml-language-server

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -192,18 +192,20 @@ every docs build, so the schema matches the code in that release.
 The schema is intended for editors and CI linters. octoDNS's own validation
 is unchanged — it continues to handle error reporting with source context.
 
-Stable URLs
-...........
+Available versions
+..................
 
 Read the Docs serves a copy of the schema under each version's ``_static``
 directory:
 
-- Latest release (recommended for most users):
-  ``https://octodns.readthedocs.io/en/stable/_static/octodns.schema.json``
-- Development (tracks ``main``):
-  ``https://octodns.readthedocs.io/en/latest/_static/octodns.schema.json``
-- A specific release, e.g. ``v2.0.0``:
-  ``https://octodns.readthedocs.io/en/v2.0.0/_static/octodns.schema.json``
+- `Bundled with this documentation <_static/octodns.schema.json>`_ — always
+  matches the version of octoDNS whose docs you are viewing
+- `Latest release <https://octodns.readthedocs.io/en/stable/_static/octodns.schema.json>`_
+  — recommended for most users; tracks the most recent release
+- `Development <https://octodns.readthedocs.io/en/latest/_static/octodns.schema.json>`_
+  — tracks ``main``
+- A specific release, e.g.
+  `v2.0.0 <https://octodns.readthedocs.io/en/v2.0.0/_static/octodns.schema.json>`_
 
 Opting in with a modeline
 .........................


### PR DESCRIPTION
## Summary

- Generate `octodns.schema.json` from `build_zone_schema()` during the Sphinx build via a `builder-inited` hook, so Read the Docs publishes a per-version copy under `_static/`. Users and external consumers can reference stable URLs like `https://octodns.readthedocs.io/en/stable/_static/octodns.schema.json` without a release workflow or committed artifact.
- Document the URL pattern, `yaml-language-server` modeline opt-in, and `yaml.schemas` editor config in `configuration.rst`.
- The schema is regenerated on every build from the currently registered record types, so it cannot drift from the code. The existing `test_schema_is_valid_json_schema` test guards meta-schema validity.

Follow-up (separate, one-time): submit a PR to [SchemaStore/schemastore](https://github.com/SchemaStore/schemastore) adding a `catalog.json` entry pointing at the stable URL.

Related:
- Builds on #1373 (generator + CLI)
- Supersedes #1272 (earlier jsonschema experimentation)

## Test plan

- [x] `./script/generate-docs` produces `docs/_build/html/_static/octodns.schema.json` (52KB, valid, all 22 record types)
- [x] `./script/test` — 474 passed, 100% branch coverage
- [x] `./script/lint` and `./script/format --check`
- [x] Verify on RTD preview that `_static/octodns.schema.json` is served under the PR's build
- [x] Manual: point `yaml.schemas` at the RTD-hosted file and confirm autocomplete + inline errors on `tests/config/unit.tests.yaml`