### PR TITLE
Normalize hex data fields to lowercase for case-insensitive comparison

### DIFF
--- a/.changelog/23088495a46f46458e4cf5ed967f7ead.md
+++ b/.changelog/23088495a46f46458e4cf5ed967f7ead.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Normalize hex data fields (TLSA certificate_association_data, SSHFP fingerprint, DS digest) to lowercase for case-insensitive comparison

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -146,14 +146,14 @@ class DsValue(EqualityTupleMixin, dict):
                 'key_tag': int(value['flags']),
                 'algorithm': int(value['protocol']),
                 'digest_type': int(value['algorithm']),
-                'digest': value['public_key'],
+                'digest': str(value['public_key']).lower(),
             }
         else:
             init = {
                 'key_tag': int(value['key_tag']),
                 'algorithm': int(value['algorithm']),
                 'digest_type': int(value['digest_type']),
-                'digest': value['digest'],
+                'digest': str(value['digest']).lower(),
             }
         super().__init__(init)
 

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -115,7 +115,7 @@ class SshfpValue(EqualityTupleMixin, dict):
             {
                 'algorithm': int(value['algorithm']),
                 'fingerprint_type': int(value['fingerprint_type']),
-                'fingerprint': value['fingerprint'],
+                'fingerprint': str(value['fingerprint']).lower(),
             }
         )
 

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -127,12 +127,11 @@ class TlsaValue(EqualityTupleMixin, dict):
                 'certificate_usage': int(value.get('certificate_usage', 0)),
                 'selector': int(value.get('selector', 0)),
                 'matching_type': int(value.get('matching_type', 0)),
-                # force it to a string, in case the hex has only numerical
-                # values and it was converted to an int at some point
-                # TODO: this needed on any others?
+                # force to str (hex-only values may be coerced to int) and
+                # normalize to lowercase for case-insensitive comparison
                 'certificate_association_data': str(
                     value['certificate_association_data']
-                ),
+                ).lower(),
             }
         )
 
@@ -190,10 +189,7 @@ class TlsaValue(EqualityTupleMixin, dict):
         )
 
     def __repr__(self):
-        return (
-            f"'{self.certificate_usage} {self.selector} '"
-            f"'{self.matching_type} {self.certificate_association_data}'"
-        )
+        return f"'{self.certificate_usage} {self.selector} {self.matching_type} {self.certificate_association_data}'"
 
 
 class TlsaRecord(ValuesMixin, Record):

--- a/tests/test_octodns_record_ds.py
+++ b/tests/test_octodns_record_ds.py
@@ -290,6 +290,57 @@ class TestRecordDs(TestCase):
         self.assertEqual('1 2 3 99148c44', a.values[1].rdata_text)
         self.assertEqual('1 2 3 99148c44', a.values[1].__repr__())
 
+    def test_digest_case_insensitive(self):
+        zone = Zone('unit.tests.', [])
+
+        # uppercase input is normalized to lowercase
+        upper = DsRecord(
+            zone,
+            'ds',
+            {
+                'ttl': 30,
+                'value': {
+                    'key_tag': 1,
+                    'algorithm': 2,
+                    'digest_type': 3,
+                    'digest': 'ABCDEF1234567890',
+                },
+            },
+        )
+        self.assertEqual('abcdef1234567890', upper.values[0].digest)
+
+        # same value in lowercase normalizes identically
+        lower = DsRecord(
+            zone,
+            'ds',
+            {
+                'ttl': 30,
+                'value': {
+                    'key_tag': 1,
+                    'algorithm': 2,
+                    'digest_type': 3,
+                    'digest': 'abcdef1234567890',
+                },
+            },
+        )
+        self.assertEqual(upper.values[0].digest, lower.values[0].digest)
+
+        # legacy field names also normalize
+        legacy = DsRecord(
+            zone,
+            'ds',
+            {
+                'ttl': 30,
+                'value': {
+                    'flags': 1,
+                    'protocol': 2,
+                    'algorithm': 3,
+                    'public_key': 'ABCDEF1234567890',
+                },
+            },
+        )
+        self.assertEqual('abcdef1234567890', legacy.values[0].digest)
+
 
 class TestDsValue(TestCase):
 

--- a/tests/test_octodns_record_sshfp.py
+++ b/tests/test_octodns_record_sshfp.py
@@ -399,6 +399,45 @@ class TestRecordSshfp(TestCase):
             },
         )
 
+    def test_fingerprint_case_insensitive(self):
+        target = SimpleProvider()
+
+        # uppercase input is normalized to lowercase
+        upper = Record.new(
+            self.zone,
+            '',
+            {
+                'type': 'SSHFP',
+                'ttl': 600,
+                'value': {
+                    'algorithm': 1,
+                    'fingerprint_type': 1,
+                    'fingerprint': 'BF6B6825D2977C511A475BBEFB88AAD54A92AC73',
+                },
+            },
+        )
+        self.assertEqual(
+            'bf6b6825d2977c511a475bbefb88aad54a92ac73',
+            upper.values[0].fingerprint,
+        )
+
+        # same value in lowercase — no change detected
+        lower = Record.new(
+            self.zone,
+            '',
+            {
+                'type': 'SSHFP',
+                'ttl': 600,
+                'value': {
+                    'algorithm': 1,
+                    'fingerprint_type': 1,
+                    'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73',
+                },
+            },
+        )
+        self.assertFalse(upper.changes(lower, target))
+        self.assertFalse(lower.changes(upper, target))
+
 
 class TestSshFpValue(TestCase):
 

--- a/tests/test_octodns_record_tlsa.py
+++ b/tests/test_octodns_record_tlsa.py
@@ -430,6 +430,44 @@ class TestRecordTlsa(TestCase):
                 ctx.exception.reasons,
             )
 
+    def test_certificate_association_data_case_insensitive(self):
+        target = SimpleProvider()
+
+        # uppercase input is normalized to lowercase
+        upper = TlsaRecord(
+            self.zone,
+            'a',
+            {
+                'ttl': 30,
+                'value': {
+                    'certificate_usage': 3,
+                    'selector': 1,
+                    'matching_type': 1,
+                    'certificate_association_data': 'ABCDEF1234567890',
+                },
+            },
+        )
+        self.assertEqual(
+            'abcdef1234567890', upper.values[0].certificate_association_data
+        )
+
+        # same value in lowercase — no change detected
+        lower = TlsaRecord(
+            self.zone,
+            'a',
+            {
+                'ttl': 30,
+                'value': {
+                    'certificate_usage': 3,
+                    'selector': 1,
+                    'matching_type': 1,
+                    'certificate_association_data': 'abcdef1234567890',
+                },
+            },
+        )
+        self.assertFalse(upper.changes(lower, target))
+        self.assertFalse(lower.changes(upper, target))
+
 
 class TestTlsaValue(TestCase):
 
@@ -456,5 +494,5 @@ class TestTlsaValue(TestCase):
         got = value.template({'needle': 42})
         self.assertIsNot(value, got)
         self.assertEqual(
-            'ABAB42ABABABABABABAB', got.certificate_association_data
+            'abab42ababababababab', got.certificate_association_data
         )


### PR DESCRIPTION
## Summary

- TLSA `certificate_association_data`, SSHFP `fingerprint`, and DS `digest` are hex data fields that are case-insensitive by nature; normalizing to lowercase on store prevents spurious changes when a provider returns the same value in a different case
- Also fixes a `TlsaValue.__repr__` bug that produced two adjacent single-quoted strings (`'1 0 ''0 abcdef...'`) instead of a single quoted string

Follows the same pattern as #1360 (NAPTR flags normalization).

Fixes #1388
Related #1360