### PR TITLE
Tighten record validation and allow 3rd-party types in JSON Schema

### DIFF
--- a/.changelog/50da5214d3334a32bebd00054daca600.md
+++ b/.changelog/50da5214d3334a32bebd00054daca600.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Support 3rd-party record types in JSON Schema

--- a/.changelog/833f8b012fcd4e49bc8213896dd7f1db.md
+++ b/.changelog/833f8b012fcd4e49bc8213896dd7f1db.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Reject unknown top-level keys on records in JSON Schema

--- a/octodns/schema/__init__.py
+++ b/octodns/schema/__init__.py
@@ -26,6 +26,14 @@ from ..record.geo import _GeoMixin
 _DEFAULT_VALUE_SCHEMA = True
 
 
+# 3rd-party providers register custom record types with names like
+# `Route53/ELB` or `octodns_route53.Route53/EC2` — an optional dotted module
+# path, a slash, then the type name. These types aren't known when the
+# schema is generated (e.g. SchemaStore publishes a static snapshot), so
+# matching this pattern puts the record in a permissive catch-all branch.
+_THIRD_PARTY_TYPE_PATTERN = r'^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*/[A-Za-z_]\w*$'
+
+
 # Syntactic constraints on record name keys. Mirrors the generic checks in
 # `Record.validate` (octodns/record/base.py) that don't require zone context:
 # no "@", no label longer than 63 chars, no "..", no trailing ".". The fqdn
@@ -108,6 +116,24 @@ def _type_branch(type_name, record_class):
     }
 
 
+def _third_party_branch():
+    # permissive catch-all for 3rd-party types (see _THIRD_PARTY_TYPE_PATTERN)
+    return {
+        'if': {
+            'properties': {'type': {'pattern': _THIRD_PARTY_TYPE_PATTERN}},
+            'required': ['type'],
+        },
+        'then': {
+            'properties': {
+                'value': True,
+                'values': True,
+                'dynamic': True,
+                'geo': True,
+            }
+        },
+    }
+
+
 def _record_def():
     types = sorted(Record.registered_types().keys())
     return {
@@ -116,7 +142,15 @@ def _record_def():
         # ttl intentionally not required — YamlProvider fills in default_ttl
         # for records that omit it
         'properties': {
-            'type': {'type': 'string', 'enum': types},
+            'type': {
+                'type': 'string',
+                # built-in types match the enum; 3rd-party types match the
+                # pattern and land in the permissive catch-all branch below
+                'anyOf': [
+                    {'enum': types},
+                    {'pattern': _THIRD_PARTY_TYPE_PATTERN},
+                ],
+            },
             'ttl': {'type': 'integer', 'minimum': 0},
             'octodns': {'$ref': '#/$defs/octodns_meta'},
         },
@@ -128,7 +162,8 @@ def _record_def():
         'allOf': [
             _type_branch(t, c)
             for t, c in sorted(Record.registered_types().items())
-        ],
+        ]
+        + [_third_party_branch()],
     }
 
 

--- a/octodns/schema/__init__.py
+++ b/octodns/schema/__init__.py
@@ -120,10 +120,11 @@ def _record_def():
             'ttl': {'type': 'integer', 'minimum': 0},
             'octodns': {'$ref': '#/$defs/octodns_meta'},
         },
