### PR TITLE
Refactor record and value validations into Validator classes

### DIFF
--- a/.changelog/c490fd3328724cd692afffa943e43fe5.md
+++ b/.changelog/c490fd3328724cd692afffa943e43fe5.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Introduce RecordValidator/ValueValidator base classes, laying groundwork for extensible record and value validations

--- a/.changelog/c490fd3328724cd692afffa943e43fe5.md
+++ b/.changelog/c490fd3328724cd692afffa943e43fe5.md
@@ -1,4 +1,4 @@
 ---
 type: minor
 ---
-Introduce RecordValidator/ValueValidator base classes, laying groundwork for extensible record and value validations
+Introduce RecordValidator/ValueValidator base classes, laying groundwork for extensible record and value validations. Overriding `validate` on a `Record` subclass or defining a `validate` classmethod on a value class is DEPRECATED; declare validators via the `VALIDATORS` class attribute instead. Will be removed in 2.0.

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -12,6 +12,11 @@ class AliasValue(_TargetValue):
 
 
 class AliasRootValidator(RecordValidator):
+    '''
+    Restricts ALIAS records to the zone root — the non-standard ALIAS
+    type only has meaning at the apex.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         if name != '':

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -31,13 +31,5 @@ class AliasRecord(ValueMixin, Record):
 
     VALIDATORS = [AliasRootValidator]
 
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = []
-        for validator in AliasRecord.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
-        reasons.extend(super().validate(name, fqdn, data))
-        return reasons
-
 
 Record.register_type(AliasRecord)

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -4,10 +4,19 @@
 
 from .base import Record, ValueMixin
 from .target import _TargetValue
+from .validator import RecordValidator
 
 
 class AliasValue(_TargetValue):
     pass
+
+
+class AliasRootValidator(RecordValidator):
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
+        if name != '':
+            return ['non-root ALIAS not allowed']
+        return []
 
 
 class AliasRecord(ValueMixin, Record):
@@ -15,11 +24,13 @@ class AliasRecord(ValueMixin, Record):
     _type = 'ALIAS'
     _value_type = AliasValue
 
+    VALIDATORS = [AliasRootValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = []
-        if name != '':
-            reasons.append('non-root ALIAS not allowed')
+        for validator in AliasRecord.VALIDATORS:
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         reasons.extend(super().validate(name, fqdn, data))
         return reasons
 

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -23,7 +23,7 @@ def unquote(s):
 
 class NameValidator(RecordValidator):
     @classmethod
-    def validate(cls, name, fqdn, data):
+    def validate(cls, record_cls, name, fqdn, data):
         reasons = []
         if name == '@':
             reasons.append('invalid name "@", use "" instead')
@@ -49,7 +49,7 @@ class NameValidator(RecordValidator):
 
 class TtlValidator(RecordValidator):
     @classmethod
-    def validate(cls, name, fqdn, data):
+    def validate(cls, record_cls, name, fqdn, data):
         reasons = []
         try:
             ttl = int(data['ttl'])
@@ -62,7 +62,7 @@ class TtlValidator(RecordValidator):
 
 class HealthcheckValidator(RecordValidator):
     @classmethod
-    def validate(cls, name, fqdn, data):
+    def validate(cls, record_cls, name, fqdn, data):
         reasons = []
         try:
             if data['octodns']['healthcheck']['protocol'] not in (
@@ -156,7 +156,7 @@ class Record(EqualityTupleMixin):
     def validate(cls, name, fqdn, data):
         reasons = []
         for validator in Record.VALIDATORS:
-            reasons.extend(validator.validate(name, fqdn, data))
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         return reasons
 
     @classmethod

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -97,6 +97,16 @@ class HealthcheckValidator(RecordValidator):
 class Record(EqualityTupleMixin):
     log = getLogger('Record')
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if 'validate' in cls.__dict__:
+            deprecated(
+                f'`{cls.__name__}.validate` override is DEPRECATED. '
+                'Declare validators via the `VALIDATORS` class attribute '
+                'instead. Will be removed in 2.0',
+                stacklevel=3,
+            )
+
     REFERENCES = (
         'https://datatracker.ietf.org/doc/html/rfc1035',
         'https://datatracker.ietf.org/doc/html/rfc1123',
@@ -372,6 +382,12 @@ def _process_value_validators(value_type, values, _type):
     # longer define validate; their VALIDATORS run via the MRO walk below.
     legacy = getattr(value_type, 'validate', None)
     if legacy is not None:
+        deprecated(
+            f'`{value_type.__name__}.validate` classmethod is DEPRECATED. '
+            'Declare validators via the `VALIDATORS` class attribute '
+            'instead. Will be removed in 2.0',
+            stacklevel=3,
+        )
         reasons.extend(legacy(values, _type))
     for klass in reversed(value_type.__mro__):
         for validator in klass.__dict__.get('VALIDATORS', ()):

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -169,11 +169,18 @@ class Record(EqualityTupleMixin):
     VALIDATORS = [NameValidator, TtlValidator, HealthcheckValidator]
 
     @classmethod
-    def validate(cls, name, fqdn, data):
+    def _process_validators(cls, name, fqdn, data):
         reasons = []
-        for validator in Record.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
+        # root→leaf so base validators run first, matching the
+        # super().validate() ordering this replaces
+        for klass in reversed(cls.__mro__):
+            for validator in klass.__dict__.get('VALIDATORS', ()):
+                reasons.extend(validator.validate(cls, name, fqdn, data))
         return reasons
+
+    @classmethod
+    def validate(cls, name, fqdn, data):
+        return cls._process_validators(name, fqdn, data)
 
     @classmethod
     def from_rrs(cls, zone, rrs, lenient=False, source=None):
@@ -358,17 +365,40 @@ class Record(EqualityTupleMixin):
         raise NotImplementedError('Abstract base class, __repr__ required')
 
 
-class ValuesMixin(object):
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = super().validate(name, fqdn, data)
+def _process_value_validators(value_type, values, _type):
+    reasons = []
+    # Back-compat: 3rd-party value classes may still override validate()
+    # directly rather than declaring VALIDATORS. In-repo value classes no
+    # longer define validate; their VALIDATORS run via the MRO walk below.
+    legacy = getattr(value_type, 'validate', None)
+    if legacy is not None:
+        reasons.extend(legacy(values, _type))
+    for klass in reversed(value_type.__mro__):
+        for validator in klass.__dict__.get('VALIDATORS', ()):
+            reasons.extend(validator.validate(value_type, values, _type))
+    return reasons
 
+
+class ValuesTypeValidator(RecordValidator):
+    '''
+    Bridges a record's ``_value_type`` into the record-level validation
+    pipeline: pulls ``values``/``value`` from ``data``, coerces to a list,
+    and runs the value type's validators (both the legacy ``validate``
+    classmethod on the value class, for 3rd-party back-compat, and any
+    ``VALIDATORS`` declared along the value type's MRO).
+    '''
+
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
         values = data.get('values', data.get('value', []))
         values = values if isinstance(values, (list, tuple)) else [values]
+        return _process_value_validators(
+            record_cls._value_type, values, record_cls._type
+        )
 
-        reasons.extend(cls._value_type.validate(values, cls._type))
 
-        return reasons
+class ValuesMixin(object):
+    VALIDATORS = [ValuesTypeValidator]
 
     @classmethod
     def data_from_rrs(cls, rrs):
@@ -427,14 +457,22 @@ class ValuesMixin(object):
         return f"<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, ['{values}']{octodns}>"
 
 
-class ValueMixin(object):
+class ValueTypeValidator(RecordValidator):
+    '''
+    Single-value variant of ``ValuesTypeValidator`` for records that use
+    ``ValueMixin``: passes ``data['value']`` (or ``None``) through to the
+    value type's validators.
+    '''
+
     @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = super().validate(name, fqdn, data)
-        reasons.extend(
-            cls._value_type.validate(data.get('value', None), cls._type)
+    def validate(cls, record_cls, name, fqdn, data):
+        return _process_value_validators(
+            record_cls._value_type, data.get('value', None), record_cls._type
         )
-        return reasons
+
+
+class ValueMixin(object):
+    VALIDATORS = [ValueTypeValidator]
 
     @classmethod
     def data_from_rrs(cls, rrs):

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -22,6 +22,12 @@ def unquote(s):
 
 
 class NameValidator(RecordValidator):
+    '''
+    Validates record name and FQDN shape: rejects the legacy ``@`` alias,
+    enforces the 253-char total FQDN length and 63-char per-label length
+    limits from RFC 1035, and flags empty/double-dot labels.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         reasons = []
@@ -48,6 +54,11 @@ class NameValidator(RecordValidator):
 
 
 class TtlValidator(RecordValidator):
+    '''
+    Validates that the record has a ttl and that it is a non-negative
+    integer.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         reasons = []
@@ -61,6 +72,11 @@ class TtlValidator(RecordValidator):
 
 
 class HealthcheckValidator(RecordValidator):
+    '''
+    Validates the optional ``octodns.healthcheck.protocol`` setting, if
+    present, is one of the supported protocols.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         reasons = []

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -12,12 +12,70 @@ from ..equality import EqualityTupleMixin
 from ..idna import IdnaError, idna_decode, idna_encode
 from .change import Update
 from .exception import RecordException, ValidationError
+from .validator import RecordValidator
 
 
 def unquote(s):
     if s and s[0] in ('"', "'"):
         return s[1:-1]
     return s
+
+
+class NameValidator(RecordValidator):
+    @classmethod
+    def validate(cls, name, fqdn, data):
+        reasons = []
+        if name == '@':
+            reasons.append('invalid name "@", use "" instead')
+        n = len(fqdn)
+        if n > 253:
+            reasons.append(
+                f'invalid fqdn, "{idna_decode(fqdn)}" is too long at {n} '
+                'chars, max is 253'
+            )
+        for label in name.split('.'):
+            n = len(label)
+            if n > 63:
+                reasons.append(
+                    f'invalid label, "{label}" is too long at {n}'
+                    ' chars, max is 63'
+                )
+        # in the case of endswith there's an implicit second . from the Zone
+        if '..' in name or name.endswith('.'):
+            reasons.append(f'invalid name, double `.` in "{idna_decode(fqdn)}"')
+        # TODO: look at the idna lib for a lot more potential validations...
+        return reasons
+
+
+class TtlValidator(RecordValidator):
+    @classmethod
+    def validate(cls, name, fqdn, data):
+        reasons = []
+        try:
+            ttl = int(data['ttl'])
+            if ttl < 0:
+                reasons.append('invalid ttl')
+        except KeyError:
+            reasons.append('missing ttl')
+        return reasons
+
+
+class HealthcheckValidator(RecordValidator):
+    @classmethod
+    def validate(cls, name, fqdn, data):
+        reasons = []
+        try:
+            if data['octodns']['healthcheck']['protocol'] not in (
+                'HTTP',
+                'HTTPS',
+                'ICMP',
+                'TCP',
+                'UDP',
+            ):
+                reasons.append('invalid healthcheck protocol')
+        except KeyError:
+            pass
+        return reasons
 
 
 class Record(EqualityTupleMixin):
@@ -92,45 +150,13 @@ class Record(EqualityTupleMixin):
                 raise ValidationError(fqdn, reasons, context)
         return _class(zone, name, data, source=source, context=context)
 
