### PR TITLE
Add REFERENCES tuple to Zone and Record types

### DIFF
--- a/.changelog/1611271de41340a893573ac38d4da488.md
+++ b/.changelog/1611271de41340a893573ac38d4da488.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add REFERENCES tuple to Zone and each Record type pointing to the RFCs (and for ALIAS an IETF draft) that define them

--- a/octodns/record/a.py
+++ b/octodns/record/a.py
@@ -19,6 +19,7 @@ Ipv4Address = Ipv4Value
 
 
 class ARecord(_DynamicMixin, _GeoMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc1035',)
     _type = 'A'
     _value_type = Ipv4Value
 

--- a/octodns/record/aaaa.py
+++ b/octodns/record/aaaa.py
@@ -19,6 +19,7 @@ Ipv6Address = Ipv6Value
 
 
 class AaaaRecord(_DynamicMixin, _GeoMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc3596',)
     _type = 'AAAA'
     _value_type = Ipv6Address
 

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -11,6 +11,7 @@ class AliasValue(_TargetValue):
 
 
 class AliasRecord(ValueMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/draft-ietf-dnsop-aname/',)
     _type = 'ALIAS'
     _value_type = AliasValue
 

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -23,6 +23,14 @@ def unquote(s):
 class Record(EqualityTupleMixin):
     log = getLogger('Record')
 
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc1035',
+        'https://datatracker.ietf.org/doc/html/rfc1123',
+        'https://datatracker.ietf.org/doc/html/rfc2181',
+        'https://datatracker.ietf.org/doc/html/rfc4592',
+        'https://datatracker.ietf.org/doc/html/rfc5890',
+    )
+
     _CLASSES = {}
 
     @classmethod

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -114,6 +114,11 @@ class CaaValue(EqualityTupleMixin, dict):
 
 
 class CaaRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc8657',
+        'https://datatracker.ietf.org/doc/html/rfc8659',
+        'https://datatracker.ietf.org/doc/html/rfc9495',
+    )
     _type = 'CAA'
     _value_type = CaaValue
 

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -12,6 +12,7 @@ class CnameValue(_TargetValue):
 
 
 class CnameRecord(_DynamicMixin, ValueMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc1035',)
     _type = 'CNAME'
     _value_type = CnameValue
 

--- a/octodns/record/dname.py
+++ b/octodns/record/dname.py
@@ -12,6 +12,7 @@ class DnameValue(_TargetValue):
 
 
 class DnameRecord(_DynamicMixin, ValueMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc6672',)
     _type = 'DNAME'
     _value_type = DnameValue
 

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -205,6 +205,15 @@ class DsValue(EqualityTupleMixin, dict):
 
 
 class DsRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc4034',
+        'https://datatracker.ietf.org/doc/html/rfc4035',
+        'https://datatracker.ietf.org/doc/html/rfc4509',
+        'https://datatracker.ietf.org/doc/html/rfc6605',
+        'https://datatracker.ietf.org/doc/html/rfc6840',
+        'https://datatracker.ietf.org/doc/html/rfc8080',
+        'https://datatracker.ietf.org/doc/html/rfc8624',
+    )
     _type = 'DS'
     _value_type = DsValue
 

--- a/octodns/record/https.py
+++ b/octodns/record/https.py
@@ -12,6 +12,11 @@ class HttpsValue(SvcbValue):
 
 
 class HttpsRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc9460',
+        'https://datatracker.ietf.org/doc/html/rfc9461',
+        'https://datatracker.ietf.org/doc/html/rfc9462',
+    )
     _type = 'HTTPS'
     _value_type = HttpsValue
 

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -420,6 +420,7 @@ class LocValue(EqualityTupleMixin, dict):
 
 
 class LocRecord(ValuesMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc1876',)
     _type = 'LOC'
     _value_type = LocValue
 

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -137,6 +137,11 @@ class MxValue(EqualityTupleMixin, dict):
 
 
 class MxRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc1035',
+        'https://datatracker.ietf.org/doc/html/rfc5321',
+        'https://datatracker.ietf.org/doc/html/rfc7505',
+    )
     _type = 'MX'
     _value_type = MxValue
 

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -205,6 +205,13 @@ class NaptrValue(EqualityTupleMixin, dict):
 
 
 class NaptrRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc3401',
+        'https://datatracker.ietf.org/doc/html/rfc3402',
+        'https://datatracker.ietf.org/doc/html/rfc3403',
+        'https://datatracker.ietf.org/doc/html/rfc3404',
+        'https://datatracker.ietf.org/doc/html/rfc3405',
+    )
     _type = 'NAPTR'
     _value_type = NaptrValue
 