-        # tolerate per-type fields (value, values, dynamic, geo, ...) and
-        # provider-specific extras; the type-specific if/then branches add
-        # the real constraints
-        'additionalProperties': True,
+        # reject typos and unknown top-level keys. `unevaluatedProperties`
+        # (unlike `additionalProperties`) sees through the if/then branches
+        # below, so value/values/dynamic/geo still pass when the matching
+        # branch declares them.
+        'unevaluatedProperties': False,
         'allOf': [
             _type_branch(t, c)
             for t, c in sorted(Record.registered_types().items())

--- a/tests/test_octodns_schema.py
+++ b/tests/test_octodns_schema.py
@@ -879,6 +879,27 @@ class TestSchema(TestCase):
                 {'a.': {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'}}
             )
 
+    def test_invalid_unknown_top_level_key_rejected(self):
+        # typos or misplaced provider-specific fields should be flagged
+        with self.assertRaises(jsonschema.ValidationError):
+            self._validator().validate(
+                {
+                    'www': {
+                        'type': 'A',
+                        'ttl': 300,
+                        'value': '1.2.3.4',
+                        'foo': 'bar',
+                    }
+                }
+            )
+
+    def test_invalid_misspelled_values_rejected(self):
+        # common typo: "vlaues" instead of "values"
+        with self.assertRaises(jsonschema.ValidationError):
+            self._validator().validate(
+                {'www': {'type': 'A', 'ttl': 300, 'vlaues': ['1.2.3.4']}}
+            )
+
     def test_numeric_name_accepted(self):
         # YAML parses unquoted numeric keys as ints (e.g. reverse-zone labels);
         # octoDNS stringifies them internally, so the schema should tolerate

--- a/tests/test_octodns_schema.py
+++ b/tests/test_octodns_schema.py
@@ -24,13 +24,16 @@ class TestSchema(TestCase):
 
     def test_every_registered_type_is_in_enum(self):
         schema = build_zone_schema()
-        enum = set(schema['$defs']['record']['properties']['type']['enum'])
+        type_schema = schema['$defs']['record']['properties']['type']
+        enum = set(type_schema['anyOf'][0]['enum'])
         registered = set(Record.registered_types().keys())
         self.assertEqual(registered, enum)
 
     def test_every_registered_type_has_exactly_one_branch(self):
         schema = build_zone_schema()
-        branches = schema['$defs']['record']['allOf']
+        # last branch is the 3rd-party catch-all (pattern-keyed); per-type
+        # branches are the rest and are const-keyed
+        branches = schema['$defs']['record']['allOf'][:-1]
         types_in_branches = [
             b['if']['properties']['type']['const'] for b in branches
         ]
@@ -815,7 +818,9 @@ class TestSchema(TestCase):
             jsonschema.Draft202012Validator.check_schema(schema)
             self.assertIn(
                 'XXTEST',
-                schema['$defs']['record']['properties']['type']['enum'],
+                schema['$defs']['record']['properties']['type']['anyOf'][0][
+                    'enum'
+                ],
             )
             validator = self._validator()
             validator.validate(
@@ -832,6 +837,44 @@ class TestSchema(TestCase):
             )
         finally:
             del Record._CLASSES['XXTEST']
+
+    def test_valid_third_party_type_short_form(self):
+        # e.g. Route53/ELB — provider not registered at schema-build time
+        validator = self._validator()
+        validator.validate(
+            {
+                'elb': {
+                    'type': 'Route53/ELB',
+                    'ttl': 300,
+                    'value': {'anything': 'goes'},
+                }
+            }
+        )
+
+    def test_valid_third_party_type_dotted_form(self):
+        # e.g. octodns_route53.Route53/EC2
+        self._validator().validate(
+            {
+                'ec2': {
+                    'type': 'octodns_route53.Route53/EC2',
+                    'ttl': 300,
+                    'values': ['arbitrary', 'shape'],
+                }
+            }
+        )
+
+    def test_invalid_third_party_type_missing_slash_rejected(self):
+        # unknown built-in-looking types are still rejected
+        with self.assertRaises(jsonschema.ValidationError):
+            self._validator().validate(
+                {'x': {'type': 'NotARealType', 'ttl': 300, 'value': 'foo'}}
+            )
+
+    def test_invalid_third_party_type_garbage_rejected(self):
+        with self.assertRaises(jsonschema.ValidationError):
+            self._validator().validate(
+                {'x': {'type': 'bad type/with spaces', 'ttl': 300}}
+            )
 
     def test_valid_apex_name(self):
         self._validator().validate(


### PR DESCRIPTION
## Summary

- Validate record **name keys** via `propertyNames` — reject `@`, `..`, trailing `.`, and labels longer than 63 chars, mirroring the generic rules in `Record.validate`. Guarded by `if type: string` so YAML loaders handing back non-string keys (numeric reverse-zone labels) still pass. *(already on `main` via the earlier `json-schema` branch, included here for full PR context)*
- Reject **unknown top-level keys** on records by switching from `additionalProperties: true` to `unevaluatedProperties: false`. `unevaluatedProperties` sees through the if/then type branches so `value`/`values`/`dynamic`/`geo` still pass, while typos like `vlaues` or misplaced fields now surface as validation errors.
- Support **3rd-party record types** — loosen the `type` property from a pure enum to `anyOf: [enum, pattern]` where the pattern matches names like `Route53/ELB` or `octodns_route53.Route53/EC2`. Add a catch-all if/then branch that declares `value`/`values`/`dynamic`/`geo` as permissive for pattern-matched types. Needed so statically-published schemas (Read the Docs, SchemaStore) don't reject records from providers the generator didn't know about.

Related:
- Follow-up to #1373 (generator + CLI)
- Builds on ideas from #1272 (earlier `name_schema` experimentation)

## Test plan

- [x] `./script/test tests/test_octodns_schema.py` — 74 tests pass (new coverage for name-key constraints, unknown-key rejection, and 3rd-party type forms)
- [x] `./script/coverage` — 480 passed, 100% branch coverage
- [x] `./script/lint` and `./script/format --check`
- [x] Round-trip `tests/config/unit.tests.yaml`, `dynamic.tests.yaml`, `subzone.unit.tests.yaml`, `dynamic-arpa/unit.tests.yaml` — no existing fixtures regress
- [x] Manual: point `yaml.schemas` at the generated file in VS Code and confirm autocomplete + typo detection on a zone file