+    VALIDATORS = [NameValidator, TtlValidator, HealthcheckValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = []
-        if name == '@':
-            reasons.append('invalid name "@", use "" instead')
-        n = len(fqdn)
-        if n > 253:
-            reasons.append(
-                f'invalid fqdn, "{idna_decode(fqdn)}" is too long at {n} '
-                'chars, max is 253'
-            )
-        for label in name.split('.'):
-            n = len(label)
-            if n > 63:
-                reasons.append(
-                    f'invalid label, "{label}" is too long at {n}'
-                    ' chars, max is 63'
-                )
-        # in the case of endswith there's an implicit second . from the Zone
-        if '..' in name or name.endswith('.'):
-            reasons.append(f'invalid name, double `.` in "{idna_decode(fqdn)}"')
-        # TODO: look at the idna lib for a lot more potential validations...
-        try:
-            ttl = int(data['ttl'])
-            if ttl < 0:
-                reasons.append('invalid ttl')
-        except KeyError:
-            reasons.append('missing ttl')
-        try:
-            if data['octodns']['healthcheck']['protocol'] not in (
-                'HTTP',
-                'HTTPS',
-                'ICMP',
-                'TCP',
-                'UDP',
-            ):
-                reasons.append('invalid healthcheck protocol')
-        except KeyError:
-            pass
+        for validator in Record.VALIDATORS:
+            reasons.extend(validator.validate(name, fqdn, data))
         return reasons
 
     @classmethod

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -5,6 +5,26 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import ValueValidator
+
+
+class CaaValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                flags = int(value.get('flags', 0))
+                if flags < 0 or flags > 255:
+                    reasons.append(f'invalid flags "{flags}"')
+            except ValueError:
+                reasons.append(f'invalid flags "{value["flags"]}"')
+
+            if 'tag' not in value:
+                reasons.append('missing tag')
+            if 'value' not in value:
+                reasons.append('missing value')
+        return reasons
 
 
 class CaaValue(EqualityTupleMixin, dict):
@@ -37,21 +57,13 @@ class CaaValue(EqualityTupleMixin, dict):
         value = unquote(value)
         return {'flags': flags, 'tag': tag, 'value': value}
 
+    VALIDATORS = [CaaValueValidator]
+
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            try:
-                flags = int(value.get('flags', 0))
-                if flags < 0 or flags > 255:
-                    reasons.append(f'invalid flags "{flags}"')
-            except ValueError:
-                reasons.append(f'invalid flags "{value["flags"]}"')
-
-            if 'tag' not in value:
-                reasons.append('missing tag')
-            if 'value' not in value:
-                reasons.append('missing value')
+        for validator in CaaValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -65,13 +65,6 @@ class CaaValue(EqualityTupleMixin, dict):
     VALIDATORS = [CaaValueValidator]
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in CaaValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -9,6 +9,11 @@ from .validator import ValueValidator
 
 
 class CaaValueValidator(ValueValidator):
+    '''
+    Validates CAA rdata: ``flags`` is an integer in [0, 255], and
+    ``tag`` and ``value`` are present.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -14,6 +14,9 @@ class ChunkedValueValidator(ValueValidator):
     ASCII-only, with no unescaped or double-escaped ``;`` characters.
     '''
 
+    _unescaped_semicolon_re = re.compile(r'\w;')
+    _double_escaped_semicolon_re = re.compile(r'\\\\;')
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         if not data:
@@ -22,9 +25,9 @@ class ChunkedValueValidator(ValueValidator):
             data = (data,)
         reasons = []
         for value in data:
-            if value_cls._unescaped_semicolon_re.search(value):
+            if cls._unescaped_semicolon_re.search(value):
                 reasons.append(f'unescaped ; in "{value}"')
-            if value_cls._double_escaped_semicolon_re.search(value):
+            if cls._double_escaped_semicolon_re.search(value):
                 reasons.append(f'double escaped ; in "{value}"')
             try:
                 value.encode('ascii')
@@ -68,9 +71,6 @@ class _ChunkedValuesMixin(ValuesMixin):
 
 
 class _ChunkedValue(str):
-    _unescaped_semicolon_re = re.compile(r'\w;')
-    _double_escaped_semicolon_re = re.compile(r'\\\\;')
-
     VALIDATORS = [ChunkedValueValidator]
 
     @classmethod

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -9,6 +9,11 @@ from .validator import ValueValidator
 
 
 class ChunkedValueValidator(ValueValidator):
+    '''
+    Validates values for TXT/SPF-style chunked strings: present,
+    ASCII-only, with no unescaped or double-escaped ``;`` characters.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         if not data:

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -85,13 +85,6 @@ class _ChunkedValue(str):
         return {'type': 'string'}
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in _ChunkedValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         ret = []
         for v in values:

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -5,6 +5,27 @@
 import re
 
 from .base import ValuesMixin
+from .validator import ValueValidator
+
+
+class ChunkedValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        if not data:
+            return ['missing value(s)']
+        elif not isinstance(data, (list, tuple)):
+            data = (data,)
+        reasons = []
+        for value in data:
+            if value_cls._unescaped_semicolon_re.search(value):
+                reasons.append(f'unescaped ; in "{value}"')
+            if value_cls._double_escaped_semicolon_re.search(value):
+                reasons.append(f'double escaped ; in "{value}"')
+            try:
+                value.encode('ascii')
+            except UnicodeEncodeError:
+                reasons.append(f'non ASCII character in "{value}"')
+        return reasons
 
 
 class _ChunkedValuesMixin(ValuesMixin):
@@ -45,6 +66,8 @@ class _ChunkedValue(str):
     _unescaped_semicolon_re = re.compile(r'\w;')
     _double_escaped_semicolon_re = re.compile(r'\\\\;')
 
+    VALIDATORS = [ChunkedValueValidator]
+
     @classmethod
     def parse_rdata_text(cls, value):
         try:
@@ -58,20 +81,9 @@ class _ChunkedValue(str):
 
     @classmethod
     def validate(cls, data, _type):
-        if not data:
-            return ['missing value(s)']
-        elif not isinstance(data, (list, tuple)):
-            data = (data,)
         reasons = []
-        for value in data:
-            if cls._unescaped_semicolon_re.search(value):
-                reasons.append(f'unescaped ; in "{value}"')
-            if cls._double_escaped_semicolon_re.search(value):
-                reasons.append(f'double escaped ; in "{value}"')
-            try:
-                value.encode('ascii')
-            except UnicodeEncodeError:
-                reasons.append(f'non ASCII character in "{value}"')
+        for validator in _ChunkedValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -13,6 +13,11 @@ class CnameValue(_TargetValue):
 
 
 class CnameRootValidator(RecordValidator):
+    '''
+    Rejects CNAME records at the zone root, which are prohibited by
+    RFC 1034/2181.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         if name == '':

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -5,10 +5,19 @@
 from .base import Record, ValueMixin
 from .dynamic import _DynamicMixin
 from .target import _TargetValue
+from .validator import RecordValidator
 
 
 class CnameValue(_TargetValue):
     pass
+
+
+class CnameRootValidator(RecordValidator):
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
+        if name == '':
+            return ['root CNAME not allowed']
+        return []
 
 
 class CnameRecord(_DynamicMixin, ValueMixin, Record):
@@ -16,11 +25,13 @@ class CnameRecord(_DynamicMixin, ValueMixin, Record):
     _type = 'CNAME'
     _value_type = CnameValue
 
+    VALIDATORS = [CnameRootValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = []
-        if name == '':
-            reasons.append('root CNAME not allowed')
+        for validator in CnameRecord.VALIDATORS:
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         reasons.extend(super().validate(name, fqdn, data))
         return reasons
 

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -32,13 +32,5 @@ class CnameRecord(_DynamicMixin, ValueMixin, Record):
 
     VALIDATORS = [CnameRootValidator]
 
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = []
-        for validator in CnameRecord.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
-        reasons.extend(super().validate(name, fqdn, data))
-        return reasons
-
 
 Record.register_type(CnameRecord)

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -136,13 +136,6 @@ class DsValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in DsValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -12,6 +12,13 @@ from .validator import ValueValidator
 
 
 class DsValueValidator(ValueValidator):
+    '''
+    Validates DS rdata. Supports both the current field names
+    (``key_tag``, ``algorithm``, ``digest_type``, ``digest``) and the
+    deprecated legacy field names (``flags``, ``protocol``,
+    ``algorithm``, ``public_key``), which will be removed in 2.0.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         if not isinstance(data, (list, tuple)):

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -8,63 +8,12 @@ from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin
 from .rr import RrParseError
+from .validator import ValueValidator
 
 
-class DsValue(EqualityTupleMixin, dict):
-    # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
-    log = getLogger('DsValue')
-
+class DsValueValidator(ValueValidator):
     @classmethod
-    def _schema(cls):
-        return {
-            'type': 'object',
-            'anyOf': [
-                {'required': ['key_tag', 'algorithm', 'digest_type', 'digest']},
-                # deprecated legacy form kept valid until 2.0
-                {'required': ['flags', 'protocol', 'algorithm', 'public_key']},
-            ],
-            'properties': {
-                'key_tag': {'type': 'integer', 'minimum': 0, 'maximum': 65535},
-                'algorithm': {'type': 'integer', 'minimum': 0, 'maximum': 255},
-                'digest_type': {
-                    'type': 'integer',
-                    'minimum': 0,
-                    'maximum': 255,
-                },
-                'digest': {'type': 'string'},
-                'flags': {'type': 'integer'},
-                'protocol': {'type': 'integer'},
-                'public_key': {'type': 'string'},
-            },
-        }
-
-    @classmethod
-    def parse_rdata_text(cls, value):
-        try:
-            key_tag, algorithm, digest_type, digest = value.split(' ')
-        except ValueError:
-            raise RrParseError()
-        try:
-            key_tag = int(key_tag)
-        except ValueError:
-            pass
-        try:
-            algorithm = int(algorithm)
-        except ValueError:
-            pass
-        try:
-            digest_type = int(digest_type)
-        except ValueError:
-            pass
-        return {
-            'key_tag': key_tag,
-            'algorithm': algorithm,
-            'digest_type': digest_type,
-            'digest': digest,
-        }
-
-    @classmethod
-    def validate(cls, data, _type):
+    def validate(cls, value_cls, data, _type):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
@@ -121,6 +70,69 @@ class DsValue(EqualityTupleMixin, dict):
                     )
                 if 'digest' not in value:
                     reasons.append('missing digest')
+        return reasons
+
+
+class DsValue(EqualityTupleMixin, dict):
+    # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
+    log = getLogger('DsValue')
+
+    VALIDATORS = [DsValueValidator]
+
+    @classmethod
+    def _schema(cls):
+        return {
+            'type': 'object',
+            'anyOf': [
+                {'required': ['key_tag', 'algorithm', 'digest_type', 'digest']},
+                # deprecated legacy form kept valid until 2.0
+                {'required': ['flags', 'protocol', 'algorithm', 'public_key']},
+            ],
+            'properties': {
+                'key_tag': {'type': 'integer', 'minimum': 0, 'maximum': 65535},
+                'algorithm': {'type': 'integer', 'minimum': 0, 'maximum': 255},
+                'digest_type': {
+                    'type': 'integer',
+                    'minimum': 0,
+                    'maximum': 255,
+                },
+                'digest': {'type': 'string'},
+                'flags': {'type': 'integer'},
+                'protocol': {'type': 'integer'},
+                'public_key': {'type': 'string'},
+            },
+        }
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        try:
+            key_tag, algorithm, digest_type, digest = value.split(' ')
+        except ValueError:
+            raise RrParseError()
+        try:
+            key_tag = int(key_tag)
+        except ValueError:
+            pass
+        try:
+            algorithm = int(algorithm)
+        except ValueError:
+            pass
+        try:
+            digest_type = int(digest_type)
+        except ValueError:
+            pass
+        return {
+            'key_tag': key_tag,
+            'algorithm': algorithm,
+            'digest_type': digest_type,
+            'digest': digest,
+        }
+
+    @classmethod
+    def validate(cls, data, _type):
+        reasons = []
+        for validator in DsValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -9,6 +9,43 @@ from logging import getLogger
 from .change import Update
 from .geo import GeoCodes
 from .subnet import Subnets
+from .validator import RecordValidator
+
+
+class DynamicValidator(RecordValidator):
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
+        reasons = []
+
+        if 'dynamic' not in data:
+            return reasons
+        elif 'geo' in data:
+            reasons.append('"dynamic" record with "geo" content')
+
+        try:
+            pools = data['dynamic']['pools']
+        except KeyError:
+            pools = {}
+
+        pool_reasons, pools_exist, pools_seen_as_fallback = (
+            record_cls._validate_pools(pools)
+        )
+        reasons.extend(pool_reasons)
+
+        try:
+            rules = data['dynamic']['rules']
+        except KeyError:
+            rules = []
+
+        rule_reasons, pools_seen = record_cls._validate_rules(pools, rules)
+        reasons.extend(rule_reasons)
+
+        unused = pools_exist - pools_seen - pools_seen_as_fallback
+        if unused:
+            unused = '", "'.join(sorted(unused))
+            reasons.append(f'unused pools: "{unused}"')
+
+        return reasons
 
 
 class _DynamicPool(object):
@@ -414,38 +451,13 @@ class _DynamicMixin(object):
 
         return reasons, pools_seen
 
+    VALIDATORS = [DynamicValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = super().validate(name, fqdn, data)
-
-        if 'dynamic' not in data:
-            return reasons
-        elif 'geo' in data:
-            reasons.append('"dynamic" record with "geo" content')
-
-        try:
-            pools = data['dynamic']['pools']
-        except KeyError:
-            pools = {}
-
-        pool_reasons, pools_exist, pools_seen_as_fallback = cls._validate_pools(
-            pools
-        )
-        reasons.extend(pool_reasons)
-
-        try:
-            rules = data['dynamic']['rules']
-        except KeyError:
-            rules = []
-
-        rule_reasons, pools_seen = cls._validate_rules(pools, rules)
-        reasons.extend(rule_reasons)
-
-        unused = pools_exist - pools_seen - pools_seen_as_fallback
-        if unused:
-            unused = '", "'.join(sorted(unused))
-            reasons.append(f'unused pools: "{unused}"')
-
+        for validator in _DynamicMixin.VALIDATORS:
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         return reasons
 
     def __init__(self, zone, name, data, *args, **kwargs):

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -6,6 +6,7 @@ import re
 from collections import defaultdict
 from logging import getLogger
 
+from .base import _process_value_validators
 from .change import Update
 from .geo import GeoCodes
 from .subnet import Subnets
@@ -290,7 +291,9 @@ class _DynamicMixin(object):
                     try:
                         value = value['value']
                         reasons.extend(
-                            cls._value_type.validate(value, cls._type)
+                            _process_value_validators(
+                                cls._value_type, value, cls._type
+                            )
                         )
                     except KeyError:
                         reasons.append(
@@ -459,13 +462,6 @@ class _DynamicMixin(object):
         return reasons, pools_seen
 
     VALIDATORS = [DynamicValidator]
-
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = super().validate(name, fqdn, data)
-        for validator in _DynamicMixin.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
-        return reasons
 
     def __init__(self, zone, name, data, *args, **kwargs):
         super().__init__(zone, name, data, *args, **kwargs)

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -13,6 +13,13 @@ from .validator import RecordValidator
 
 
 class DynamicValidator(RecordValidator):
+    '''
+    Validates the ``dynamic`` block of a dynamic record: the pools
+    structure (fallback chains, value types, status flags), the rules
+    list (geo/subnet targeting and pool references), and that no pools
+    are defined but unused.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         reasons = []

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -133,6 +133,12 @@ class GeoValue(EqualityTupleMixin):
 
 
 class GeoValidator(RecordValidator):
+    '''
+    Validates the deprecated ``geo`` block of a record: each key is a
+    valid continent/country/subdivision code and each list of values
+    passes the record's value-type validation.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         reasons = []

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
-from .base import ValuesMixin
+from .base import ValuesMixin, _process_value_validators
 from .change import Update
 from .geo_data import geo_data
 from .validator import RecordValidator
@@ -151,7 +151,9 @@ class GeoValidator(RecordValidator):
             for code, values in geo.items():
                 reasons.extend(GeoValue._validate_geo(code))
                 reasons.extend(
-                    record_cls._value_type.validate(values, record_cls._type)
+                    _process_value_validators(
+                        record_cls._value_type, values, record_cls._type
+                    )
                 )
         except KeyError:
             pass
@@ -183,13 +185,6 @@ class _GeoMixin(ValuesMixin):
         }
 
     VALIDATORS = [GeoValidator]
-
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = super().validate(name, fqdn, data)
-        for validator in _GeoMixin.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
-        return reasons
 
     def __init__(self, zone, name, data, *args, **kwargs):
         super().__init__(zone, name, data, *args, **kwargs)

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -10,6 +10,7 @@ from ..equality import EqualityTupleMixin
 from .base import ValuesMixin
 from .change import Update
 from .geo_data import geo_data
+from .validator import RecordValidator
 
 
 class GeoCodes(object):
@@ -131,6 +132,26 @@ class GeoValue(EqualityTupleMixin):
         )
 
 
+class GeoValidator(RecordValidator):
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
+        reasons = []
+        try:
+            geo = dict(data['geo'])
+            deprecated(
+                '`geo` records are DEPRECATED. `dynamic` records should be used instead. Will be removed in 2.0',
+                stacklevel=99,
+            )
+            for code, values in geo.items():
+                reasons.extend(GeoValue._validate_geo(code))
+                reasons.extend(
+                    record_cls._value_type.validate(values, record_cls._type)
+                )
+        except KeyError:
+            pass
+        return reasons
+
+
 class _GeoMixin(ValuesMixin):
     '''
     Adds GeoDNS support to a record.
@@ -155,20 +176,13 @@ class _GeoMixin(ValuesMixin):
             },
         }
 