--- a/octodns/record/ns.py
+++ b/octodns/record/ns.py
@@ -11,6 +11,7 @@ class NsValue(_TargetsValue):
 
 
 class NsRecord(ValuesMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc1035',)
     _type = 'NS'
     _value_type = NsValue
 

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -43,6 +43,7 @@ class OpenpgpkeyValue(str):
 
 
 class OpenpgpkeyRecord(ValuesMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc7929',)
     _type = 'OPENPGPKEY'
     _value_type = OpenpgpkeyValue
 

--- a/octodns/record/ptr.py
+++ b/octodns/record/ptr.py
@@ -11,6 +11,7 @@ class PtrValue(_TargetsValue):
 
 
 class PtrRecord(ValuesMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc1035',)
     _type = 'PTR'
     _value_type = PtrValue
 

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -8,6 +8,7 @@ from .chunked import _ChunkedValue, _ChunkedValuesMixin
 
 
 class SpfRecord(_ChunkedValuesMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc7208',)
     _type = 'SPF'
     _value_type = _ChunkedValue
 

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -153,6 +153,10 @@ class SrvValue(EqualityTupleMixin, dict):
 
 
 class SrvRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc2782',
+        'https://datatracker.ietf.org/doc/html/rfc6335',
+    )
     _type = 'SRV'
     _value_type = SrvValue
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -157,6 +157,12 @@ class SshfpValue(EqualityTupleMixin, dict):
 
 
 class SshfpRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc4255',
+        'https://datatracker.ietf.org/doc/html/rfc6594',
+        'https://datatracker.ietf.org/doc/html/rfc7479',
+        'https://datatracker.ietf.org/doc/html/rfc8709',
+    )
     _type = 'SSHFP'
     _value_type = SshfpValue
 

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -320,6 +320,11 @@ class SvcbValue(EqualityTupleMixin, dict):
 
 
 class SvcbRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc9460',
+        'https://datatracker.ietf.org/doc/html/rfc9461',
+        'https://datatracker.ietf.org/doc/html/rfc9462',
+    )
     _type = 'SVCB'
     _value_type = SvcbValue
 

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -187,6 +187,12 @@ class TlsaValue(EqualityTupleMixin, dict):
 
 
 class TlsaRecord(ValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc6698',
+        'https://datatracker.ietf.org/doc/html/rfc7671',
+        'https://datatracker.ietf.org/doc/html/rfc7672',
+        'https://datatracker.ietf.org/doc/html/rfc7673',
+    )
     _type = 'TLSA'
     _value_type = TlsaValue
 

--- a/octodns/record/txt.py
+++ b/octodns/record/txt.py
@@ -11,6 +11,11 @@ class TxtValue(_ChunkedValue):
 
 
 class TxtRecord(_ChunkedValuesMixin, Record):
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc1035',
+        'https://datatracker.ietf.org/doc/html/rfc1464',
+        'https://datatracker.ietf.org/doc/html/rfc6763',
+    )
     _type = 'TXT'
     _value_type = TxtValue
 

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -132,8 +132,8 @@ class UriValue(EqualityTupleMixin, dict):
         return f"'{self.priority} {self.weight} \"{self.target}\"'"
 
 
-# https://datatracker.ietf.org/doc/html/rfc7553
 class UriRecord(ValuesMixin, Record):
+    REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc7553',)
     _type = 'URI'
     _value_type = UriValue
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -167,6 +167,7 @@ class UrlfwdValue(EqualityTupleMixin, dict):
 
 
 class UrlfwdRecord(ValuesMixin, Record):
+    REFERENCES = ()
     _type = 'URLFWD'
     _value_type = UrlfwdValue
 

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -144,6 +144,13 @@ class Zone(object):
 
     log = getLogger('Zone')
 
+    REFERENCES = (
+        'https://datatracker.ietf.org/doc/html/rfc1034',
+        'https://datatracker.ietf.org/doc/html/rfc1035',
+        'https://datatracker.ietf.org/doc/html/rfc2181',
+        'https://datatracker.ietf.org/doc/html/rfc4592',
+    )
+
     def __init__(
         self,
         name,


### PR DESCRIPTION
## Summary
- Adds a `REFERENCES` tuple of spec URLs as a class constant on every `Record` subclass and on `Zone`, covering the RFC(s) that define each type. Companion/extension RFCs are included for comprehensive coverage.
- Cross-cutting naming/FQDN references (RFCs 1035, 1123, 2181, 4592, 5890) live on the `Record` base class; each subclass declares the RFCs specific to its record type.
- Vendor-specific types that lack a standards-track definition: ALIAS points to `draft-ietf-dnsop-aname/`; URLFWD is left as an empty tuple.

## Test plan
- [x] `./script/format` — clean
- [x] `./script/lint` — clean
- [x] `./script/coverage` — 480 tests pass, 100% coverage