+    VALIDATORS = [GeoValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = super().validate(name, fqdn, data)
-        try:
-            geo = dict(data['geo'])
-            deprecated(
-                '`geo` records are DEPRECATED. `dynamic` records should be used instead. Will be removed in 2.0',
-                stacklevel=99,
-            )
-            for code, values in geo.items():
-                reasons.extend(GeoValue._validate_geo(code))
-                reasons.extend(cls._value_type.validate(values, cls._type))
-        except KeyError:
-            pass
+        for validator in _GeoMixin.VALIDATORS:
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         return reasons
 
     def __init__(self, zone, name, data, *args, **kwargs):

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -46,13 +46,6 @@ class _IpValue(str):
         return {'type': 'string', 'format': cls._address_name.lower()}
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in _IpValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         # Translating None into '' so that the list will be sortable in
         # python3, get everything to str first

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -7,6 +7,12 @@ from .validator import ValueValidator
 
 
 class IpValueValidator(ValueValidator):
+    '''
+    Validates IP address values: rejects empty/missing values and
+    defers to the value class's ``_address_type`` (``IPv4Address`` or
+    ``IPv6Address``) to parse each value.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         if not isinstance(data, (list, tuple)):

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -3,17 +3,12 @@
 #
 
 
-class _IpValue(str):
-    @classmethod
-    def parse_rdata_text(cls, value):
-        return value
+from .validator import ValueValidator
 
-    @classmethod
-    def _schema(cls):
-        return {'type': 'string', 'format': cls._address_name.lower()}
 
+class IpValueValidator(ValueValidator):
     @classmethod
-    def validate(cls, data, _type):
+    def validate(cls, value_cls, data, _type):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         if len(data) == 0:
@@ -26,10 +21,29 @@ class _IpValue(str):
                 reasons.append('missing value(s)')
             else:
                 try:
-                    cls._address_type(str(value))
+                    value_cls._address_type(str(value))
                 except Exception:
-                    addr_name = cls._address_name
+                    addr_name = value_cls._address_name
                     reasons.append(f'invalid {addr_name} address "{value}"')
+        return reasons
+
+
+class _IpValue(str):
+    VALIDATORS = [IpValueValidator]
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        return value
+
+    @classmethod
+    def _schema(cls):
+        return {'type': 'string', 'format': cls._address_name.lower()}
+
+    @classmethod
+    def validate(cls, data, _type):
+        reasons = []
+        for validator in _IpValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -9,6 +9,14 @@ from .validator import ValueValidator
 
 
 class LocValueValidator(ValueValidator):
+    '''
+    Validates LOC rdata per RFC 1876: latitude/longitude degrees and
+    minutes are integers in their respective ranges, the seconds,
+    altitude, size, and precision fields are floats in range, and the
+    ``lat_direction`` (N/S) and ``long_direction`` (E/W) are valid
+    cardinal directions.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         int_keys = [

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -259,13 +259,6 @@ class LocValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in LocValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -5,6 +5,98 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import ValueValidator
+
+
+class LocValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        int_keys = [
+            'lat_degrees',
+            'lat_minutes',
+            'long_degrees',
+            'long_minutes',
+        ]
+
+        float_keys = [
+            'lat_seconds',
+            'long_seconds',
+            'altitude',
+            'size',
+            'precision_horz',
+            'precision_vert',
+        ]
+
+        direction_keys = ['lat_direction', 'long_direction']
+
+        reasons = []
+        for value in data:
+            for key in int_keys:
+                try:
+                    int(value[key])
+                    if (
+                        (
+                            key == 'lat_degrees'
+                            and not 0 <= int(value[key]) <= 90
+                        )
+                        or (
+                            key == 'long_degrees'
+                            and not 0 <= int(value[key]) <= 180
+                        )
+                        or (
+                            key in ['lat_minutes', 'long_minutes']
+                            and not 0 <= int(value[key]) <= 59
+                        )
+                    ):
+                        reasons.append(
+                            f'invalid value for {key} ' f'"{value[key]}"'
+                        )
+                except KeyError:
+                    reasons.append(f'missing {key}')
+                except ValueError:
+                    reasons.append(f'invalid {key} "{value[key]}"')
+
+            for key in float_keys:
+                try:
+                    float(value[key])
+                    if (
+                        (
+                            key in ['lat_seconds', 'long_seconds']
+                            and not 0 <= float(value[key]) <= 59.999
+                        )
+                        or (
+                            key == 'altitude'
+                            and not -100000.00
+                            <= float(value[key])
+                            <= 42849672.95
+                        )
+                        or (
+                            key in ['size', 'precision_horz', 'precision_vert']
+                            and not 0 <= float(value[key]) <= 90000000.00
+                        )
+                    ):
+                        reasons.append(
+                            f'invalid value for {key} ' f'"{value[key]}"'
+                        )
+                except KeyError:
+                    reasons.append(f'missing {key}')
+                except ValueError:
+                    reasons.append(f'invalid {key} "{value[key]}"')
+
+            for key in direction_keys:
+                try:
+                    str(value[key])
+                    if key == 'lat_direction' and value[key] not in ['N', 'S']:
+                        reasons.append(
+                            f'invalid direction for {key} ' f'"{value[key]}"'
+                        )
+                    if key == 'long_direction' and value[key] not in ['E', 'W']:
+                        reasons.append(
+                            f'invalid direction for {key} ' f'"{value[key]}"'
+                        )
+                except KeyError:
+                    reasons.append(f'missing {key}')
+        return reasons
 
 
 class LocValue(EqualityTupleMixin, dict):
@@ -12,6 +104,8 @@ class LocValue(EqualityTupleMixin, dict):
     # of how the type was impelemented. Would be nice to rework things to match
     # while maintaining backwards compatibility.
     # https://www.rfc-editor.org/rfc/rfc1876.html
+
+    VALIDATORS = [LocValueValidator]
 
     @classmethod
     def _schema(cls):
@@ -158,91 +252,9 @@ class LocValue(EqualityTupleMixin, dict):
 
     @classmethod
     def validate(cls, data, _type):
-        int_keys = [
-            'lat_degrees',
-            'lat_minutes',
-            'long_degrees',
-            'long_minutes',
-        ]
-
-        float_keys = [
-            'lat_seconds',
-            'long_seconds',
-            'altitude',
-            'size',
-            'precision_horz',
-            'precision_vert',
-        ]
-
-        direction_keys = ['lat_direction', 'long_direction']
-
         reasons = []
-        for value in data:
-            for key in int_keys:
-                try:
-                    int(value[key])
-                    if (
-                        (
-                            key == 'lat_degrees'
-                            and not 0 <= int(value[key]) <= 90
-                        )
-                        or (
-                            key == 'long_degrees'
-                            and not 0 <= int(value[key]) <= 180
-                        )
-                        or (
-                            key in ['lat_minutes', 'long_minutes']
-                            and not 0 <= int(value[key]) <= 59
-                        )
-                    ):
-                        reasons.append(
-                            f'invalid value for {key} ' f'"{value[key]}"'
-                        )
-                except KeyError:
-                    reasons.append(f'missing {key}')
-                except ValueError:
-                    reasons.append(f'invalid {key} "{value[key]}"')
-
-            for key in float_keys:
-                try:
-                    float(value[key])
-                    if (
-                        (
-                            key in ['lat_seconds', 'long_seconds']
-                            and not 0 <= float(value[key]) <= 59.999
-                        )
-                        or (
-                            key == 'altitude'
-                            and not -100000.00
-                            <= float(value[key])
-                            <= 42849672.95
-                        )
-                        or (
-                            key in ['size', 'precision_horz', 'precision_vert']
-                            and not 0 <= float(value[key]) <= 90000000.00
-                        )
-                    ):
-                        reasons.append(
-                            f'invalid value for {key} ' f'"{value[key]}"'
-                        )
-                except KeyError:
-                    reasons.append(f'missing {key}')
-                except ValueError:
-                    reasons.append(f'invalid {key} "{value[key]}"')
-
-            for key in direction_keys:
-                try:
-                    str(value[key])
-                    if key == 'lat_direction' and value[key] not in ['N', 'S']:
-                        reasons.append(
-                            f'invalid direction for {key} ' f'"{value[key]}"'
-                        )
-                    if key == 'long_direction' and value[key] not in ['E', 'W']:
-                        reasons.append(
-                            f'invalid direction for {key} ' f'"{value[key]}"'
-                        )
-                except KeyError:
-                    reasons.append(f'missing {key}')
+        for validator in LocValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -7,6 +7,30 @@ from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import validate_target_fqdn
+from .validator import ValueValidator
+
+
+class MxValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                try:
+                    int(value['preference'])
+                except KeyError:
+                    int(value['priority'])
+            except KeyError:
+                reasons.append('missing preference')
+            except ValueError:
+                reasons.append(f'invalid preference "{value["preference"]}"')
+            exchange = None
+            try:
+                exchange = value.get('exchange') or value['value']
+                reasons += validate_target_fqdn(exchange, _type, 'exchange')
+            except KeyError:
+                reasons.append('missing exchange')
+        return reasons
 
 
 class MxValue(EqualityTupleMixin, dict):
@@ -55,25 +79,13 @@ class MxValue(EqualityTupleMixin, dict):
         exchange = unquote(exchange)
         return {'preference': preference, 'exchange': exchange}
 
+    VALIDATORS = [MxValueValidator]
+
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            try:
-                try:
-                    int(value['preference'])
-                except KeyError:
-                    int(value['priority'])
-            except KeyError:
-                reasons.append('missing preference')
-            except ValueError:
-                reasons.append(f'invalid preference "{value["preference"]}"')
-            exchange = None
-            try:
-                exchange = value.get('exchange') or value['value']
-                reasons += validate_target_fqdn(exchange, _type, 'exchange')
-            except KeyError:
-                reasons.append('missing exchange')
+        for validator in MxValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -88,13 +88,6 @@ class MxValue(EqualityTupleMixin, dict):
     VALIDATORS = [MxValueValidator]
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in MxValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -11,6 +11,12 @@ from .validator import ValueValidator
 
 
 class MxValueValidator(ValueValidator):
+    '''
+    Validates MX rdata: an integer-parsable ``preference`` (or legacy
+    ``priority`` alias) and a valid ``exchange`` FQDN (or legacy
+    ``value`` alias).
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -104,13 +104,6 @@ class NaptrValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in NaptrValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -9,6 +9,12 @@ from .validator import ValueValidator
 
 
 class NaptrValueValidator(ValueValidator):
+    '''
+    Validates NAPTR rdata: ``order`` and ``preference`` are
+    integer-parsable, ``flags`` is one of the RFC 3403 values, and
+    ``service``, ``regexp``, and ``replacement`` are all present.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -5,10 +5,45 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import ValueValidator
+
+
+class NaptrValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                int(value['order'])
+            except KeyError:
+                reasons.append('missing order')
+            except ValueError:
+                reasons.append(f'invalid order "{value["order"]}"')
+            try:
+                int(value['preference'])
+            except KeyError:
+                reasons.append('missing preference')
+            except ValueError:
+                reasons.append(f'invalid preference "{value["preference"]}"')
+            try:
+                flags = value['flags']
+                if flags not in value_cls.VALID_FLAGS:
+                    reasons.append(f'unrecognized flags "{flags}"')
+            except KeyError:
+                reasons.append('missing flags')
+
+            # TODO: validate these... they're non-trivial
+            for k in ('service', 'regexp', 'replacement'):
+                if k not in value:
+                    reasons.append(f'missing {k}')
+
+        return reasons
 
 
 class NaptrValue(EqualityTupleMixin, dict):
     VALID_FLAGS = ('S', 'A', 'U', 'P', 's', 'a', 'u', 'p')
+
+    VALIDATORS = [NaptrValueValidator]
 
     @classmethod
     def _schema(cls):
@@ -65,31 +100,8 @@ class NaptrValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            try:
-                int(value['order'])
-            except KeyError:
-                reasons.append('missing order')
-            except ValueError:
-                reasons.append(f'invalid order "{value["order"]}"')
-            try:
-                int(value['preference'])
-            except KeyError:
-                reasons.append('missing preference')
-            except ValueError:
-                reasons.append(f'invalid preference "{value["preference"]}"')
-            try:
-                flags = value['flags']
-                if flags not in cls.VALID_FLAGS:
-                    reasons.append(f'unrecognized flags "{flags}"')
-            except KeyError:
-                reasons.append('missing flags')
-
-            # TODO: validate these... they're non-trivial
-            for k in ('service', 'regexp', 'replacement'):
-                if k not in value:
-                    reasons.append(f'missing {k}')
-
+        for validator in NaptrValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -7,6 +7,11 @@ from .validator import ValueValidator
 
 
 class OpenpgpkeyValueValidator(ValueValidator):
+    '''
+    Validates OPENPGPKEY values: at least one non-empty base64-encoded
+    OpenPGP key must be provided.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         if not data or all(not d for d in data):

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -39,13 +39,6 @@ class OpenpgpkeyValue(str):
         return value.replace(' ', '')
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in OpenpgpkeyValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -3,6 +3,15 @@
 #
 
 from .base import Record, ValuesMixin
+from .validator import ValueValidator
+
+
+class OpenpgpkeyValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        if not data or all(not d for d in data):
+            return ['missing value(s)']
+        return []
 
 
 class OpenpgpkeyValue(str):
@@ -11,6 +20,8 @@ class OpenpgpkeyValue(str):
 
     RFC 7929 - DANE Bindings for OpenPGP
     '''
+
+    VALIDATORS = [OpenpgpkeyValueValidator]
 
     @classmethod
     def _schema(cls):
@@ -24,9 +35,10 @@ class OpenpgpkeyValue(str):
 
     @classmethod
     def validate(cls, data, _type):
-        if not data or all(not d for d in data):
-            return ['missing value(s)']
-        return []
+        reasons = []
+        for validator in OpenpgpkeyValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
+        return reasons
 
     @classmethod
     def process(cls, values):

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -9,7 +9,7 @@ from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import validate_target_fqdn
-from .validator import RecordValidator
+from .validator import RecordValidator, ValueValidator
 
 
 class SrvNameValidator(RecordValidator):
@@ -20,7 +20,41 @@ class SrvNameValidator(RecordValidator):
         return []
 
 
+class SrvValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            # TODO: validate algorithm and fingerprint_type values
+            try:
+                int(value['priority'])
+            except KeyError:
+                reasons.append('missing priority')
+            except ValueError:
+                reasons.append(f'invalid priority "{value["priority"]}"')
+            try:
+                int(value['weight'])
+            except KeyError:
+                reasons.append('missing weight')
+            except ValueError:
+                reasons.append(f'invalid weight "{value["weight"]}"')
+            try:
+                int(value['port'])
+            except KeyError:
+                reasons.append('missing port')
+            except ValueError:
+                reasons.append(f'invalid port "{value["port"]}"')
+            try:
+                target = value['target']
+                reasons += validate_target_fqdn(target, _type, 'target')
+            except KeyError:
+                reasons.append('missing target')
+        return reasons
+
+
 class SrvValue(EqualityTupleMixin, dict):
+    VALIDATORS = [SrvValueValidator]
+
     @classmethod
     def _schema(cls):
         return {
@@ -63,31 +97,8 @@ class SrvValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            # TODO: validate algorithm and fingerprint_type values
-            try:
-                int(value['priority'])
-            except KeyError:
-                reasons.append('missing priority')
-            except ValueError:
-                reasons.append(f'invalid priority "{value["priority"]}"')
-            try:
-                int(value['weight'])
-            except KeyError:
-                reasons.append('missing weight')
-            except ValueError:
-                reasons.append(f'invalid weight "{value["weight"]}"')
-            try:
-                int(value['port'])
-            except KeyError:
-                reasons.append('missing port')
-            except ValueError:
-                reasons.append(f'invalid port "{value["port"]}"')
-            try:
-                target = value['target']
-                reasons += validate_target_fqdn(target, _type, 'target')
-            except KeyError:
-                reasons.append('missing target')
+        for validator in SrvValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -108,13 +108,6 @@ class SrvValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in SrvValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 
@@ -194,14 +187,6 @@ class SrvRecord(ValuesMixin, Record):
     _value_type = SrvValue
 
     VALIDATORS = [SrvNameValidator]
-
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = []
-        for validator in SrvRecord.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
-        reasons.extend(super().validate(name, fqdn, data))
-        return reasons
 
 
 Record.register_type(SrvRecord)

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -13,6 +13,12 @@ from .validator import RecordValidator, ValueValidator
 
 
 class SrvNameValidator(RecordValidator):
+    '''
+    Validates that an SRV record's name matches the
+    ``_service._protocol`` pattern required by RFC 2782 (e.g.
+    ``_http._tcp``), or is a wildcard.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         if not record_cls._name_re.match(name):
@@ -21,6 +27,11 @@ class SrvNameValidator(RecordValidator):
 
 
 class SrvValueValidator(ValueValidator):
+    '''
+    Validates SRV rdata: priority, weight, and port are present and
+    integer-parsable, and target is a valid FQDN.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -19,9 +19,11 @@ class SrvNameValidator(RecordValidator):
     ``_http._tcp``), or is a wildcard.
     '''
 
+    _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
-        if not record_cls._name_re.match(name):
+        if not cls._name_re.match(name):
             return ['invalid name for SRV record']
         return []
 
@@ -190,7 +192,6 @@ class SrvRecord(ValuesMixin, Record):
     )
     _type = 'SRV'
     _value_type = SrvValue
-    _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
     VALIDATORS = [SrvNameValidator]
 

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -9,6 +9,15 @@ from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import validate_target_fqdn
+from .validator import RecordValidator
+
+
+class SrvNameValidator(RecordValidator):
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
+        if not record_cls._name_re.match(name):
+            return ['invalid name for SRV record']
+        return []
 
 
 class SrvValue(EqualityTupleMixin, dict):
@@ -161,11 +170,13 @@ class SrvRecord(ValuesMixin, Record):
     _value_type = SrvValue
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
+    VALIDATORS = [SrvNameValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = []
-        if not cls._name_re.match(name):
-            reasons.append('invalid name for SRV record')
+        for validator in SrvRecord.VALIDATORS:
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         reasons.extend(super().validate(name, fqdn, data))
         return reasons
 

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -16,6 +16,11 @@ class SshfpValueValidator(ValueValidator):
     SHA-256 = 64).
     '''
 
+    # Expected fingerprint hex-string length per fingerprint_type, from RFC
+    # 4255/6594: type 1 = SHA-1 (160 bits, 40 hex chars), type 2 = SHA-256
+    # (256 bits, 64 hex chars).
+    FINGERPRINT_LENGTHS = {1: 40, 2: 64}
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []
@@ -49,8 +54,8 @@ class SshfpValueValidator(ValueValidator):
             # an actual fingerprint; unknown types and missing fingerprints
             # are already reported above and we don't want to stack a
             # confusing secondary error on top of them.
-            elif fingerprint_type in value_cls.FINGERPRINT_LENGTHS:
-                expected = value_cls.FINGERPRINT_LENGTHS[fingerprint_type]
+            elif fingerprint_type in cls.FINGERPRINT_LENGTHS:
+                expected = cls.FINGERPRINT_LENGTHS[fingerprint_type]
                 actual = len(value['fingerprint'])
                 if actual != expected:
                     reasons.append(
@@ -64,10 +69,6 @@ class SshfpValueValidator(ValueValidator):
 class SshfpValue(EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
-    # Expected fingerprint hex-string length per fingerprint_type, from RFC
-    # 4255/6594: type 1 = SHA-1 (160 bits, 40 hex chars), type 2 = SHA-256
-    # (256 bits, 64 hex chars).
-    FINGERPRINT_LENGTHS = {1: 40, 2: 64}
 
     VALIDATORS = [SshfpValueValidator]
 

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -9,6 +9,13 @@ from .validator import ValueValidator
 
 
 class SshfpValueValidator(ValueValidator):
+    '''
+    Validates SSHFP rdata: ``algorithm`` and ``fingerprint_type`` are
+    from the recognized sets in RFC 4255/6594, and the ``fingerprint``
+    hex string's length matches the fingerprint type (SHA-1 = 40,
+    SHA-256 = 64).
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -5,6 +5,53 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import ValueValidator
+
+
+class SshfpValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                algorithm = int(value['algorithm'])
+                if algorithm not in value_cls.VALID_ALGORITHMS:
+                    reasons.append(f'unrecognized algorithm "{algorithm}"')
+            except KeyError:
+                reasons.append('missing algorithm')
+            except ValueError:
+                reasons.append(f'invalid algorithm "{value["algorithm"]}"')
+            # Start unset so the length check below can tell the difference
+            # between a known-good fingerprint_type and a missing/invalid one.
+            fingerprint_type = None
+            try:
+                fingerprint_type = int(value['fingerprint_type'])
+                if fingerprint_type not in value_cls.VALID_FINGERPRINT_TYPES:
+                    reasons.append(
+                        'unrecognized fingerprint_type ' f'"{fingerprint_type}"'
+                    )
+            except KeyError:
+                reasons.append('missing fingerprint_type')
+            except ValueError:
+                reasons.append(
+                    'invalid fingerprint_type ' f'"{value["fingerprint_type"]}"'
+                )
+            if 'fingerprint' not in value:
+                reasons.append('missing fingerprint')
+            # Only length-check when we have both a known fingerprint_type and
+            # an actual fingerprint; unknown types and missing fingerprints
+            # are already reported above and we don't want to stack a
+            # confusing secondary error on top of them.
+            elif fingerprint_type in value_cls.FINGERPRINT_LENGTHS:
+                expected = value_cls.FINGERPRINT_LENGTHS[fingerprint_type]
+                actual = len(value['fingerprint'])
+                if actual != expected:
+                    reasons.append(
+                        f'fingerprint length {actual} does not match '
+                        f'fingerprint_type {fingerprint_type} '
+                        f'(expected {expected})'
+                    )
+        return reasons
 
 
 class SshfpValue(EqualityTupleMixin, dict):
@@ -14,6 +61,8 @@ class SshfpValue(EqualityTupleMixin, dict):
     # 4255/6594: type 1 = SHA-1 (160 bits, 40 hex chars), type 2 = SHA-256
     # (256 bits, 64 hex chars).
     FINGERPRINT_LENGTHS = {1: 40, 2: 64}
+
+    VALIDATORS = [SshfpValueValidator]
 
     @classmethod
     def _schema(cls):
@@ -53,45 +102,8 @@ class SshfpValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            try:
-                algorithm = int(value['algorithm'])
-                if algorithm not in cls.VALID_ALGORITHMS:
-                    reasons.append(f'unrecognized algorithm "{algorithm}"')
-            except KeyError:
-                reasons.append('missing algorithm')
-            except ValueError:
-                reasons.append(f'invalid algorithm "{value["algorithm"]}"')
-            # Start unset so the length check below can tell the difference
-            # between a known-good fingerprint_type and a missing/invalid one.
-            fingerprint_type = None
-            try:
-                fingerprint_type = int(value['fingerprint_type'])
-                if fingerprint_type not in cls.VALID_FINGERPRINT_TYPES:
-                    reasons.append(
-                        'unrecognized fingerprint_type ' f'"{fingerprint_type}"'
-                    )
-            except KeyError:
-                reasons.append('missing fingerprint_type')
-            except ValueError:
-                reasons.append(
-                    'invalid fingerprint_type ' f'"{value["fingerprint_type"]}"'
-                )
-            if 'fingerprint' not in value:
-                reasons.append('missing fingerprint')
-            # Only length-check when we have both a known fingerprint_type and
-            # an actual fingerprint; unknown types and missing fingerprints
-            # are already reported above and we don't want to stack a
-            # confusing secondary error on top of them.
-            elif fingerprint_type in cls.FINGERPRINT_LENGTHS:
-                expected = cls.FINGERPRINT_LENGTHS[fingerprint_type]
-                actual = len(value['fingerprint'])
-                if actual != expected:
-                    reasons.append(
-                        f'fingerprint length {actual} does not match '
-                        f'fingerprint_type {fingerprint_type} '
-                        f'(expected {expected})'
-                    )
+        for validator in SshfpValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -108,13 +108,6 @@ class SshfpValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in SshfpValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -13,6 +13,7 @@ from .base import Record, ValuesMixin, unquote
 from .chunked import _ChunkedValue
 from .rr import RrParseError
 from .target import validate_target_fqdn
+from .validator import ValueValidator
 
 SUPPORTED_PARAMS = {}
 
@@ -140,7 +141,59 @@ SUPPORTED_PARAMS = {
 }
 
 
+class SvcbValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            svcpriority = -1
+            if 'svcpriority' not in value:
+                reasons.append('missing svcpriority')
+            else:
+                try:
+                    svcpriority = int(value.get('svcpriority', 0))
+                    if svcpriority < 0 or svcpriority > 65535:
+                        reasons.append(f'invalid priority ' f'"{svcpriority}"')
+                except ValueError:
+                    reasons.append(f'invalid priority "{value["svcpriority"]}"')
+
+            reasons += validate_target_fqdn(
+                value.get('targetname'), _type, 'targetname'
+            )
+
+            if 'svcparams' in value:
+                svcparams = value.get('svcparams', dict())
+                if svcpriority == 0 and len(svcparams) != 0:
+                    reasons.append('svcparams set on AliasMode SVCB record')
+                for svcparamkey, svcparamvalue in svcparams.items():
+                    # XXX: Should we test for keys existing when set in 'mandatory'?
+                    if svcparamkey.startswith('key'):
+                        reasons += validate_svckey_number(svcparamkey)
+                        continue
+                    if (
+                        svcparamkey not in SUPPORTED_PARAMS.keys()
+                        and not svcparamkey.startswith('key')
+                    ):
+                        reasons.append(f'Unknown SvcParam {svcparamkey}')
+                        continue
+                    if SUPPORTED_PARAMS[svcparamkey].get('has_arg', True):
+                        reasons += SUPPORTED_PARAMS[svcparamkey]['validate'](
+                            svcparamvalue
+                        )
+                    if (
+                        not SUPPORTED_PARAMS[svcparamkey].get('has_arg', True)
+                        and svcparamvalue is not None
+                    ):
+                        reasons.append(
+                            f'SvcParam {svcparamkey} has value when it should not'
+                        )
+
+        return reasons
+
+
 class SvcbValue(EqualityTupleMixin, dict):
+
+    VALIDATORS = [SvcbValueValidator]
 
     @classmethod
     def _schema(cls):
@@ -196,49 +249,8 @@ class SvcbValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            svcpriority = -1
-            if 'svcpriority' not in value:
-                reasons.append('missing svcpriority')
-            else:
-                try:
-                    svcpriority = int(value.get('svcpriority', 0))
-                    if svcpriority < 0 or svcpriority > 65535:
-                        reasons.append(f'invalid priority ' f'"{svcpriority}"')
-                except ValueError:
-                    reasons.append(f'invalid priority "{value["svcpriority"]}"')
-
-            reasons += validate_target_fqdn(
-                value.get('targetname'), _type, 'targetname'
-            )
-
-            if 'svcparams' in value:
-                svcparams = value.get('svcparams', dict())
-                if svcpriority == 0 and len(svcparams) != 0:
-                    reasons.append('svcparams set on AliasMode SVCB record')
-                for svcparamkey, svcparamvalue in svcparams.items():
-                    # XXX: Should we test for keys existing when set in 'mandatory'?
-                    if svcparamkey.startswith('key'):
-                        reasons += validate_svckey_number(svcparamkey)
-                        continue
-                    if (
-                        svcparamkey not in SUPPORTED_PARAMS.keys()
-                        and not svcparamkey.startswith('key')
-                    ):
-                        reasons.append(f'Unknown SvcParam {svcparamkey}')
-                        continue
-                    if SUPPORTED_PARAMS[svcparamkey].get('has_arg', True):
-                        reasons += SUPPORTED_PARAMS[svcparamkey]['validate'](
-                            svcparamvalue
-                        )
-                    if (
-                        not SUPPORTED_PARAMS[svcparamkey].get('has_arg', True)
-                        and svcparamvalue is not None
-                    ):
-                        reasons.append(
-                            f'SvcParam {svcparamkey} has value when it should not'
-                        )
-
+        for validator in SvcbValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -142,6 +142,14 @@ SUPPORTED_PARAMS = {
 
 
 class SvcbValueValidator(ValueValidator):
+    '''
+    Validates SVCB/HTTPS rdata per RFC 9460: ``svcpriority`` in
+    [0, 65535], ``targetname`` is a valid FQDN, and each SvcParam is
+    either a recognized key (validated by its per-key helper) or a
+    properly-formed ``keyNNN`` number. Also rejects SvcParams on
+    AliasMode (``svcpriority`` == 0) records.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -9,7 +9,7 @@ from ipaddress import AddressValueError, IPv4Address, IPv6Address
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, _process_value_validators, unquote
 from .chunked import _ChunkedValue
 from .rr import RrParseError
 from .target import validate_target_fqdn
@@ -40,7 +40,7 @@ def validate_svcparam_alpn(svcparamvalue):
     if len(reasons) != 0:
         return reasons
     for alpn in svcparamvalue:
-        reasons += _ChunkedValue.validate(alpn, 'SVCB')
+        reasons += _process_value_validators(_ChunkedValue, alpn, 'SVCB')
     return reasons
 
 
@@ -253,13 +253,6 @@ class SvcbValue(EqualityTupleMixin, dict):
             'targetname': targetname,
             'svcparams': params,
         }
-
-    @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in SvcbValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
 
     @classmethod
     def process(cls, values):

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -33,12 +33,20 @@ def validate_target_fqdn(target, _type, key='value'):
 
 
 class TargetValueValidator(ValueValidator):
+    '''
+    Validates a single-value target FQDN (CNAME, ALIAS, DNAME, PTR).
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         return validate_target_fqdn(data, _type)
 
 
 class TargetsValueValidator(ValueValidator):
+    '''
+    Validates a list of target FQDNs (NS). Rejects empty lists.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         if not data:

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -5,6 +5,7 @@
 from fqdn import FQDN
 
 from ..idna import idna_encode
+from .validator import ValueValidator
 
 
 def validate_target_fqdn(target, _type, key='value'):
@@ -31,7 +32,28 @@ def validate_target_fqdn(target, _type, key='value'):
     return reasons
 
 
+class TargetValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        return validate_target_fqdn(data, _type)
+
+
+class TargetsValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        if not data:
+            return ['missing value(s)']
+
+        reasons = []
+        for value in data:
+            reasons += validate_target_fqdn(value, _type)
+
+        return reasons
+
+
 class _TargetValue(str):
+    VALIDATORS = [TargetValueValidator]
+
     @classmethod
     def parse_rdata_text(self, value):
         return value
@@ -42,7 +64,10 @@ class _TargetValue(str):
 
     @classmethod
     def validate(cls, data, _type):
-        return validate_target_fqdn(data, _type)
+        reasons = []
+        for validator in _TargetValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
+        return reasons
 
     @classmethod
     def process(cls, value):
@@ -67,6 +92,8 @@ class _TargetValue(str):
 #
 # much like _TargetValue, but geared towards multiple values
 class _TargetsValue(str):
+    VALIDATORS = [TargetsValueValidator]
+
     @classmethod
     def parse_rdata_text(cls, value):
         return value
@@ -77,13 +104,9 @@ class _TargetsValue(str):
 
     @classmethod
     def validate(cls, data, _type):
-        if not data:
-            return ['missing value(s)']
-
         reasons = []
-        for value in data:
-            reasons += validate_target_fqdn(value, _type)
-
+        for validator in _TargetsValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -71,13 +71,6 @@ class _TargetValue(str):
         return {'type': 'string'}
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in _TargetValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, value):
         if value:
             return cls(value)
@@ -109,13 +102,6 @@ class _TargetsValue(str):
     @classmethod
     def _schema(cls):
         return {'type': 'string'}
-
-    @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in _TargetsValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
 
     @classmethod
     def process(cls, values):

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -9,6 +9,12 @@ from .validator import ValueValidator
 
 
 class TlsaValueValidator(ValueValidator):
+    '''
+    Validates TLSA rdata: ``certificate_usage`` in [0, 3],
+    ``selector`` in [0, 1], ``matching_type`` in [0, 2], and
+    ``certificate_association_data`` is present.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -5,9 +5,56 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import ValueValidator
+
+
+class TlsaValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                certificate_usage = int(value.get('certificate_usage', 0))
+                if certificate_usage < 0 or certificate_usage > 3:
+                    reasons.append(
+                        f'invalid certificate_usage ' f'"{certificate_usage}"'
+                    )
+            except ValueError:
+                reasons.append(
+                    f'invalid certificate_usage '
+                    f'"{value["certificate_usage"]}"'
+                )
+
+            try:
+                selector = int(value.get('selector', 0))
+                if selector < 0 or selector > 1:
+                    reasons.append(f'invalid selector "{selector}"')
+            except ValueError:
+                reasons.append(f'invalid selector "{value["selector"]}"')
+
+            try:
+                matching_type = int(value.get('matching_type', 0))
+                if matching_type < 0 or matching_type > 2:
+                    reasons.append(f'invalid matching_type "{matching_type}"')
+            except ValueError:
+                reasons.append(
+                    f'invalid matching_type ' f'"{value["matching_type"]}"'
+                )
+
+            if 'certificate_usage' not in value:
+                reasons.append('missing certificate_usage')
+            if 'selector' not in value:
+                reasons.append('missing selector')
+            if 'matching_type' not in value:
+                reasons.append('missing matching_type')
+            if 'certificate_association_data' not in value:
+                reasons.append('missing certificate_association_data')
+        return reasons
 
 
 class TlsaValue(EqualityTupleMixin, dict):
+    VALIDATORS = [TlsaValueValidator]
+
     @classmethod
     def _schema(cls):
         return {
@@ -68,43 +115,8 @@ class TlsaValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            try:
-                certificate_usage = int(value.get('certificate_usage', 0))
-                if certificate_usage < 0 or certificate_usage > 3:
-                    reasons.append(
-                        f'invalid certificate_usage ' f'"{certificate_usage}"'
-                    )
-            except ValueError:
-                reasons.append(
-                    f'invalid certificate_usage '
-                    f'"{value["certificate_usage"]}"'
-                )
-
-            try:
-                selector = int(value.get('selector', 0))
-                if selector < 0 or selector > 1:
-                    reasons.append(f'invalid selector "{selector}"')
-            except ValueError:
-                reasons.append(f'invalid selector "{value["selector"]}"')
-
-            try:
-                matching_type = int(value.get('matching_type', 0))
-                if matching_type < 0 or matching_type > 2:
-                    reasons.append(f'invalid matching_type "{matching_type}"')
-            except ValueError:
-                reasons.append(
-                    f'invalid matching_type ' f'"{value["matching_type"]}"'
-                )
-
-            if 'certificate_usage' not in value:
-                reasons.append('missing certificate_usage')
-            if 'selector' not in value:
-                reasons.append('missing selector')
-            if 'matching_type' not in value:
-                reasons.append('missing matching_type')
-            if 'certificate_association_data' not in value:
-                reasons.append('missing certificate_association_data')
+        for validator in TlsaValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -119,13 +119,6 @@ class TlsaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in TlsaValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -97,13 +97,6 @@ class UriValue(EqualityTupleMixin, dict):
         return {'priority': priority, 'weight': weight, 'target': target}
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in UriValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 
@@ -171,14 +164,6 @@ class UriRecord(ValuesMixin, Record):
     _value_type = UriValue
 
     VALIDATORS = [UriNameValidator]
-
-    @classmethod
-    def validate(cls, name, fqdn, data):
-        reasons = []
-        for validator in UriRecord.VALIDATORS:
-            reasons.extend(validator.validate(cls, name, fqdn, data))
-        reasons.extend(super().validate(name, fqdn, data))
-        return reasons
 
 
 Record.register_type(UriRecord)

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -8,6 +8,15 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import RecordValidator
+
+
+class UriNameValidator(RecordValidator):
+    @classmethod
+    def validate(cls, record_cls, name, fqdn, data):
+        if not record_cls._name_re.match(name):
+            return ['invalid name for URI record']
+        return []
 
 
 class UriValue(EqualityTupleMixin, dict):
@@ -138,11 +147,13 @@ class UriRecord(ValuesMixin, Record):
     _value_type = UriValue
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
+    VALIDATORS = [UriNameValidator]
+
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = []
-        if not cls._name_re.match(name):
-            reasons.append('invalid name for URI record')
+        for validator in UriRecord.VALIDATORS:
+            reasons.extend(validator.validate(cls, name, fqdn, data))
         reasons.extend(super().validate(name, fqdn, data))
         return reasons
 

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -12,6 +12,12 @@ from .validator import RecordValidator, ValueValidator
 
 
 class UriNameValidator(RecordValidator):
+    '''
+    Validates that a URI record's name matches the
+    ``_service._protocol`` pattern required by RFC 7553, or is a
+    wildcard.
+    '''
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
         if not record_cls._name_re.match(name):
@@ -20,6 +26,11 @@ class UriNameValidator(RecordValidator):
 
 
 class UriValueValidator(ValueValidator):
+    '''
+    Validates URI rdata: priority and weight are present and
+    integer-parsable, and target is non-empty.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -8,7 +8,7 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import RecordValidator
+from .validator import RecordValidator, ValueValidator
 
 
 class UriNameValidator(RecordValidator):
@@ -19,7 +19,41 @@ class UriNameValidator(RecordValidator):
         return []
 
 
+class UriValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            # TODO: validate algorithm and fingerprint_type values
+            try:
+                int(value['priority'])
+            except KeyError:
+                reasons.append('missing priority')
+            except ValueError:
+                reasons.append(f'invalid priority "{value["priority"]}"')
+            try:
+                int(value['weight'])
+            except KeyError:
+                reasons.append('missing weight')
+            except ValueError:
+                reasons.append(f'invalid weight "{value["weight"]}"')
+            try:
+                target = value['target']
+                if not target:
+                    reasons.append('missing target')
+                    continue
+                # actual validation of the target is non-trivial and specific
+                # to the details of the schema etc. rfc3986 has support for
+                # validation, but we don't currently require the module and
+                # this seems too esoteric a use case to add it
+            except KeyError:
+                reasons.append('missing target')
+        return reasons
+
+
 class UriValue(EqualityTupleMixin, dict):
+    VALIDATORS = [UriValueValidator]
+
     @classmethod
     def _schema(cls):
         return {
@@ -52,31 +86,8 @@ class UriValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            # TODO: validate algorithm and fingerprint_type values
-            try:
-                int(value['priority'])
-            except KeyError:
-                reasons.append('missing priority')
-            except ValueError:
-                reasons.append(f'invalid priority "{value["priority"]}"')
-            try:
-                int(value['weight'])
-            except KeyError:
-                reasons.append('missing weight')
-            except ValueError:
-                reasons.append(f'invalid weight "{value["weight"]}"')
-            try:
-                target = value['target']
-                if not target:
-                    reasons.append('missing target')
-                    continue
-                # actual validation of the target is non-trivial and specific
-                # to the details of the schema etc. rfc3986 has support for
-                # validation, but we don't currently require the module and
-                # this seems too esoteric a use case to add it
-            except KeyError:
-                reasons.append('missing target')
+        for validator in UriValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -18,9 +18,11 @@ class UriNameValidator(RecordValidator):
     wildcard.
     '''
 
+    _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
+
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
-        if not record_cls._name_re.match(name):
+        if not cls._name_re.match(name):
             return ['invalid name for URI record']
         return []
 
@@ -167,7 +169,6 @@ class UriRecord(ValuesMixin, Record):
     REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc7553',)
     _type = 'URI'
     _value_type = UriValue
-    _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
     VALIDATORS = [UriNameValidator]
 

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -99,13 +99,6 @@ class UrlfwdValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def validate(cls, data, _type):
-        reasons = []
-        for validator in UrlfwdValue.VALIDATORS:
-            reasons.extend(validator.validate(cls, data, _type))
-        return reasons
-
-    @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
 

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -9,6 +9,12 @@ from .validator import ValueValidator
 
 
 class UrlfwdValueValidator(ValueValidator):
+    '''
+    Validates URLFWD rdata: ``code`` is a valid HTTP redirect code,
+    ``masking`` and ``query`` are in the recognized enum sets, and
+    ``path`` and ``target`` are present.
+    '''
+
     @classmethod
     def validate(cls, value_cls, data, _type):
         reasons = []

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -5,12 +5,50 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .validator import ValueValidator
+
+
+class UrlfwdValueValidator(ValueValidator):
+    @classmethod
+    def validate(cls, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                code = int(value['code'])
+                if code not in value_cls.VALID_CODES:
+                    reasons.append(f'unrecognized return code "{code}"')
+            except KeyError:
+                reasons.append('missing code')
+            except ValueError:
+                reasons.append(f'invalid return code "{value["code"]}"')
+            try:
+                masking = int(value['masking'])
+                if masking not in value_cls.VALID_MASKS:
+                    reasons.append(f'unrecognized masking setting "{masking}"')
+            except KeyError:
+                reasons.append('missing masking')
+            except ValueError:
+                reasons.append(f'invalid masking setting "{value["masking"]}"')
+            try:
+                query = int(value['query'])
+                if query not in value_cls.VALID_QUERY:
+                    reasons.append(f'unrecognized query setting "{query}"')
+            except KeyError:
+                reasons.append('missing query')
+            except ValueError:
+                reasons.append(f'invalid query setting "{value["query"]}"')
+            for k in ('path', 'target'):
+                if k not in value:
+                    reasons.append(f'missing {k}')
+        return reasons
 
 
 class UrlfwdValue(EqualityTupleMixin, dict):
     VALID_CODES = (301, 302)
     VALID_MASKS = (0, 1, 2)
     VALID_QUERY = (0, 1)
+
+    VALIDATORS = [UrlfwdValueValidator]
 
     @classmethod
     def _schema(cls):
@@ -57,34 +95,8 @@ class UrlfwdValue(EqualityTupleMixin, dict):
     @classmethod
     def validate(cls, data, _type):
         reasons = []
-        for value in data:
-            try:
-                code = int(value['code'])
-                if code not in cls.VALID_CODES:
-                    reasons.append(f'unrecognized return code "{code}"')
-            except KeyError:
-                reasons.append('missing code')
-            except ValueError:
-                reasons.append(f'invalid return code "{value["code"]}"')
-            try:
-                masking = int(value['masking'])
-                if masking not in cls.VALID_MASKS:
-                    reasons.append(f'unrecognized masking setting "{masking}"')
-            except KeyError:
-                reasons.append('missing masking')
-            except ValueError:
-                reasons.append(f'invalid masking setting "{value["masking"]}"')
-            try:
-                query = int(value['query'])
-                if query not in cls.VALID_QUERY:
-                    reasons.append(f'unrecognized query setting "{query}"')
-            except KeyError:
-                reasons.append('missing query')
-            except ValueError:
-                reasons.append(f'invalid query setting "{value["query"]}"')
-            for k in ('path', 'target'):
-                if k not in value:
-                    reasons.append(f'missing {k}')
+        for validator in UrlfwdValue.VALIDATORS:
+            reasons.extend(validator.validate(cls, data, _type))
         return reasons
 
     @classmethod

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -11,7 +11,10 @@ class RecordValidator:
     describing any validation failures. An empty list indicates the record is
     valid. ``record_cls`` is the concrete Record subclass being validated and
     gives validators access to class-level attributes (``_type``,
-    ``_value_type``, etc.) when needed.
+    ``_value_type``, etc.) when needed. Attributes consulted only by a
+    validator should live on the validator itself; ``record_cls`` is only
+    the right home for state that's shared across the record and its
+    validators.
     '''
 
     @classmethod
@@ -22,11 +25,13 @@ class RecordValidator:
         Parameters
         ----------
         record_cls : type
-            The concrete ``Record`` subclass being validated. Validators that
-            need access to class-level attributes (e.g. ``_type``,
-            ``_value_type``, ``_name_re``) should read them from
+            The concrete ``Record`` subclass being validated. Validators
+            that need access to record class-level attributes (e.g.
+            ``_type``, ``_value_type``) should read them from
             ``record_cls`` rather than ``cls``, since ``cls`` is the
-            validator class itself.
+            validator class itself. Attributes consulted only by a
+            validator should live on the validator, not on
+            ``record_cls``.
         name : str
             The record's name relative to its zone (``''`` for the zone
             root). Already ``idna_encode``'d.
@@ -62,6 +67,9 @@ class ValueValidator:
     Subclasses override ``validate`` to return a list of reason strings
     describing any validation failures. An empty list indicates the value is
     valid. ``value_cls`` is the concrete value class being validated.
+    Attributes consulted only by a validator should live on the validator
+    itself; ``value_cls`` is only the right home for state that's shared
+    across the value class and its validators.
     '''
 
     @classmethod
@@ -73,10 +81,12 @@ class ValueValidator:
         ----------
         value_cls : type
             The concrete value class being validated (e.g. ``MxValue``,
-            ``_Ipv4Value``). Validators that need access to class-level
-            attributes (e.g. ``VALID_ALGORITHMS``, ``_address_type``,
-            regex patterns) should read them from ``value_cls`` rather
-            than ``cls``, since ``cls`` is the validator class itself.
+            ``_Ipv4Value``). Validators that need access to value
+            class-level attributes (e.g. ``VALID_ALGORITHMS``,
+            ``_address_type``) should read them from ``value_cls``
+            rather than ``cls``, since ``cls`` is the validator class
+            itself. Attributes consulted only by a validator should
+            live on the validator, not on ``value_cls``.
         data : list | tuple | str | dict
             The rdata to validate. For multi-value record types this is a
             list/tuple of value dicts or strings; for single-value types

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -1,0 +1,31 @@
+#
+#
+#
+
+
+class RecordValidator:
+    '''
+    Base class for record-level validators.
+
+    Subclasses override ``validate`` to return a list of reason strings
+    describing any validation failures. An empty list indicates the record is
+    valid.
+    '''
+
+    @classmethod
+    def validate(cls, name, fqdn, data):
+        return []
+
+
+class ValueValidator:
+    '''
+    Base class for value-level validators.
+
+    Subclasses override ``validate`` to return a list of reason strings
+    describing any validation failures. An empty list indicates the value is
+    valid.
+    '''
+
+    @classmethod
+    def validate(cls, data, _type):
+        return []

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -9,11 +9,13 @@ class RecordValidator:
 
     Subclasses override ``validate`` to return a list of reason strings
     describing any validation failures. An empty list indicates the record is
-    valid.
+    valid. ``record_cls`` is the concrete Record subclass being validated and
+    gives validators access to class-level attributes (``_type``,
+    ``_value_type``, etc.) when needed.
     '''
 
     @classmethod
-    def validate(cls, name, fqdn, data):
+    def validate(cls, record_cls, name, fqdn, data):
         return []
 
 
@@ -23,9 +25,9 @@ class ValueValidator:
 
     Subclasses override ``validate`` to return a list of reason strings
     describing any validation failures. An empty list indicates the value is
-    valid.
+    valid. ``value_cls`` is the concrete value class being validated.
     '''
 
     @classmethod
-    def validate(cls, data, _type):
+    def validate(cls, value_cls, data, _type):
         return []

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -16,6 +16,42 @@ class RecordValidator:
 
     @classmethod
     def validate(cls, record_cls, name, fqdn, data):
+        '''
+        Validate a record's non-value attributes.
+
+        Parameters
+        ----------
+        record_cls : type
+            The concrete ``Record`` subclass being validated. Validators that
+            need access to class-level attributes (e.g. ``_type``,
+            ``_value_type``, ``_name_re``) should read them from
+            ``record_cls`` rather than ``cls``, since ``cls`` is the
+            validator class itself.
+        name : str
+            The record's name relative to its zone (``''`` for the zone
+            root). Already ``idna_encode``'d.
+        fqdn : str
+            The record's fully-qualified domain name (``name`` + zone name).
+        data : dict
+            The raw record config dict (as loaded from YAML/JSON) including
+            ``ttl``, ``type``, ``value``/``values``, and any type-specific
+            fields like ``dynamic``, ``geo``, or ``octodns``.
+
+        Returns
+        -------
+        list[str]
+            A list of human-readable reason strings describing validation
+            failures. Must return an empty list when the record is valid.
+            Reasons from multiple validators are concatenated by the caller,
+            so each reason must stand alone without context from the others.
+
+        Notes
+        -----
+        Implementations must not raise on invalid input — all failures are
+        reported via the returned list. Reason strings are surfaced
+        verbatim in ``ValidationError`` messages, so phrasing and
+        punctuation should be stable across releases.
+        '''
         return []
 
 
@@ -30,4 +66,43 @@ class ValueValidator:
 
     @classmethod
     def validate(cls, value_cls, data, _type):
+        '''
+        Validate a record's rdata values.
+
+        Parameters
+        ----------
+        value_cls : type
+            The concrete value class being validated (e.g. ``MxValue``,
+            ``_Ipv4Value``). Validators that need access to class-level
+            attributes (e.g. ``VALID_ALGORITHMS``, ``_address_type``,
+            regex patterns) should read them from ``value_cls`` rather
+            than ``cls``, since ``cls`` is the validator class itself.
+        data : list | tuple | str | dict
+            The rdata to validate. For multi-value record types this is a
+            list/tuple of value dicts or strings; for single-value types
+            it may be a bare value. Most validators iterate ``data``
+            directly — when a validator needs to accept either form it
+            should normalize with ``if not isinstance(data, (list,
+            tuple)): data = (data,)``.
+        _type : str
+            The record type string (e.g. ``'MX'``, ``'A'``). Passed
+            through to helpers like ``validate_target_fqdn`` which format
+            it into their reason strings.
+
+        Returns
+        -------
+        list[str]
+            A list of human-readable reason strings describing validation
+            failures. Must return an empty list when the values are
+            valid. Reasons from multiple validators are concatenated by
+            the caller, so each reason must stand alone without context
+            from the others.
+
+        Notes
+        -----
+        Implementations must not raise on invalid input — all failures
+        are reported via the returned list. Reason strings are surfaced
+        verbatim in ``ValidationError`` messages, so phrasing and
+        punctuation should be stable across releases.
+        '''
         return []

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -2,6 +2,7 @@
 #
 #
 
+import warnings
 from unittest import TestCase
 
 from octodns.idna import idna_encode
@@ -1134,3 +1135,44 @@ class TestValidators(TestCase):
         self.assertEqual(
             [], _process_value_validators(StatefulValueType, ['allowed'], 'TXT')
         )
+
+    def test_legacy_record_validate_deprecation(self):
+        # 3rd-party records that still override Record.validate get a
+        # DeprecationWarning at class-definition time, telling them to
+        # migrate to declaring VALIDATORS before 2.0.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+
+            class LegacyRecord(ARecord):
+                @classmethod
+                def validate(cls, name, fqdn, data):
+                    return []
+
+        matched = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and 'LegacyRecord.validate' in str(w.message)
+        ]
+        self.assertTrue(matched)
+
+    def test_legacy_value_validate_deprecation(self):
+        # 3rd-party value classes that still define a `validate` classmethod
+        # are invoked for back-compat but emit a DeprecationWarning so they
+        # know to migrate to declaring VALIDATORS before 2.0.
+        class LegacyValueType(str):
+            @classmethod
+            def validate(cls, data, _type):
+                return ['legacy reason']
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            reasons = _process_value_validators(LegacyValueType, ['x'], 'TXT')
+        self.assertEqual(['legacy reason'], reasons)
+        matched = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and 'LegacyValueType.validate' in str(w.message)
+        ]
+        self.assertTrue(matched)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -27,6 +27,7 @@ from octodns.record.base import (
     HealthcheckValidator,
     NameValidator,
     TtlValidator,
+    _process_value_validators,
     unquote,
 )
 from octodns.record.cname import CnameRootValidator
@@ -1083,4 +1084,53 @@ class TestValidators(TestCase):
         self.assertEqual(
             ['invalid name for URI record'],
             UriNameValidator.validate(UriRecord, 'bad', 'bad.unit.tests.', {}),
+        )
+
+    def test_instance_record_validator(self):
+        # VALIDATORS entries may be instances with state (e.g. ctor args),
+        # not just classes. Bound-method dispatch passes self in place of cls.
+        class StatefulNameValidator:
+            def __init__(self, forbidden_prefix):
+                self.forbidden_prefix = forbidden_prefix
+
+            def validate(self, record_cls, name, fqdn, data):
+                if name.startswith(self.forbidden_prefix):
+                    return [f'name starts with "{self.forbidden_prefix}"']
+                return []
+
+        class StatefulRecord(ARecord):
+            VALIDATORS = [StatefulNameValidator('bad-')]
+
+        data = {'ttl': 30, 'type': 'A', 'value': '1.2.3.4'}
+        self.assertIn(
+            'name starts with "bad-"',
+            StatefulRecord.validate('bad-name', 'bad-name.unit.tests.', data),
+        )
+        self.assertEqual(
+            [], StatefulRecord.validate('ok', 'ok.unit.tests.', data)
+        )
+
+    def test_instance_value_validator(self):
+        # Same idea for value-level validators — an instance with state
+        # attached to a value class's VALIDATORS works via bound-method
+        # dispatch through the MRO walk in _process_value_validators.
+        class StatefulValueValidator:
+            def __init__(self, forbidden):
+                self.forbidden = forbidden
+
+            def validate(self, value_cls, data, _type):
+                data = data if isinstance(data, (list, tuple)) else [data]
+                if any(v == self.forbidden for v in data):
+                    return [f'forbidden value "{self.forbidden}"']
+                return []
+
+        class StatefulValueType(str):
+            VALIDATORS = [StatefulValueValidator('blocked')]
+
+        self.assertIn(
+            'forbidden value "blocked"',
+            _process_value_validators(StatefulValueType, ['blocked'], 'TXT'),
+        )
+        self.assertEqual(
+            [], _process_value_validators(StatefulValueType, ['allowed'], 'TXT')
         )

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -22,12 +22,18 @@ from octodns.record import (
     ValidationError,
     ValuesMixin,
 )
+from octodns.record.alias import AliasRootValidator
 from octodns.record.base import (
     HealthcheckValidator,
     NameValidator,
     TtlValidator,
     unquote,
 )
+from octodns.record.cname import CnameRootValidator
+from octodns.record.dynamic import DynamicValidator
+from octodns.record.geo import GeoValidator
+from octodns.record.srv import SrvNameValidator, SrvRecord
+from octodns.record.uri import UriNameValidator, UriRecord
 from octodns.record.validator import RecordValidator, ValueValidator
 from octodns.yaml import ContextDict
 from octodns.zone import Zone
@@ -939,56 +945,62 @@ class TestRecordValidation(TestCase):
 
 class TestValidators(TestCase):
     def test_record_validator_base(self):
-        self.assertEqual([], RecordValidator.validate('', 'unit.tests.', {}))
+        self.assertEqual(
+            [], RecordValidator.validate(ARecord, '', 'unit.tests.', {})
+        )
 
     def test_value_validator_base(self):
-        self.assertEqual([], ValueValidator.validate(None, 'A'))
+        self.assertEqual([], ValueValidator.validate(None, None, 'A'))
 
     def test_name_validator(self):
         self.assertEqual(
-            [], NameValidator.validate('www', 'www.unit.tests.', {})
+            [], NameValidator.validate(ARecord, 'www', 'www.unit.tests.', {})
         )
         self.assertEqual(
             ['invalid name "@", use "" instead'],
-            NameValidator.validate('@', '@.unit.tests.', {}),
+            NameValidator.validate(ARecord, '@', '@.unit.tests.', {}),
         )
         long_name = '.'.join(['a' * 60] * 5)
         long_fqdn = f'{long_name}.unit.tests.'
-        reasons = NameValidator.validate(long_name, long_fqdn, {})
+        reasons = NameValidator.validate(ARecord, long_name, long_fqdn, {})
         self.assertTrue(
             any('too long at' in r and 'max is 253' in r for r in reasons)
         )
         long_label = 'x' * 64
         reasons = NameValidator.validate(
-            long_label, f'{long_label}.unit.tests.', {}
+            ARecord, long_label, f'{long_label}.unit.tests.', {}
         )
         self.assertTrue(
             any('invalid label' in r and 'max is 63' in r for r in reasons)
         )
         self.assertEqual(
             ['invalid name, double `.` in "foo..bar.unit.tests."'],
-            NameValidator.validate('foo..bar', 'foo..bar.unit.tests.', {}),
+            NameValidator.validate(
+                ARecord, 'foo..bar', 'foo..bar.unit.tests.', {}
+            ),
         )
 
     def test_ttl_validator(self):
         self.assertEqual(
-            [], TtlValidator.validate('', 'unit.tests.', {'ttl': 42})
+            [], TtlValidator.validate(ARecord, '', 'unit.tests.', {'ttl': 42})
         )
         self.assertEqual(
-            ['missing ttl'], TtlValidator.validate('', 'unit.tests.', {})
+            ['missing ttl'],
+            TtlValidator.validate(ARecord, '', 'unit.tests.', {}),
         )
         self.assertEqual(
             ['invalid ttl'],
-            TtlValidator.validate('', 'unit.tests.', {'ttl': -1}),
+            TtlValidator.validate(ARecord, '', 'unit.tests.', {'ttl': -1}),
         )
 
     def test_healthcheck_validator(self):
         self.assertEqual(
-            [], HealthcheckValidator.validate('', 'unit.tests.', {})
+            [], HealthcheckValidator.validate(ARecord, '', 'unit.tests.', {})
         )
         self.assertEqual(
             [],
             HealthcheckValidator.validate(
+                ARecord,
                 '',
                 'unit.tests.',
                 {'octodns': {'healthcheck': {'protocol': 'HTTPS'}}},
@@ -997,8 +1009,78 @@ class TestValidators(TestCase):
         self.assertEqual(
             ['invalid healthcheck protocol'],
             HealthcheckValidator.validate(
+                ARecord,
                 '',
                 'unit.tests.',
                 {'octodns': {'healthcheck': {'protocol': 'BOGUS'}}},
             ),
+        )
+
+    def test_dynamic_validator(self):
+        # no `dynamic` key -> no reasons
+        self.assertEqual(
+            [], DynamicValidator.validate(ARecord, '', 'unit.tests.', {})
+        )
+        # `dynamic` and `geo` co-present triggers a reason
+        reasons = DynamicValidator.validate(
+            ARecord, '', 'unit.tests.', {'dynamic': {}, 'geo': {}}
+        )
+        self.assertIn('"dynamic" record with "geo" content', reasons)
+
+    def test_geo_validator(self):
+        # no `geo` key -> no reasons
+        self.assertEqual(
+            [], GeoValidator.validate(ARecord, '', 'unit.tests.', {})
+        )
+        # invalid geo code surfaces a reason
+        reasons = GeoValidator.validate(
+            ARecord, '', 'unit.tests.', {'geo': {'X': ['1.2.3.4']}}
+        )
+        self.assertIn('invalid geo "X"', reasons)
+
+    def test_srv_name_validator(self):
+        self.assertEqual(
+            [],
+            SrvNameValidator.validate(
+                SrvRecord, '_sip._tcp', '_sip._tcp.unit.tests.', {}
+            ),
+        )
+        self.assertEqual(
+            ['invalid name for SRV record'],
+            SrvNameValidator.validate(SrvRecord, 'bad', 'bad.unit.tests.', {}),
+        )
+
+    def test_cname_root_validator(self):
+        self.assertEqual(
+            [],
+            CnameRootValidator.validate(
+                CnameRecord, 'www', 'www.unit.tests.', {}
+            ),
+        )
+        self.assertEqual(
+            ['root CNAME not allowed'],
+            CnameRootValidator.validate(CnameRecord, '', 'unit.tests.', {}),
+        )
+
+    def test_alias_root_validator(self):
+        self.assertEqual(
+            [], AliasRootValidator.validate(AliasRecord, '', 'unit.tests.', {})
+        )
+        self.assertEqual(
+            ['non-root ALIAS not allowed'],
+            AliasRootValidator.validate(
+                AliasRecord, 'www', 'www.unit.tests.', {}
+            ),
+        )
+
+    def test_uri_name_validator(self):
+        self.assertEqual(
+            [],
+            UriNameValidator.validate(
+                UriRecord, '_sip._tcp', '_sip._tcp.unit.tests.', {}
+            ),
+        )
+        self.assertEqual(
+            ['invalid name for URI record'],
+            UriNameValidator.validate(UriRecord, 'bad', 'bad.unit.tests.', {}),
         )

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -22,7 +22,13 @@ from octodns.record import (
     ValidationError,
     ValuesMixin,
 )
-from octodns.record.base import unquote
+from octodns.record.base import (
+    HealthcheckValidator,
+    NameValidator,
+    TtlValidator,
+    unquote,
+)
+from octodns.record.validator import RecordValidator, ValueValidator
 from octodns.yaml import ContextDict
 from octodns.zone import Zone
 
@@ -929,3 +935,70 @@ class TestRecordValidation(TestCase):
             method = getattr(value_type, attr)
             self.assertTrue(method, f'{_type}, {cls} has {attr}')
             # this one is a @property so not callable
+
+
+class TestValidators(TestCase):
+    def test_record_validator_base(self):
+        self.assertEqual([], RecordValidator.validate('', 'unit.tests.', {}))
+
+    def test_value_validator_base(self):
+        self.assertEqual([], ValueValidator.validate(None, 'A'))
+
+    def test_name_validator(self):
+        self.assertEqual(
+            [], NameValidator.validate('www', 'www.unit.tests.', {})
+        )
+        self.assertEqual(
+            ['invalid name "@", use "" instead'],
+            NameValidator.validate('@', '@.unit.tests.', {}),
+        )
+        long_name = '.'.join(['a' * 60] * 5)
+        long_fqdn = f'{long_name}.unit.tests.'
+        reasons = NameValidator.validate(long_name, long_fqdn, {})
+        self.assertTrue(
+            any('too long at' in r and 'max is 253' in r for r in reasons)
+        )
+        long_label = 'x' * 64
+        reasons = NameValidator.validate(
+            long_label, f'{long_label}.unit.tests.', {}
+        )
+        self.assertTrue(
+            any('invalid label' in r and 'max is 63' in r for r in reasons)
+        )
+        self.assertEqual(
+            ['invalid name, double `.` in "foo..bar.unit.tests."'],
+            NameValidator.validate('foo..bar', 'foo..bar.unit.tests.', {}),
+        )
+
+    def test_ttl_validator(self):
+        self.assertEqual(
+            [], TtlValidator.validate('', 'unit.tests.', {'ttl': 42})
+        )
+        self.assertEqual(
+            ['missing ttl'], TtlValidator.validate('', 'unit.tests.', {})
+        )
+        self.assertEqual(
+            ['invalid ttl'],
+            TtlValidator.validate('', 'unit.tests.', {'ttl': -1}),
+        )
+
+    def test_healthcheck_validator(self):
+        self.assertEqual(
+            [], HealthcheckValidator.validate('', 'unit.tests.', {})
+        )
+        self.assertEqual(
+            [],
+            HealthcheckValidator.validate(
+                '',
+                'unit.tests.',
+                {'octodns': {'healthcheck': {'protocol': 'HTTPS'}}},
+            ),
+        )
+        self.assertEqual(
+            ['invalid healthcheck protocol'],
+            HealthcheckValidator.validate(
+                '',
+                'unit.tests.',
+                {'octodns': {'healthcheck': {'protocol': 'BOGUS'}}},
+            ),
+        )

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -4,6 +4,7 @@
 
 from unittest import TestCase
 
+from octodns.record.base import _process_value_validators
 from octodns.record.chunked import _ChunkedValue, _ChunkedValuesMixin
 from octodns.record.spf import SpfRecord
 from octodns.record.txt import TxtValue
@@ -44,35 +45,40 @@ class TestChunkedValue(TestCase):
     def test_validate(self):
         # valid stuff
         for data in ('a', 'ab', 'abcdefg', 'abc def', 'abc\\; def'):
-            self.assertFalse(_ChunkedValue.validate(data, 'TXT'))
-            self.assertFalse(_ChunkedValue.validate([data], 'TXT'))
+            self.assertFalse(
+                _process_value_validators(_ChunkedValue, data, 'TXT')
+            )
+            self.assertFalse(
+                _process_value_validators(_ChunkedValue, [data], 'TXT')
+            )
 
         # missing
         for data in (None, []):
             self.assertEqual(
-                ['missing value(s)'], _ChunkedValue.validate(data, 'TXT')
+                ['missing value(s)'],
+                _process_value_validators(_ChunkedValue, data, 'TXT'),
             )
 
         # unescaped ;
         self.assertEqual(
             ['unescaped ; in "hello; world"'],
-            _ChunkedValue.validate('hello; world', 'TXT'),
+            _process_value_validators(_ChunkedValue, 'hello; world', 'TXT'),
         )
 
         # double escaped ;
         self.assertEqual(
             ['double escaped ; in "hello\\\\; world"'],
-            _ChunkedValue.validate('hello\\\\; world', 'TXT'),
+            _process_value_validators(_ChunkedValue, 'hello\\\\; world', 'TXT'),
         )
 
         # non-asci
         self.assertEqual(
             ['non ASCII character in "v=spf1 –all"'],
-            _ChunkedValue.validate('v=spf1 –all', 'TXT'),
+            _process_value_validators(_ChunkedValue, 'v=spf1 –all', 'TXT'),
         )
         self.assertEqual(
             ['non ASCII character in "Déjà vu"'],
-            _ChunkedValue.validate('Déjà vu', 'TXT'),
+            _process_value_validators(_ChunkedValue, 'Déjà vu', 'TXT'),
         )
 
     zone = Zone('unit.tests.', [])

--- a/tests/test_octodns_record_ds.py
+++ b/tests/test_octodns_record_ds.py
@@ -4,6 +4,7 @@
 
 from unittest import TestCase
 
+from octodns.record.base import _process_value_validators
 from octodns.record.ds import DsRecord, DsValue
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
@@ -135,11 +136,13 @@ class TestRecordDs(TestCase):
             'digest': '99148c81',
         }
         self.assertEqual(data, DsValue.parse_rdata_text('0 1 2 99148c81'))
-        self.assertEqual([], DsValue.validate(data, 'DS'))
+        self.assertEqual([], _process_value_validators(DsValue, data, 'DS'))
 
         # missing key_tag
         data = {'algorithm': 1, 'digest_type': 2, 'digest': '99148c81'}
-        self.assertEqual(['missing key_tag'], DsValue.validate(data, 'DS'))
+        self.assertEqual(
+            ['missing key_tag'], _process_value_validators(DsValue, data, 'DS')
+        )
         # invalid key_tag
         data = {
             'key_tag': 'a',
@@ -147,11 +150,17 @@ class TestRecordDs(TestCase):
             'digest_type': 2,
             'digest': '99148c81',
         }
-        self.assertEqual(['invalid key_tag "a"'], DsValue.validate(data, 'DS'))
+        self.assertEqual(
+            ['invalid key_tag "a"'],
+            _process_value_validators(DsValue, data, 'DS'),
+        )
 
         # missing algorithm
         data = {'key_tag': 1, 'digest_type': 2, 'digest': '99148c81'}
-        self.assertEqual(['missing algorithm'], DsValue.validate(data, 'DS'))
+        self.assertEqual(
+            ['missing algorithm'],
+            _process_value_validators(DsValue, data, 'DS'),
+        )
         # invalid algorithm
         data = {
             'key_tag': 1,
@@ -160,12 +169,16 @@ class TestRecordDs(TestCase):
             'digest': '99148c81',
         }
         self.assertEqual(
-            ['invalid algorithm "a"'], DsValue.validate(data, 'DS')
+            ['invalid algorithm "a"'],
+            _process_value_validators(DsValue, data, 'DS'),
         )
 
         # missing digest_type
         data = {'key_tag': 1, 'algorithm': 2, 'digest': '99148c81'}
-        self.assertEqual(['missing digest_type'], DsValue.validate(data, 'DS'))
+        self.assertEqual(
+            ['missing digest_type'],
+            _process_value_validators(DsValue, data, 'DS'),
+        )
         # invalid digest_type
         data = {
             'key_tag': 1,
@@ -174,34 +187,51 @@ class TestRecordDs(TestCase):
             'digest': '99148c81',
         }
         self.assertEqual(
-            ['invalid digest_type "a"'], DsValue.validate(data, 'DS')
+            ['invalid digest_type "a"'],
+            _process_value_validators(DsValue, data, 'DS'),
         )
 
         # missing public_key (list)
         data = {'key_tag': 1, 'algorithm': 2, 'digest_type': 3}
-        self.assertEqual(['missing digest'], DsValue.validate([data], 'DS'))
+        self.assertEqual(
+            ['missing digest'], _process_value_validators(DsValue, [data], 'DS')
+        )
 
         # do validations again with old field style
 
         # missing flags (list)
         data = {'protocol': 2, 'algorithm': 3, 'public_key': '99148c81'}
-        self.assertEqual(['missing flags'], DsValue.validate([data], 'DS'))
+        self.assertEqual(
+            ['missing flags'], _process_value_validators(DsValue, [data], 'DS')
+        )
 
         # missing protocol (list)
         data = {'flags': 1, 'algorithm': 3, 'public_key': '99148c81'}
-        self.assertEqual(['missing protocol'], DsValue.validate([data], 'DS'))
+        self.assertEqual(
+            ['missing protocol'],
+            _process_value_validators(DsValue, [data], 'DS'),
+        )
 
         # missing algorithm (list)
         data = {'flags': 1, 'protocol': 2, 'public_key': '99148c81'}
-        self.assertEqual(['missing algorithm'], DsValue.validate([data], 'DS'))
+        self.assertEqual(
+            ['missing algorithm'],
+            _process_value_validators(DsValue, [data], 'DS'),
+        )
 
         # missing public_key (list)
         data = {'flags': 1, 'algorithm': 3, 'protocol': 2}
-        self.assertEqual(['missing public_key'], DsValue.validate([data], 'DS'))
+        self.assertEqual(
+            ['missing public_key'],
+            _process_value_validators(DsValue, [data], 'DS'),
+        )
 
         # missing public_key (list)
         data = {'flags': 1, 'algorithm': 3, 'protocol': 2, 'digest': '99148c81'}
-        self.assertEqual(['missing public_key'], DsValue.validate([data], 'DS'))
+        self.assertEqual(
+            ['missing public_key'],
+            _process_value_validators(DsValue, [data], 'DS'),
+        )
 
         # invalid flags, protocol and algorithm
         data = {
@@ -216,7 +246,7 @@ class TestRecordDs(TestCase):
                 'invalid protocol "a"',
                 'invalid algorithm "a"',
             ],
-            DsValue.validate(data, 'DS'),
+            _process_value_validators(DsValue, data, 'DS'),
         )
 
         zone = Zone('unit.tests.', [])


### PR DESCRIPTION
## Summary

Purely structural refactor of record and value validation — no behavior
changes. Existing `validate()` bodies on Record subclasses, mixins, and
value classes have been extracted into dedicated `RecordValidator` /
`ValueValidator` subclasses attached via a per-class `VALIDATORS` list.
Reason strings are preserved byte-for-byte; the full test suite and 100%
branch coverage pass unchanged.

This lays the groundwork for a follow-up that will make validations
extensible and configurable — users will be able to register custom
validators and enable/disable individual checks. That user-facing surface
is intentionally out of scope here.

## Design

Two small base classes in a new `octodns/record/validator.py`:

- `RecordValidator.validate(record_cls, name, fqdn, data)`
- `ValueValidator.validate(value_cls, data, _type)`

Each Record subclass / mixin / value class declares its own `VALIDATORS`
list. Composition still happens via the existing MRO `super().validate()`
chain — each layer iterates its own `VALIDATORS` (referenced by explicit
class name to avoid MRO shadowing) and chains to `super()`. Granularity is
one validator per value type, and record-level checks split along logical
concerns (name shape vs. TTL vs. healthcheck, etc.).

## Process

Work landed as three separately-reviewable commits on this branch:

1. **Extract Record-level validations into validator classes** — introduce
   `RecordValidator` / `ValueValidator` base classes and migrate
   `Record.validate()` (name / TTL / healthcheck) as the reference
   implementation.
2. **Migrate record-level validations to RecordValidator classes** —
   `_DynamicMixin`, `_GeoMixin`, and per-type overrides on SRV, CNAME,
   ALIAS, and URI.
3. **Migrate value-level validations to ValueValidator classes** — 15 value
   classes: CAA, chunked, DS, IP, LOC, MX, NAPTR, OPENPGPKEY, SRV, SSHFP,
   SVCB/HTTPS, target, TLSA, URI, URLFWD.

## Test plan

- [x] `./script/test` — 491 tests pass
- [x] `./script/coverage` — 100% branch coverage
- [x] `./script/lint` — clean
- [x] `./script/format --check` — clean
- [x] New direct unit tests for each validator class added alongside the
      migrations; existing tests untouched so equality of reason strings is
      enforced.