### PR TITLE
Add new strict validators set and include existing rfc-compliant validators in it 

### DIFF
--- a/.changelog/7edd4ce3eec447a7af5e63875a93dcbb.md
+++ b/.changelog/7edd4ce3eec447a7af5e63875a93dcbb.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add new strict validators set and include existing rfc-compliant validators in it

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -225,6 +225,10 @@ Validators active in both ``legacy`` and ``strict``:
 +------------------------+------------------------------------------+
 | ``openpgpkey-value-rfc``| OPENPGPKEY rdata format (RFC 7929)      |
 +------------------------+------------------------------------------+
+| ``dynamic``            | Dynamic routing config (pools and rules) |
++------------------------+------------------------------------------+
+| ``urlfwd-value``       | URLFWD rdata format                      |
++------------------------+------------------------------------------+
 
 Validators active in ``legacy`` only (will be superseded in ``strict``):
 
@@ -232,8 +236,6 @@ Validators active in ``legacy`` only (will be superseded in ``strict``):
 | id                   | description                              |
 +======================+==========================================+
 | ``geo``              | Geo routing config                       |
-+----------------------+------------------------------------------+
-| ``dynamic``          | Dynamic routing config                   |
 +----------------------+------------------------------------------+
 | ``srv-name``         | SRV name format                          |
 +----------------------+------------------------------------------+
@@ -254,8 +256,6 @@ Validators active in ``legacy`` only (will be superseded in ``strict``):
 | ``ds-value``         | DS rdata format                          |
 +----------------------+------------------------------------------+
 | ``tlsa-value``       | TLSA rdata format                        |
-+----------------------+------------------------------------------+
-| ``urlfwd-value``     | URLFWD rdata format                      |
 +----------------------+------------------------------------------+
 
 Validators active in ``strict`` only (stricter replacements):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -307,15 +307,25 @@ To opt into all strict validators at once::
 
 Validators active in ``best-practice`` only:
 
-+-------------------------------+--------------------------------------------------+
-| id                            | description                                      |
-+===============================+==================================================+
-| ``target-value-best-practice``| CNAME/ALIAS/DNAME target must end with ``"."``   |
-|                               | (absolute name prevents resolver search-domain   |
-|                               | append)                                          |
-+-------------------------------+--------------------------------------------------+
-| ``targets-value-best-practice``| NS/PTR targets must each end with ``"."``       |
-+-------------------------------+--------------------------------------------------+
++----------------------------------+-----------------------------------------------+
+| id                               | description                                   |
++==================================+===============================================+
+| ``target-value-best-practice``   | CNAME/ALIAS/DNAME target must end with        |
+|                                  | ``"."`` (absolute name prevents resolver      |
+|                                  | search-domain append)                         |
++----------------------------------+-----------------------------------------------+
+| ``targets-value-best-practice``  | NS/PTR targets must each end with ``"."``     |
++----------------------------------+-----------------------------------------------+
+| ``mx-value-best-practice``       | MX ``exchange`` must end with ``"."``         |
++----------------------------------+-----------------------------------------------+
+| ``srv-value-best-practice``      | SRV ``target`` must end with ``"."``          |
++----------------------------------+-----------------------------------------------+
+| ``svcb-value-best-practice``     | SVCB ``targetname`` must end with ``"."``     |
++----------------------------------+-----------------------------------------------+
+| ``https-value-best-practice``    | HTTPS ``targetname`` must end with ``"."``    |
++----------------------------------+-----------------------------------------------+
+| ``naptr-value-best-practice``    | NAPTR ``replacement`` must end with ``"."``   |
++----------------------------------+-----------------------------------------------+
 
 The recommended configuration is to enable both sets::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -275,6 +275,14 @@ Validators active in ``strict`` only (stricter replacements):
 |                    | _data must be hex; SHA-256/SHA-512 length enforced    |
 |                    | (RFC 6698); replaces ``tlsa-value``                   |
 +--------------------+-------------------------------------------------------+
+| ``ds-value-rfc``   | DS key_tag uint16, algorithm/digest_type uint8;       |
+|                    | digest must be hex; SHA-1/SHA-256/SHA-384 length      |
+|                    | enforced (RFC 4034/4509/6605); replaces ``ds-value``  |
++--------------------+-------------------------------------------------------+
+| ``naptr-value-rfc``| NAPTR order/preference uint16; flags S/A/U/P only;    |
+|                    | replacement must be FQDN or "." (RFC 3403);           |
+|                    | replaces ``naptr-value``                              |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -267,6 +267,10 @@ Validators active in ``strict`` only (stricter replacements):
 | ``mx-value-rfc``   | MX preference in [0, 65535]; null MX rules per        |
 |                    | RFC 7505; replaces ``mx-value``                       |
 +--------------------+-------------------------------------------------------+
+| ``caa-value-rfc``  | CAA flags restricted to 0/128 (RFC 8659 §4.1);        |
+|                    | tag must match ``[a-zA-Z0-9]+``; replaces             |
+|                    | ``caa-value``                                         |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -161,17 +161,25 @@ are active for a run (default: ``['legacy']``)::
 
 Omitting ``manager.enabled`` is equivalent to ``enabled: [legacy]`` and
 preserves the original octoDNS behaviour. The ``legacy`` set will remain
-the default until a future release when ``strict`` takes over as the default.
+the default until a future release when ``strict`` and ``best-practice``
+take over as the defaults.
 
-To migrate to stricter validation, replace ``legacy`` with ``strict``::
+To migrate to stricter validation, replace ``legacy`` with ``strict`` and
+add ``best-practice``::
 
   manager:
     enabled:
       - strict
+      - best-practice
 
 The ``strict`` set contains stricter validators that supersede their
 ``legacy`` counterparts — use one or the other, not both, to avoid redundant
 checks.
+
+The ``best-practice`` set contains validators that enforce DNS best-practice
+recommendations (rather than RFC requirements) and is independent of
+``strict``/``legacy``. The recommended configuration is to enable both
+``strict`` and ``best-practice`` together.
 
 A validator can belong to multiple sets; it becomes active when any of its
 sets is listed in ``manager.enabled``.
@@ -297,7 +305,26 @@ To opt into all strict validators at once::
     enabled:
       - strict
 
-In a future release ``strict`` will become the default set.
+Validators active in ``best-practice`` only:
+
++-------------------------------+--------------------------------------------------+
+| id                            | description                                      |
++===============================+==================================================+
+| ``target-value-best-practice``| CNAME/ALIAS/DNAME target must end with ``"."``   |
+|                               | (absolute name prevents resolver search-domain   |
+|                               | append)                                          |
++-------------------------------+--------------------------------------------------+
+| ``targets-value-best-practice``| NS/PTR targets must each end with ``"."``       |
++-------------------------------+--------------------------------------------------+
+
+The recommended configuration is to enable both sets::
+
+  manager:
+    enabled:
+      - strict
+      - best-practice
+
+In a future release ``strict`` and ``best-practice`` will become the default sets.
 
 Adding validators via config
 ............................

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -287,6 +287,9 @@ Validators active in ``strict`` only (stricter replacements):
 |                    | fingerprint must be hex; SHA-1/SHA-256 length         |
 |                    | enforced (RFC 4255/6594); replaces ``sshfp-value``    |
 +--------------------+-------------------------------------------------------+
+| ``uri-value-rfc``  | URI priority/weight uint16 [0, 65535] (RFC 7553 §4);  |
+|                    | replaces ``uri-value``                                |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -264,6 +264,9 @@ Validators active in ``strict`` only (stricter replacements):
 | ``uri-name-rfc``   | URI name strict per RFC 7553 + RFC 6335 §5.1;         |
 |                    | replaces ``uri-name``                                 |
 +--------------------+-------------------------------------------------------+
+| ``mx-value-rfc``   | MX preference in [0, 65535]; null MX rules per        |
+|                    | RFC 7505; replaces ``mx-value``                       |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -261,6 +261,9 @@ Validators active in ``strict`` only (stricter replacements):
 | ``srv-value-rfc``  | SRV rdata strict per RFC 2782 (range, null target);   |
 |                    | replaces ``srv-value``                                |
 +--------------------+-------------------------------------------------------+
+| ``uri-name-rfc``   | URI name strict per RFC 7553 + RFC 6335 §5.1;         |
+|                    | replaces ``uri-name``                                 |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -271,6 +271,10 @@ Validators active in ``strict`` only (stricter replacements):
 |                    | tag must match ``[a-zA-Z0-9]+``; replaces             |
 |                    | ``caa-value``                                         |
 +--------------------+-------------------------------------------------------+
+| ``tlsa-value-rfc`` | TLSA fields uint8 [0, 255]; certificate_association   |
+|                    | _data must be hex; SHA-256/SHA-512 length enforced    |
+|                    | (RFC 6698); replaces ``tlsa-value``                   |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -283,6 +283,10 @@ Validators active in ``strict`` only (stricter replacements):
 |                    | replacement must be FQDN or "." (RFC 3403);           |
 |                    | replaces ``naptr-value``                              |
 +--------------------+-------------------------------------------------------+
+| ``sshfp-value-rfc``| SSHFP algorithm/fingerprint_type uint8 [0, 255];      |
+|                    | fingerprint must be hex; SHA-1/SHA-256 length         |
+|                    | enforced (RFC 4255/6594); replaces ``sshfp-value``    |
++--------------------+-------------------------------------------------------+
 
 To opt into all strict validators at once::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -161,16 +161,17 @@ are active for a run (default: ``['legacy']``)::
 
 Omitting ``manager.enabled`` is equivalent to ``enabled: [legacy]`` and
 preserves the original octoDNS behaviour. The ``legacy`` set will remain
-the default until a future release when ``rfc`` takes over as the default.
+the default until a future release when ``strict`` takes over as the default.
 
-To migrate to stricter RFC validation, replace ``legacy`` with ``rfc``::
+To migrate to stricter validation, replace ``legacy`` with ``strict``::
 
   manager:
     enabled:
-      - rfc
+      - strict
 
-The ``rfc`` set contains stricter validators that supersede their ``legacy``
-counterparts — use one or the other, not both, to avoid redundant checks.
+The ``strict`` set contains stricter validators that supersede their
+``legacy`` counterparts — use one or the other, not both, to avoid redundant
+checks.
 
 A validator can belong to multiple sets; it becomes active when any of its
 sets is listed in ``manager.enabled``.
@@ -181,39 +182,58 @@ Setting ``enabled: []`` activates only validators whose ``sets`` is ``None``
 Built-in validator ids
 ......................
 
-Each built-in validator has a stable short id. All belong to the ``legacy``
-set and can be disabled individually with ``manager.disable_validators``.
+Validators with ids ending in ``-rfc`` enforce requirements derived directly
+from an RFC. Ids prefixed with ``_`` (e.g. ``_values-type``) are internal
+bridge validators with ``sets=None`` — always active and cannot be disabled.
+
+Validators active in both ``legacy`` and ``strict``:
+
++------------------------+------------------------------------------+
+| id                     | description                              |
++========================+==========================================+
+| ``name-rfc``           | Record name format (RFC 1035/2181)       |
++------------------------+------------------------------------------+
+| ``ttl-rfc``            | TTL range (positive integer)             |
++------------------------+------------------------------------------+
+| ``healthcheck``        | octoDNS healthcheck config fields        |
++------------------------+------------------------------------------+
+| ``cname-root-rfc``     | CNAME must not be at zone root           |
++------------------------+------------------------------------------+
+| ``alias-root``         | ALIAS must not be at zone root           |
++------------------------+------------------------------------------+
+| ``ip-value-rfc``       | A / AAAA value format                    |
++------------------------+------------------------------------------+
+| ``target-value-rfc``   | CNAME/ALIAS/DNAME/PTR target format      |
++------------------------+------------------------------------------+
+| ``targets-value-rfc``  | NS targets format                        |
++------------------------+------------------------------------------+
+| ``loc-value-rfc``      | LOC rdata format (RFC 1876)              |
++------------------------+------------------------------------------+
+| ``chunked-value-rfc``  | TXT/SPF chunk encoding                   |
++------------------------+------------------------------------------+
+| ``svcb-value-rfc``     | SVCB rdata format (RFC 9460)             |
++------------------------+------------------------------------------+
+| ``https-value-rfc``    | HTTPS rdata format (RFC 9460)            |
++------------------------+------------------------------------------+
+| ``openpgpkey-value-rfc``| OPENPGPKEY rdata format (RFC 7929)      |
++------------------------+------------------------------------------+
+
+Validators active in ``legacy`` only (will be superseded in ``strict``):
 
 +----------------------+------------------------------------------+
 | id                   | description                              |
 +======================+==========================================+
-| ``name``             | Record name format                       |
+| ``geo``              | Geo routing config                       |
 +----------------------+------------------------------------------+
-| ``ttl``              | TTL range (positive integer)             |
-+----------------------+------------------------------------------+
-| ``healthcheck``      | Octodns healthcheck config fields        |
-+----------------------+------------------------------------------+
-| ``cname-root``       | CNAME must not be at zone root           |
-+----------------------+------------------------------------------+
-| ``alias-root``       | ALIAS must not be at zone root           |
+| ``dynamic``          | Dynamic routing config                   |
 +----------------------+------------------------------------------+
 | ``srv-name``         | SRV name format                          |
 +----------------------+------------------------------------------+
 | ``uri-name``         | URI name format                          |
 +----------------------+------------------------------------------+
-| ``geo``              | Geo routing config                       |
-+----------------------+------------------------------------------+
-| ``dynamic``          | Dynamic routing config                   |
-+----------------------+------------------------------------------+
-| ``ip-value``         | A / AAAA value format                    |
-+----------------------+------------------------------------------+
 | ``caa-value``        | CAA rdata format                         |
 +----------------------+------------------------------------------+
 | ``mx-value``         | MX rdata format                          |
-+----------------------+------------------------------------------+
-| ``target-value``     | CNAME/ALIAS/DNAME/PTR target format      |
-+----------------------+------------------------------------------+
-| ``targets-value``    | NS targets format                        |
 +----------------------+------------------------------------------+
 | ``sshfp-value``      | SSHFP algorithm/fingerprint format       |
 +----------------------+------------------------------------------+
@@ -223,48 +243,14 @@ set and can be disabled individually with ``manager.disable_validators``.
 +----------------------+------------------------------------------+
 | ``naptr-value``      | NAPTR rdata format                       |
 +----------------------+------------------------------------------+
-| ``loc-value``        | LOC rdata format                         |
-+----------------------+------------------------------------------+
 | ``ds-value``         | DS rdata format                          |
 +----------------------+------------------------------------------+
 | ``tlsa-value``       | TLSA rdata format                        |
 +----------------------+------------------------------------------+
-| ``openpgpkey-value`` | OPENPGPKEY rdata format                  |
-+----------------------+------------------------------------------+
 | ``urlfwd-value``     | URLFWD rdata format                      |
 +----------------------+------------------------------------------+
-| ``svcb-value``       | SVCB rdata format                        |
-+----------------------+------------------------------------------+
-| ``https-value``      | HTTPS rdata format                       |
-+----------------------+------------------------------------------+
-| ``chunked-value``    | TXT/SPF chunk size                       |
-+----------------------+------------------------------------------+
 
-Ids prefixed with ``_`` (e.g. ``_values-type``) are internal bridge validators
-with ``sets=None`` — they are always active and cannot be disabled.
-
-Validator naming convention
-...........................
-
-Validators are split into two flavors based on what they enforce:
-
-* ``RfcValidator`` / ids ending in ``-rfc`` — enforce requirements that come
-  directly from an RFC. Reasons reference specific RFC numbers.
-* ``BpValidator`` / ids ending in ``-bp`` — enforce best-practice
-  recommendations that aren't strictly required by an RFC (e.g. trailing
-  ``.`` on hostnames).
-
-Both follow the same config and registration paths described below; the
-naming just makes the source of each rule explicit so you can opt in or
-out with intent.
-
-Opt-in RFC validators
-.....................
-
-The ``rfc`` set contains stricter validators that replace the corresponding
-``legacy`` validators. They are not enabled by default because enabling them
-on an existing zone may surface records that don't strictly conform to their
-RFCs. The current ``rfc`` validators are:
+Validators active in ``strict`` only (stricter replacements):
 
 +--------------------+-------------------------------------------------------+
 | id                 | description                                           |
@@ -276,13 +262,13 @@ RFCs. The current ``rfc`` validators are:
 |                    | replaces ``srv-value``                                |
 +--------------------+-------------------------------------------------------+
 
-To opt in, set ``manager.enabled`` to ``rfc`` instead of ``legacy``::
+To opt into all strict validators at once::
 
   manager:
     enabled:
-      - rfc
+      - strict
 
-In a future release ``rfc`` will become the default set.
+In a future release ``strict`` will become the default set.
 
 Adding validators via config
 ............................

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -27,7 +27,7 @@ class AliasRecord(ValueMixin, Record):
     REFERENCES = ('https://datatracker.ietf.org/doc/draft-ietf-dnsop-aname/',)
     _type = 'ALIAS'
     _value_type = AliasValue
-    VALIDATORS = [AliasRootValidator('alias-root', sets={'legacy'})]
+    VALIDATORS = [AliasRootValidator('alias-root', sets={'legacy', 'strict'})]
 
 
 Record.register_type(AliasRecord)

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -538,6 +538,8 @@ class ValueMixin(object):
         return f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, {self.value}{octodns}>'
 
 
-Record.register_validator(NameValidator('name', sets={'legacy'}))
-Record.register_validator(TtlValidator('ttl', sets={'legacy'}))
-Record.register_validator(HealthcheckValidator('healthcheck', sets={'legacy'}))
+Record.register_validator(NameValidator('name-rfc', sets={'legacy', 'strict'}))
+Record.register_validator(TtlValidator('ttl-rfc', sets={'legacy', 'strict'}))
+Record.register_validator(
+    HealthcheckValidator('healthcheck', sets={'legacy', 'strict'})
+)

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -2,6 +2,8 @@
 #
 #
 
+import re
+
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
@@ -31,10 +33,53 @@ class CaaValueValidator(ValueValidator):
         return reasons
 
 
-class CaaValue(EqualityTupleMixin, dict):
-    # https://tools.ietf.org/html/rfc6844#page-5
+class CaaValueRfcValidator(ValueValidator):
+    '''
+    Strict CAA rdata validator per RFC 8659 §4.1.
 
-    VALIDATORS = [CaaValueValidator('caa-value', sets={'legacy'})]
+    - ``flags`` must be 0 or 128 — only bit 0 (Issuer Critical) is
+      defined; all other bits are reserved and must be zero.
+    - ``tag`` must match ``[a-zA-Z0-9]+``.
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    _tag_re = re.compile(r'^[a-zA-Z0-9]+$')
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                flags = int(value.get('flags', 0))
+                if flags not in (0, 128):
+                    reasons.append(
+                        f'flags "{flags}" is not valid; must be 0 or 128'
+                    )
+            except (ValueError, TypeError):
+                reasons.append(f'invalid flags "{value["flags"]}"')
+
+            tag = value.get('tag')
+            if not tag:
+                reasons.append('missing tag')
+            elif not self._tag_re.match(tag):
+                reasons.append(f'invalid tag "{tag}"')
+
+            if 'value' not in value:
+                reasons.append('missing value')
+        return reasons
+
+
+class CaaValue(EqualityTupleMixin, dict):
+    # https://tools.ietf.org/html/rfc8659
+
+    VALIDATORS = [
+        CaaValueValidator('caa-value', sets={'legacy'}),
+        CaaValueRfcValidator('caa-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -36,7 +36,7 @@ class ChunkedValueValidator(ValueValidator):
 
 
 chunked_value_validator = ChunkedValueValidator(
-    'chunked-value', sets={'legacy'}
+    'chunked-value-rfc', sets={'legacy', 'strict'}
 )
 
 

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -28,7 +28,9 @@ class CnameRecord(_DynamicMixin, ValueMixin, Record):
     REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc1035',)
     _type = 'CNAME'
     _value_type = CnameValue
-    VALIDATORS = [CnameRootValidator('cname-root', sets={'legacy'})]
+    VALIDATORS = [
+        CnameRootValidator('cname-root-rfc', sets={'legacy', 'strict'})
+    ]
 
 
 Record.register_type(CnameRecord)

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -2,6 +2,7 @@
 #
 #
 
+import re
 from logging import getLogger
 
 from ..deprecation import deprecated
@@ -79,11 +80,79 @@ class DsValueValidator(ValueValidator):
         return reasons
 
 
+class DsValueRfcValidator(ValueValidator):
+    '''
+    Strict DS rdata validator per RFC 4034 §5.1, RFC 4509, and RFC 6605.
+
+    - ``key_tag`` must be in [0, 65535] (uint16).
+    - ``algorithm`` must be in [0, 255] (uint8).
+    - ``digest_type`` must be in [0, 255] (uint8).
+    - ``digest`` must be a valid hexadecimal string.
+    - For known digest types, the digest length is enforced:
+      type 1 (SHA-1) = 40 hex chars, type 2 (SHA-256) = 64 hex chars,
+      type 4 (SHA-384) = 96 hex chars.
+
+    The deprecated legacy field names (``flags``, ``protocol``,
+    ``public_key``) are not accepted in strict mode.
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    _hex_re = re.compile(r'^[0-9a-fA-F]+$')
+    _digest_type_lengths = {1: 40, 2: 64, 4: 96}
+
+    def validate(self, value_cls, data, _type):
+        if not isinstance(data, (list, tuple)):
+            data = (data,)
+        reasons = []
+        for value in data:
+            digest_type = None
+            for field, max_val in (
+                ('key_tag', 65535),
+                ('algorithm', 255),
+                ('digest_type', 255),
+            ):
+                if field not in value:
+                    reasons.append(f'missing {field}')
+                else:
+                    try:
+                        int_val = int(value[field])
+                        if not 0 <= int_val <= max_val:
+                            reasons.append(
+                                f'invalid {field} "{int_val}"; must be 0-{max_val}'
+                            )
+                        elif field == 'digest_type':
+                            digest_type = int_val
+                    except (ValueError, TypeError):
+                        reasons.append(f'invalid {field} "{value[field]}"')
+
+            if 'digest' not in value:
+                reasons.append('missing digest')
+            else:
+                digest = value['digest']
+                if not digest or not self._hex_re.match(str(digest)):
+                    reasons.append(f'invalid digest "{digest}"; must be hex')
+                elif digest_type in self._digest_type_lengths:
+                    expected = self._digest_type_lengths[digest_type]
+                    if len(str(digest)) != expected:
+                        reasons.append(
+                            f'digest must be {expected} hex characters for digest_type {digest_type}'
+                        )
+        return reasons
+
+
 class DsValue(EqualityTupleMixin, dict):
     # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
     log = getLogger('DsValue')
 
-    VALIDATORS = [DsValueValidator('ds-value', sets={'legacy'})]
+    VALIDATORS = [
+        DsValueValidator('ds-value', sets={'legacy'}),
+        DsValueRfcValidator('ds-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -164,7 +164,7 @@ class _Dynamic(object):
 
 
 class _DynamicMixin(object):
-    VALIDATORS = [DynamicValidator('dynamic', sets={'legacy'})]
+    VALIDATORS = [DynamicValidator('dynamic', sets={'legacy', 'strict'})]
 
     geo_re = re.compile(
         r'^(?P<continent_code>\w\w)(-(?P<country_code>\w\w)'

--- a/octodns/record/https.py
+++ b/octodns/record/https.py
@@ -4,12 +4,19 @@
 #
 
 from .base import Record, ValuesMixin
-from .svcb import SvcbValueValidator, _SvcbValueBase
+from .svcb import (
+    SvcbValueBestPracticeValidator,
+    SvcbValueValidator,
+    _SvcbValueBase,
+)
 
 
 class HttpsValue(_SvcbValueBase):
     VALIDATORS = [
-        SvcbValueValidator('https-value-rfc', sets={'legacy', 'strict'})
+        SvcbValueValidator('https-value-rfc', sets={'legacy', 'strict'}),
+        SvcbValueBestPracticeValidator(
+            'https-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
 

--- a/octodns/record/https.py
+++ b/octodns/record/https.py
@@ -8,7 +8,9 @@ from .svcb import SvcbValueValidator, _SvcbValueBase
 
 
 class HttpsValue(_SvcbValueBase):
-    VALIDATORS = [SvcbValueValidator('https-value', sets={'legacy'})]
+    VALIDATORS = [
+        SvcbValueValidator('https-value-rfc', sets={'legacy', 'strict'})
+    ]
 
 
 class HttpsRecord(ValuesMixin, Record):

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -34,7 +34,7 @@ class IpValueValidator(ValueValidator):
 
 
 class _IpValue(str):
-    VALIDATORS = [IpValueValidator('ip-value', sets={'legacy'})]
+    VALIDATORS = [IpValueValidator('ip-value-rfc', sets={'legacy', 'strict'})]
 
     @classmethod
     def parse_rdata_text(cls, value):

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -112,7 +112,7 @@ class LocValue(EqualityTupleMixin, dict):
     # while maintaining backwards compatibility.
     # https://www.rfc-editor.org/rfc/rfc1876.html
 
-    VALIDATORS = [LocValueValidator('loc-value', sets={'legacy'})]
+    VALIDATORS = [LocValueValidator('loc-value-rfc', sets={'legacy', 'strict'})]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -6,7 +6,7 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .target import validate_target_fqdn
+from .target import _check_target_format, _check_target_trailing_dot
 from .validator import ValueValidator
 
 
@@ -32,7 +32,7 @@ class MxValueValidator(ValueValidator):
             exchange = None
             try:
                 exchange = value.get('exchange') or value['value']
-                reasons += validate_target_fqdn(exchange, _type, 'exchange')
+                reasons += _check_target_format(exchange, _type, 'exchange')
             except KeyError:
                 reasons.append('missing exchange')
         return reasons
@@ -80,7 +80,31 @@ class MxValueRfcValidator(ValueValidator):
                         'preference must be 0 for null MX (exchange ".")'
                     )
             else:
-                reasons += validate_target_fqdn(exchange, _type, 'exchange')
+                reasons += _check_target_format(exchange, _type, 'exchange')
+        return reasons
+
+
+class MxValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that the MX ``exchange`` field ends with a trailing ``.``
+    (fully-qualified name).  Without the trailing dot resolvers may
+    append the host search domain, causing extra lookups.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            exchange = value.get('exchange') or value.get('value')
+            if exchange:
+                reasons += _check_target_trailing_dot(
+                    exchange, _type, 'exchange'
+                )
         return reasons
 
 
@@ -88,6 +112,9 @@ class MxValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         MxValueValidator('mx-value', sets={'legacy'}),
         MxValueRfcValidator('mx-value-rfc', sets={'strict'}),
+        MxValueBestPracticeValidator(
+            'mx-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -38,8 +38,57 @@ class MxValueValidator(ValueValidator):
         return reasons
 
 
+class MxValueRfcValidator(ValueValidator):
+    '''
+    Strict MX rdata validator per RFC 5321 and RFC 7505.
+
+    - ``preference`` must be in [0, 65535].
+    - When ``exchange`` is ``"."``, ``preference`` must be 0 (null MX
+      per RFC 7505 §3).
+    - When ``exchange`` is not ``"."``, it must be a valid FQDN.
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            preference = None
+            if 'preference' in value or 'priority' in value:
+                raw = value.get('preference', value.get('priority'))
+                try:
+                    preference = int(raw)
+                    if not 0 <= preference <= 65535:
+                        reasons.append(
+                            f'preference "{preference}" out of range 0-65535'
+                        )
+                except (ValueError, TypeError):
+                    reasons.append(f'invalid preference "{raw}"')
+            else:
+                reasons.append('missing preference')
+
+            exchange = value.get('exchange') or value.get('value')
+            if not exchange:
+                reasons.append('missing exchange')
+            elif exchange == '.':
+                if preference is not None and preference != 0:
+                    reasons.append(
+                        'preference must be 0 for null MX (exchange ".")'
+                    )
+            else:
+                reasons += validate_target_fqdn(exchange, _type, 'exchange')
+        return reasons
+
+
 class MxValue(EqualityTupleMixin, dict):
-    VALIDATORS = [MxValueValidator('mx-value', sets={'legacy'})]
+    VALIDATORS = [
+        MxValueValidator('mx-value', sets={'legacy'}),
+        MxValueRfcValidator('mx-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -5,6 +5,7 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
+from .target import _check_target_trailing_dot
 from .validator import ValueValidator
 
 
@@ -93,17 +94,31 @@ class NaptrValueRfcValidator(ValueValidator):
 
             if 'replacement' not in value:
                 reasons.append('missing replacement')
-            else:
-                replacement = value['replacement']
-                if (
-                    replacement
-                    and replacement != '.'
-                    and not replacement.endswith('.')
-                ):
-                    reasons.append(
-                        f'NAPTR replacement "{replacement}" missing trailing .'
-                    )
 
+        return reasons
+
+
+class NaptrValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that the NAPTR ``replacement`` field ends with a trailing
+    ``.`` (fully-qualified name) when non-empty and not the null
+    replacement ``"."``.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            replacement = value.get('replacement')
+            if replacement:
+                reasons += _check_target_trailing_dot(
+                    replacement, _type, 'replacement'
+                )
         return reasons
 
 
@@ -113,6 +128,9 @@ class NaptrValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         NaptrValueValidator('naptr-value', sets={'legacy'}),
         NaptrValueRfcValidator('naptr-value-rfc', sets={'strict'}),
+        NaptrValueBestPracticeValidator(
+            'naptr-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -45,10 +45,75 @@ class NaptrValueValidator(ValueValidator):
         return reasons
 
 
+class NaptrValueRfcValidator(ValueValidator):
+    '''
+    Strict NAPTR rdata validator per RFC 3403 §4.1.
+
+    - ``order`` and ``preference`` must be integers in [0, 65535] (uint16).
+    - ``flags`` must be one of ``S``, ``A``, ``U``, ``P`` (case-insensitive)
+      or empty.
+    - ``replacement`` must be a fully-qualified domain name (ending with
+      ``"."``) or ``"."`` for the null replacement.
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    _valid_flags = frozenset('SAUP')
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            for field in ('order', 'preference'):
+                if field not in value:
+                    reasons.append(f'missing {field}')
+                else:
+                    try:
+                        int_val = int(value[field])
+                        if not 0 <= int_val <= 65535:
+                            reasons.append(
+                                f'invalid {field} "{int_val}"; must be 0-65535'
+                            )
+                    except (ValueError, TypeError):
+                        reasons.append(f'invalid {field} "{value[field]}"')
+
+            if 'flags' not in value:
+                reasons.append('missing flags')
+            else:
+                flags = value['flags']
+                if flags and flags.upper() not in self._valid_flags:
+                    reasons.append(f'unrecognized flags "{flags}"')
+
+            for k in ('service', 'regexp'):
+                if k not in value:
+                    reasons.append(f'missing {k}')
+
+            if 'replacement' not in value:
+                reasons.append('missing replacement')
+            else:
+                replacement = value['replacement']
+                if (
+                    replacement
+                    and replacement != '.'
+                    and not replacement.endswith('.')
+                ):
+                    reasons.append(
+                        f'NAPTR replacement "{replacement}" missing trailing .'
+                    )
+
+        return reasons
+
+
 class NaptrValue(EqualityTupleMixin, dict):
     VALID_FLAGS = ('S', 'A', 'U', 'P', 's', 'a', 'u', 'p')
 
-    VALIDATORS = [NaptrValueValidator('naptr-value', sets={'legacy'})]
+    VALIDATORS = [
+        NaptrValueValidator('naptr-value', sets={'legacy'}),
+        NaptrValueRfcValidator('naptr-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -25,7 +25,11 @@ class OpenpgpkeyValue(str):
     RFC 7929 - DANE Bindings for OpenPGP
     '''
 
-    VALIDATORS = [OpenpgpkeyValueValidator('openpgpkey-value', sets={'legacy'})]
+    VALIDATORS = [
+        OpenpgpkeyValueValidator(
+            'openpgpkey-value-rfc', sets={'legacy', 'strict'}
+        )
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -8,7 +8,7 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .target import validate_target_fqdn
+from .target import _check_target_format, _check_target_trailing_dot
 from .validator import RecordValidator, ValueValidator
 
 
@@ -57,7 +57,7 @@ class SrvValueValidator(ValueValidator):
                 reasons.append(f'invalid port "{value["port"]}"')
             try:
                 target = value['target']
-                reasons += validate_target_fqdn(target, _type, 'target')
+                reasons += _check_target_format(target, _type, 'target')
             except KeyError:
                 reasons.append('missing target')
         return reasons
@@ -165,10 +165,34 @@ class SrvValueRfcValidator(ValueValidator):
         return reasons
 
 
+class SrvValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that the SRV ``target`` field ends with a trailing ``.``
+    (fully-qualified name).
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            target = value.get('target')
+            if target:
+                reasons += _check_target_trailing_dot(target, _type, 'target')
+        return reasons
+
+
 class SrvValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         SrvValueValidator('srv-value', sets={'legacy'}),
         SrvValueRfcValidator('srv-value-rfc', sets={'strict'}),
+        SrvValueBestPracticeValidator(
+            'srv-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -168,7 +168,7 @@ class SrvValueRfcValidator(ValueValidator):
 class SrvValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         SrvValueValidator('srv-value', sets={'legacy'}),
-        SrvValueRfcValidator('srv-value-rfc', sets={'rfc'}),
+        SrvValueRfcValidator('srv-value-rfc', sets={'strict'}),
     ]
 
     @classmethod
@@ -290,7 +290,7 @@ class SrvRecord(ValuesMixin, Record):
     _value_type = SrvValue
     VALIDATORS = [
         SrvNameValidator('srv-name', sets={'legacy'}),
-        SrvNameRfcValidator('srv-name-rfc', sets={'rfc'}),
+        SrvNameRfcValidator('srv-name-rfc', sets={'strict'}),
     ]
 
 

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -2,6 +2,8 @@
 #
 #
 
+import re
+
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
@@ -65,11 +67,71 @@ class SshfpValueValidator(ValueValidator):
         return reasons
 
 
+class SshfpValueRfcValidator(ValueValidator):
+    '''
+    Strict SSHFP rdata validator per RFC 4255/6594/7479/8709.
+
+    - ``algorithm`` must be an integer in [0, 255].
+    - ``fingerprint_type`` must be an integer in [0, 255].
+    - ``fingerprint`` must be a valid lowercase hex string.
+    - For ``fingerprint_type`` 1 (SHA-1): fingerprint must be 40 hex chars.
+    - For ``fingerprint_type`` 2 (SHA-256): fingerprint must be 64 hex chars.
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    _hex_re = re.compile(r'^[0-9a-fA-F]+$')
+    _fingerprint_type_lengths = {1: 40, 2: 64}
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            fingerprint_type = None
+            for field, max_val in (
+                ('algorithm', 255),
+                ('fingerprint_type', 255),
+            ):
+                if field not in value:
+                    reasons.append(f'missing {field}')
+                else:
+                    try:
+                        int_val = int(value[field])
+                        if not 0 <= int_val <= max_val:
+                            reasons.append(
+                                f'invalid {field} "{int_val}"; must be 0-{max_val}'
+                            )
+                        elif field == 'fingerprint_type':
+                            fingerprint_type = int_val
+                    except (ValueError, TypeError):
+                        reasons.append(f'invalid {field} "{value[field]}"')
+            if 'fingerprint' not in value:
+                reasons.append('missing fingerprint')
+            else:
+                fp = value['fingerprint']
+                if not fp or not self._hex_re.match(str(fp)):
+                    reasons.append(f'invalid fingerprint "{fp}"; must be hex')
+                elif fingerprint_type in self._fingerprint_type_lengths:
+                    expected = self._fingerprint_type_lengths[fingerprint_type]
+                    if len(str(fp)) != expected:
+                        reasons.append(
+                            f'fingerprint must be {expected} hex characters '
+                            f'for fingerprint_type {fingerprint_type}'
+                        )
+        return reasons
+
+
 class SshfpValue(EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
 
-    VALIDATORS = [SshfpValueValidator('sshfp-value', sets={'legacy'})]
+    VALIDATORS = [
+        SshfpValueValidator('sshfp-value', sets={'legacy'}),
+        SshfpValueRfcValidator('sshfp-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -12,7 +12,7 @@ from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .chunked import _ChunkedValue, chunked_value_validator
 from .rr import RrParseError
-from .target import validate_target_fqdn
+from .target import _check_target_format, _check_target_trailing_dot
 from .validator import ValueValidator
 
 SUPPORTED_PARAMS = {}
@@ -164,7 +164,7 @@ class SvcbValueValidator(ValueValidator):
                 except ValueError:
                     reasons.append(f'invalid priority "{value["svcpriority"]}"')
 
-            reasons += validate_target_fqdn(
+            reasons += _check_target_format(
                 value.get('targetname'), _type, 'targetname'
             )
 
@@ -328,9 +328,33 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         return f"'{self.rdata_text}'"
 
 
+class SvcbValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that the SVCB/HTTPS ``targetname`` field ends with a trailing
+    ``.`` (fully-qualified name).
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            reasons += _check_target_trailing_dot(
+                value.get('targetname'), _type, 'targetname'
+            )
+        return reasons
+
+
 class SvcbValue(_SvcbValueBase):
     VALIDATORS = [
-        SvcbValueValidator('svcb-value-rfc', sets={'legacy', 'strict'})
+        SvcbValueValidator('svcb-value-rfc', sets={'legacy', 'strict'}),
+        SvcbValueBestPracticeValidator(
+            'svcb-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
 

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -329,7 +329,9 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
 
 
 class SvcbValue(_SvcbValueBase):
-    VALIDATORS = [SvcbValueValidator('svcb-value', sets={'legacy'})]
+    VALIDATORS = [
+        SvcbValueValidator('svcb-value-rfc', sets={'legacy', 'strict'})
+    ]
 
 
 class SvcbRecord(ValuesMixin, Record):

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -34,12 +34,6 @@ def _check_target_trailing_dot(target, _type, key='value'):
     return []
 
 
-def validate_target_fqdn(target, _type, key='value'):
-    return _check_target_format(
-        target, _type, key
-    ) + _check_target_trailing_dot(target, _type, key)
-
-
 class TargetValueValidator(ValueValidator):
     '''
     Validates a single-value target FQDN (CNAME, ALIAS, DNAME, PTR).

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -58,7 +58,9 @@ class TargetsValueValidator(ValueValidator):
 
 
 class _TargetValue(str):
-    VALIDATORS = [TargetValueValidator('target-value', sets={'legacy'})]
+    VALIDATORS = [
+        TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'})
+    ]
 
     @classmethod
     def parse_rdata_text(self, value):
@@ -91,7 +93,9 @@ class _TargetValue(str):
 #
 # much like _TargetValue, but geared towards multiple values
 class _TargetsValue(str):
-    VALIDATORS = [TargetsValueValidator('targets-value', sets={'legacy'})]
+    VALIDATORS = [
+        TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'})
+    ]
 
     @classmethod
     def parse_rdata_text(cls, value):

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -8,28 +8,36 @@ from ..idna import idna_encode
 from .validator import ValueValidator
 
 
-def validate_target_fqdn(target, _type, key='value'):
+def _check_target_format(target, _type, key='value'):
     if not target:
         return [f'missing {key}']
-
-    # Allow null target for records types that support it.
     if target == '.' and _type in ['HTTPS', 'MX', 'SVCB', 'SRV']:
         return []
-
-    # Bypass record value validation if it contains templating variables as they
-    # haven't been substituted yet.
     if '{' in target and '}' in target:
         return []
-
-    reasons = []
     target = idna_encode(target)
     if not FQDN(str(target), allow_underscores=True).is_valid:
-        reasons.append(f'{_type} {key} "{target}" is not a valid FQDN')
+        return [f'{_type} {key} "{target}" is not a valid FQDN']
+    return []
 
+
+def _check_target_trailing_dot(target, _type, key='value'):
+    if not target:
+        return []
+    if target == '.' and _type in ['HTTPS', 'MX', 'SVCB', 'SRV']:
+        return []
+    if '{' in target and '}' in target:
+        return []
+    target = idna_encode(target)
     if not target.endswith('.'):
-        reasons.append(f'{_type} {key} "{target}" missing trailing .')
+        return [f'{_type} {key} "{target}" missing trailing .']
+    return []
 
-    return reasons
+
+def validate_target_fqdn(target, _type, key='value'):
+    return _check_target_format(
+        target, _type, key
+    ) + _check_target_trailing_dot(target, _type, key)
 
 
 class TargetValueValidator(ValueValidator):
@@ -38,7 +46,7 @@ class TargetValueValidator(ValueValidator):
     '''
 
     def validate(self, value_cls, data, _type):
-        return validate_target_fqdn(data, _type)
+        return _check_target_format(data, _type)
 
 
 class TargetsValueValidator(ValueValidator):
@@ -52,14 +60,53 @@ class TargetsValueValidator(ValueValidator):
 
         reasons = []
         for value in data:
-            reasons += validate_target_fqdn(value, _type)
+            reasons += _check_target_format(value, _type)
 
+        return reasons
+
+
+class TargetValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that a single-value target ends with a trailing ``.`` (i.e. is
+    an absolute/fully-qualified name).  Without the trailing dot, resolvers
+    may append the host's search domain, multiplying query traffic.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        return _check_target_trailing_dot(data, _type)
+
+
+class TargetsValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that each target in a multi-value record ends with a trailing
+    ``.`` (i.e. is an absolute/fully-qualified name).
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            reasons += _check_target_trailing_dot(value, _type)
         return reasons
 
 
 class _TargetValue(str):
     VALIDATORS = [
-        TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'})
+        TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'}),
+        TargetValueBestPracticeValidator(
+            'target-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod
@@ -94,7 +141,10 @@ class _TargetValue(str):
 # much like _TargetValue, but geared towards multiple values
 class _TargetsValue(str):
     VALIDATORS = [
-        TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'})
+        TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'}),
+        TargetsValueBestPracticeValidator(
+            'targets-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -2,6 +2,8 @@
 #
 #
 
+import re
+
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
@@ -57,8 +59,69 @@ class TlsaValueValidator(ValueValidator):
         return reasons
 
 
+class TlsaValueRfcValidator(ValueValidator):
+    '''
+    Strict TLSA rdata validator per RFC 6698.
+
+    - ``certificate_usage``, ``selector``, and ``matching_type`` must each be
+      integers in [0, 255] (uint8 fields).
+    - ``certificate_association_data`` must be a valid hexadecimal string.
+    - When ``matching_type`` is 1 (SHA-256), the data must be exactly 64 hex
+      characters (32 bytes).
+    - When ``matching_type`` is 2 (SHA-512), the data must be exactly 128 hex
+      characters (64 bytes).
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    _hex_re = re.compile(r'^[0-9a-fA-F]+$')
+    _matching_type_lengths = {1: 64, 2: 128}
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            matching_type = None
+            for field in ('certificate_usage', 'selector', 'matching_type'):
+                if field not in value:
+                    reasons.append(f'missing {field}')
+                else:
+                    try:
+                        int_val = int(value[field])
+                        if not 0 <= int_val <= 255:
+                            reasons.append(
+                                f'invalid {field} "{int_val}"; must be 0-255'
+                            )
+                        elif field == 'matching_type':
+                            matching_type = int_val
+                    except (ValueError, TypeError):
+                        reasons.append(f'invalid {field} "{value[field]}"')
+
+            if 'certificate_association_data' not in value:
+                reasons.append('missing certificate_association_data')
+            else:
+                cad = value['certificate_association_data']
+                if not cad or not self._hex_re.match(str(cad)):
+                    reasons.append(
+                        f'invalid certificate_association_data "{cad}"; must be hex'
+                    )
+                elif matching_type in self._matching_type_lengths:
+                    expected = self._matching_type_lengths[matching_type]
+                    if len(str(cad)) != expected:
+                        reasons.append(
+                            f'certificate_association_data must be {expected} hex characters for matching_type {matching_type}'
+                        )
+        return reasons
+
+
 class TlsaValue(EqualityTupleMixin, dict):
-    VALIDATORS = [TlsaValueValidator('tlsa-value', sets={'legacy'})]
+    VALIDATORS = [
+        TlsaValueValidator('tlsa-value', sets={'legacy'}),
+        TlsaValueRfcValidator('tlsa-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -62,8 +62,45 @@ class UriValueValidator(ValueValidator):
         return reasons
 
 
+class UriValueRfcValidator(ValueValidator):
+    '''
+    Strict URI rdata validator per RFC 7553 §4.
+
+    - ``priority`` must be an integer in [0, 65535] (uint16).
+    - ``weight`` must be an integer in [0, 65535] (uint16).
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            for field in ('priority', 'weight'):
+                if field not in value:
+                    reasons.append(f'missing {field}')
+                else:
+                    try:
+                        int_val = int(value[field])
+                        if not 0 <= int_val <= 65535:
+                            reasons.append(
+                                f'invalid {field} "{int_val}"; must be 0-65535'
+                            )
+                    except (ValueError, TypeError):
+                        reasons.append(f'invalid {field} "{value[field]}"')
+            if 'target' not in value:
+                reasons.append('missing target')
+        return reasons
+
+
 class UriValue(EqualityTupleMixin, dict):
-    VALIDATORS = [UriValueValidator('uri-value', sets={'legacy'})]
+    VALIDATORS = [
+        UriValueValidator('uri-value', sets={'legacy'}),
+        UriValueRfcValidator('uri-value-rfc', sets={'strict'}),
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -156,11 +156,64 @@ class UriValue(EqualityTupleMixin, dict):
         return f"'{self.priority} {self.weight} \"{self.target}\"'"
 
 
+class UriNameRfcValidator(RecordValidator):
+    '''
+    Strict URI name validator per RFC 7553 §3 and RFC 6335 §5.1.
+
+    Requires the first two labels of the record name to be
+    ``_service._proto`` (``*._proto`` is still accepted for wildcards).
+    Both label bodies (after the leading ``_``) must conform to the
+    RFC 6335 §5.1 service name syntax: 1-15 characters, starting with a
+    letter, ending with a letter or digit, containing only letters,
+    digits, and hyphens, and with no consecutive hyphens.
+
+    Enabled as part of the ``strict`` validator set::
+
+      manager:
+        enabled:
+          - strict
+    '''
+
+    _max_len = 15
+
+    @classmethod
+    def _is_valid_service_name(cls, body):
+        if not body or len(body) > cls._max_len:
+            return False
+        if not body[0].isalpha():
+            return False
+        if not body[-1].isalnum():
+            return False
+        if '--' in body:
+            return False
+        return all(c.isalnum() or c == '-' for c in body)
+
+    def validate(self, record_cls, name, fqdn, data):
+        labels = name.split('.') if name else []
+        if len(labels) < 2:
+            return ['URI name must have at least two labels (_service._proto)']
+
+        reasons = []
+        service, proto = labels[0], labels[1]
+        if service != '*' and not (
+            service.startswith('_') and self._is_valid_service_name(service[1:])
+        ):
+            reasons.append(f'invalid URI service label "{service}"')
+        if not (
+            proto.startswith('_') and self._is_valid_service_name(proto[1:])
+        ):
+            reasons.append(f'invalid URI proto label "{proto}"')
+        return reasons
+
+
 class UriRecord(ValuesMixin, Record):
     REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc7553',)
     _type = 'URI'
     _value_type = UriValue
-    VALIDATORS = [UriNameValidator('uri-name', sets={'legacy'})]
+    VALIDATORS = [
+        UriNameValidator('uri-name', sets={'legacy'}),
+        UriNameRfcValidator('uri-name-rfc', sets={'strict'}),
+    ]
 
 
 Record.register_type(UriRecord)

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -53,7 +53,9 @@ class UrlfwdValue(EqualityTupleMixin, dict):
     VALID_MASKS = (0, 1, 2)
     VALID_QUERY = (0, 1)
 
-    VALIDATORS = [UrlfwdValueValidator('urlfwd-value', sets={'legacy'})]
+    VALIDATORS = [
+        UrlfwdValueValidator('urlfwd-value', sets={'legacy', 'strict'})
+    ]
 
     @classmethod
     def _schema(cls):

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -282,7 +282,7 @@ class ValueValidator:
             tuple)): data = (data,)``.
         _type : str
             The record type string (e.g. ``'MX'``, ``'A'``). Passed
-            through to helpers like ``validate_target_fqdn`` which format
+            through to helpers like ``_check_target_format`` which format
             it into their reason strings.
 
         Returns

--- a/tests/config/validators-id-collision.yaml
+++ b/tests/config/validators-id-collision.yaml
@@ -1,9 +1,9 @@
 validators:
-  name:
+  name-rfc:
     class: helpers.TestRecordValidator
 manager:
   validators:
     '*':
-      - name
+      - name-rfc
 providers: {}
 zones: {}

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -243,8 +243,8 @@ class TestManager(TestCase):
             global_validators = Record.registered_validators()['record'].get(
                 '*', []
             )
-            self.assertTrue(any(v.id == 'name' for v in global_validators))
-            self.assertTrue(any(v.id == 'ttl' for v in global_validators))
+            self.assertTrue(any(v.id == 'name-rfc' for v in global_validators))
+            self.assertTrue(any(v.id == 'ttl-rfc' for v in global_validators))
 
     def test_validators_enabled_sets(self):
         # manager.enabled can include multiple set names; validators
@@ -266,7 +266,7 @@ class TestManager(TestCase):
             global_validators = Record.registered_validators()['record'].get(
                 '*', []
             )
-            self.assertTrue(any(v.id == 'name' for v in global_validators))
+            self.assertTrue(any(v.id == 'name-rfc' for v in global_validators))
 
     def test_validators_enabled_empty(self):
         # manager.enabled: [] removes all non-bridge validators from active.

--- a/tests/test_octodns_record_alias.py
+++ b/tests/test_octodns_record_alias.py
@@ -96,18 +96,6 @@ class TestRecordAlias(TestCase):
             ['ALIAS value "__." is not a valid FQDN'], ctx.exception.reasons
         )
 
-        # missing trailing .
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone,
-                '',
-                {'type': 'ALIAS', 'ttl': 600, 'value': 'foo.bar.com'},
-            )
-        self.assertEqual(
-            ['ALIAS value "foo.bar.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
-
     def test_template_validation(self):
         templ = Templating('test')
 
@@ -131,16 +119,54 @@ class TestRecordAlias(TestCase):
             {
                 'type': 'ALIAS',
                 'ttl': 600,
-                # Value is missing trailing dot
+                # Value is missing trailing dot — no error without best-practice
                 'value': '{zone_name}example.com',
             },
             lenient=False,
         )
         zone.add_record(alias, replace=True)
+        templ.process_source_and_target_zones(zone, None, None)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['ALIAS value "unit.tests.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+    def test_best_practice_validator(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('target-value-best-practice', types=['ALIAS'])
+        try:
+            # missing trailing dot is caught
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {'type': 'ALIAS', 'ttl': 600, 'value': 'foo.bar.com'},
+                )
+            self.assertEqual(
+                ['ALIAS value "foo.bar.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot caught after template substitution
+            templ = Templating('test')
+            alias = Record.new(
+                zone,
+                '',
+                {
+                    'type': 'ALIAS',
+                    'ttl': 600,
+                    'value': '{zone_name}example.com',
+                },
+                lenient=False,
+            )
+            zone.add_record(alias, replace=True)
+            with self.assertRaises(ValidationError) as ctx:
+                templ.process_source_and_target_zones(zone, None, None)
+            self.assertEqual(
+                ['ALIAS value "unit.tests.example.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone, '', {'type': 'ALIAS', 'ttl': 600, 'value': 'foo.bar.com.'}
+            )
+        finally:
+            Record.disable_validator(
+                'target-value-best-practice', types=['ALIAS']
+            )

--- a/tests/test_octodns_record_caa.py
+++ b/tests/test_octodns_record_caa.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from helpers import SimpleProvider
 
 from octodns.record import Record
-from octodns.record.caa import CaaRecord, CaaValue
+from octodns.record.caa import CaaRecord, CaaValue, CaaValueRfcValidator
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
@@ -285,6 +285,157 @@ class TestRecordCaa(TestCase):
                 {'type': 'CAA', 'ttl': 600, 'value': {'tag': 'iodef'}},
             )
         self.assertEqual(['missing value'], ctx.exception.reasons)
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        caa_value_ids = set(v.id for v in registered['value'].get('CAA', []))
+        self.assertNotIn('caa-value-rfc', caa_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = CaaValueRfcValidator('caa-value-rfc').validate
+
+        # valid: flags 0
+        self.assertEqual(
+            [],
+            validate(
+                CaaValue,
+                [{'flags': 0, 'tag': 'issue', 'value': 'ca.example.net'}],
+                'CAA',
+            ),
+        )
+        # valid: flags 128
+        self.assertEqual(
+            [],
+            validate(
+                CaaValue,
+                [
+                    {
+                        'flags': 128,
+                        'tag': 'iodef',
+                        'value': 'mailto:security@example.com',
+                    }
+                ],
+                'CAA',
+            ),
+        )
+        # valid: alphanumeric tag
+        self.assertEqual(
+            [],
+            validate(
+                CaaValue,
+                [{'flags': 0, 'tag': 'issuewild', 'value': 'ca.example.net'}],
+                'CAA',
+            ),
+        )
+
+        # invalid flags (not 0 or 128)
+        self.assertEqual(
+            ['flags "1" is not valid; must be 0 or 128'],
+            validate(
+                CaaValue,
+                [{'flags': 1, 'tag': 'issue', 'value': 'ca.example.net'}],
+                'CAA',
+            ),
+        )
+        self.assertEqual(
+            ['flags "255" is not valid; must be 0 or 128'],
+            validate(
+                CaaValue,
+                [{'flags': 255, 'tag': 'issue', 'value': 'ca.example.net'}],
+                'CAA',
+            ),
+        )
+
+        # invalid flags (not parseable)
+        self.assertEqual(
+            ['invalid flags "nope"'],
+            validate(
+                CaaValue,
+                [{'flags': 'nope', 'tag': 'issue', 'value': 'ca.example.net'}],
+                'CAA',
+            ),
+        )
+
+        # missing tag
+        self.assertEqual(
+            ['missing tag'],
+            validate(
+                CaaValue, [{'flags': 0, 'value': 'ca.example.net'}], 'CAA'
+            ),
+        )
+
+        # invalid tag (contains hyphen)
+        self.assertEqual(
+            ['invalid tag "is-sue"'],
+            validate(
+                CaaValue,
+                [{'flags': 0, 'tag': 'is-sue', 'value': 'ca.example.net'}],
+                'CAA',
+            ),
+        )
+
+        # missing value
+        self.assertEqual(
+            ['missing value'],
+            validate(CaaValue, [{'flags': 0, 'tag': 'issue'}], 'CAA'),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('caa-value-rfc', types=['CAA'])
+        try:
+            # invalid flags
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'CAA',
+                        'ttl': 600,
+                        'value': {
+                            'flags': 64,
+                            'tag': 'issue',
+                            'value': 'ca.example.net',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['flags "64" is not valid; must be 0 or 128'],
+                ctx.exception.reasons,
+            )
+            # invalid tag
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'CAA',
+                        'ttl': 600,
+                        'value': {
+                            'flags': 0,
+                            'tag': 'is-sue',
+                            'value': 'ca.example.net',
+                        },
+                    },
+                )
+            self.assertEqual(['invalid tag "is-sue"'], ctx.exception.reasons)
+            # valid passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'CAA',
+                    'ttl': 600,
+                    'value': {
+                        'flags': 128,
+                        'tag': 'iodef',
+                        'value': 'mailto:security@example.com',
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('caa-value-rfc', types=['CAA'])
 
 
 class TestCaaValue(TestCase):

--- a/tests/test_octodns_record_cname.py
+++ b/tests/test_octodns_record_cname.py
@@ -84,18 +84,6 @@ class TestRecordCname(TestCase):
             ['CNAME value "___." is not a valid FQDN'], ctx.exception.reasons
         )
 
-        # missing trailing .
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone,
-                'www',
-                {'type': 'CNAME', 'ttl': 600, 'value': 'foo.bar.com'},
-            )
-        self.assertEqual(
-            ['CNAME value "foo.bar.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
-
         # doesn't allow urls
         with self.assertRaises(ValidationError) as ctx:
             Record.new(
@@ -104,10 +92,7 @@ class TestRecordCname(TestCase):
                 {'type': 'CNAME', 'ttl': 600, 'value': 'https://google.com'},
             )
         self.assertEqual(
-            [
-                'CNAME value "https://google.com" is not a valid FQDN',
-                'CNAME value "https://google.com" missing trailing .',
-            ],
+            ['CNAME value "https://google.com" is not a valid FQDN'],
             ctx.exception.reasons,
         )
 
@@ -123,10 +108,7 @@ class TestRecordCname(TestCase):
                 },
             )
         self.assertEqual(
-            [
-                'CNAME value "https://google.com/a/b/c" is not a valid FQDN',
-                'CNAME value "https://google.com/a/b/c" missing trailing .',
-            ],
+            ['CNAME value "https://google.com/a/b/c" is not a valid FQDN'],
             ctx.exception.reasons,
         )
 
@@ -138,10 +120,7 @@ class TestRecordCname(TestCase):
                 {'type': 'CNAME', 'ttl': 600, 'value': 'google.com/some/path'},
             )
         self.assertEqual(
-            [
-                'CNAME value "google.com/some/path" is not a valid FQDN',
-                'CNAME value "google.com/some/path" missing trailing .',
-            ],
+            ['CNAME value "google.com/some/path" is not a valid FQDN'],
             ctx.exception.reasons,
         )
 
@@ -168,16 +147,56 @@ class TestRecordCname(TestCase):
             {
                 'type': 'CNAME',
                 'ttl': 600,
-                # Value is missing trailing dot
+                # Value is missing trailing dot — no error without best-practice
                 'value': '{zone_name}example.com',
             },
             lenient=False,
         )
         zone.add_record(cname, replace=True)
+        templ.process_source_and_target_zones(zone, None, None)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['CNAME value "unit.tests.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+    def test_best_practice_validator(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('target-value-best-practice', types=['CNAME'])
+        try:
+            # missing trailing dot is caught
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'www',
+                    {'type': 'CNAME', 'ttl': 600, 'value': 'foo.bar.com'},
+                )
+            self.assertEqual(
+                ['CNAME value "foo.bar.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot caught after template substitution
+            templ = Templating('test')
+            cname = Record.new(
+                zone,
+                'www',
+                {
+                    'type': 'CNAME',
+                    'ttl': 600,
+                    'value': '{zone_name}example.com',
+                },
+                lenient=False,
+            )
+            zone.add_record(cname, replace=True)
+            with self.assertRaises(ValidationError) as ctx:
+                templ.process_source_and_target_zones(zone, None, None)
+            self.assertEqual(
+                ['CNAME value "unit.tests.example.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone,
+                'www',
+                {'type': 'CNAME', 'ttl': 600, 'value': 'foo.bar.com.'},
+            )
+        finally:
+            Record.disable_validator(
+                'target-value-best-practice', types=['CNAME']
+            )

--- a/tests/test_octodns_record_dname.py
+++ b/tests/test_octodns_record_dname.py
@@ -82,18 +82,6 @@ class TestRecordDname(TestCase):
             ['DNAME value "." is not a valid FQDN'], ctx.exception.reasons
         )
 
-        # missing trailing .
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone,
-                'www',
-                {'type': 'DNAME', 'ttl': 600, 'value': 'foo.bar.com'},
-            )
-        self.assertEqual(
-            ['DNAME value "foo.bar.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
-
     def test_template_validation(self):
         templ = Templating('test')
 
@@ -117,16 +105,56 @@ class TestRecordDname(TestCase):
             {
                 'type': 'DNAME',
                 'ttl': 600,
-                # Value is missing trailing dot
+                # Value is missing trailing dot — no error without best-practice
                 'value': '{zone_name}example.com',
             },
             lenient=False,
         )
         zone.add_record(dname, replace=True)
+        templ.process_source_and_target_zones(zone, None, None)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['DNAME value "unit.tests.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+    def test_best_practice_validator(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('target-value-best-practice', types=['DNAME'])
+        try:
+            # missing trailing dot is caught
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'www',
+                    {'type': 'DNAME', 'ttl': 600, 'value': 'foo.bar.com'},
+                )
+            self.assertEqual(
+                ['DNAME value "foo.bar.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot caught after template substitution
+            templ = Templating('test')
+            dname = Record.new(
+                zone,
+                'sub',
+                {
+                    'type': 'DNAME',
+                    'ttl': 600,
+                    'value': '{zone_name}example.com',
+                },
+                lenient=False,
+            )
+            zone.add_record(dname, replace=True)
+            with self.assertRaises(ValidationError) as ctx:
+                templ.process_source_and_target_zones(zone, None, None)
+            self.assertEqual(
+                ['DNAME value "unit.tests.example.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone,
+                'www',
+                {'type': 'DNAME', 'ttl': 600, 'value': 'foo.bar.com.'},
+            )
+        finally:
+            Record.disable_validator(
+                'target-value-best-practice', types=['DNAME']
+            )

--- a/tests/test_octodns_record_ds.py
+++ b/tests/test_octodns_record_ds.py
@@ -4,8 +4,10 @@
 
 from unittest import TestCase
 
+from octodns.record import Record
 from octodns.record.base import _process_value_validators
-from octodns.record.ds import DsRecord, DsValue
+from octodns.record.ds import DsRecord, DsValue, DsValueRfcValidator
+from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
 
@@ -340,6 +342,291 @@ class TestRecordDs(TestCase):
             },
         )
         self.assertEqual('abcdef1234567890', legacy.values[0].digest)
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        ds_value_ids = set(v.id for v in registered['value'].get('DS', []))
+        self.assertNotIn('ds-value-rfc', ds_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = DsValueRfcValidator('ds-value-rfc').validate
+
+        sha1 = 'a' * 40
+        sha256 = 'b' * 64
+        sha384 = 'c' * 96
+
+        # valid: digest_type 0 (no length constraint)
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 8,
+                        'digest_type': 0,
+                        'digest': 'deadbeef',
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # valid: digest_type 1 (SHA-1), 40 hex chars
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': sha1,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # valid: digest_type 2 (SHA-256), 64 hex chars
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 8,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # valid: digest_type 4 (SHA-384), 96 hex chars
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 14,
+                        'digest_type': 4,
+                        'digest': sha384,
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # key_tag out of range
+        self.assertEqual(
+            ['invalid key_tag "70000"; must be 0-65535'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 70000,
+                        'algorithm': 8,
+                        'digest_type': 0,
+                        'digest': 'deadbeef',
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # key_tag non-integer
+        self.assertEqual(
+            ['invalid key_tag "nope"'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 'nope',
+                        'algorithm': 8,
+                        'digest_type': 0,
+                        'digest': 'deadbeef',
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # algorithm out of range
+        self.assertEqual(
+            ['invalid algorithm "300"; must be 0-255'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 300,
+                        'digest_type': 0,
+                        'digest': 'deadbeef',
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # invalid digest (not hex)
+        self.assertEqual(
+            ['invalid digest "notahex"; must be hex'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 8,
+                        'digest_type': 0,
+                        'digest': 'notahex',
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # digest_type 1, wrong length
+        self.assertEqual(
+            ['digest must be 40 hex characters for digest_type 1'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': 'deadbeef',
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # digest_type 2, wrong length
+        self.assertEqual(
+            ['digest must be 64 hex characters for digest_type 2'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 8,
+                        'digest_type': 2,
+                        'digest': sha1,
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # digest_type 4, wrong length
+        self.assertEqual(
+            ['digest must be 96 hex characters for digest_type 4'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 14,
+                        'digest_type': 4,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+
+        # missing all fields
+        self.assertEqual(
+            [
+                'missing key_tag',
+                'missing algorithm',
+                'missing digest_type',
+                'missing digest',
+            ],
+            validate(DsValue, [{}], 'DS'),
+        )
+
+        # accepts list or single value
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                {
+                    'key_tag': 1,
+                    'algorithm': 8,
+                    'digest_type': 0,
+                    'digest': 'deadbeef',
+                },
+                'DS',
+            ),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('ds-value-rfc', types=['DS'])
+        sha256 = 'a' * 64
+        try:
+            # non-hex digest
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'DS',
+                        'ttl': 600,
+                        'value': {
+                            'key_tag': 1234,
+                            'algorithm': 8,
+                            'digest_type': 2,
+                            'digest': 'notahex',
+                        },
+                    },
+                )
+            self.assertIn(
+                'invalid digest "notahex"; must be hex', ctx.exception.reasons
+            )
+            # wrong length for SHA-256
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'DS',
+                        'ttl': 600,
+                        'value': {
+                            'key_tag': 1234,
+                            'algorithm': 8,
+                            'digest_type': 2,
+                            'digest': 'deadbeef',
+                        },
+                    },
+                )
+            self.assertIn(
+                'digest must be 64 hex characters for digest_type 2',
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'DS',
+                    'ttl': 600,
+                    'value': {
+                        'key_tag': 1234,
+                        'algorithm': 8,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('ds-value-rfc', types=['DS'])
 
 
 class TestDsValue(TestCase):

--- a/tests/test_octodns_record_mx.py
+++ b/tests/test_octodns_record_mx.py
@@ -9,7 +9,12 @@ from helpers import SimpleProvider
 from octodns.processor.templating import Templating
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.mx import MxRecord, MxValue, MxValueRfcValidator
+from octodns.record.mx import (
+    MxRecord,
+    MxValue,
+    MxValueBestPracticeValidator,
+    MxValueRfcValidator,
+)
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
 
@@ -214,20 +219,15 @@ class TestRecordMx(TestCase):
             )
         self.assertEqual(['missing exchange'], ctx.exception.reasons)
 
-        # missing trailing .
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone,
-                '',
-                {
-                    'type': 'MX',
-                    'ttl': 600,
-                    'value': {'preference': 10, 'exchange': 'foo.bar.com'},
-                },
-            )
-        self.assertEqual(
-            ['MX exchange "foo.bar.com" missing trailing .'],
-            ctx.exception.reasons,
+        # missing trailing . is a best-practice check, not legacy
+        Record.new(
+            self.zone,
+            '',
+            {
+                'type': 'MX',
+                'ttl': 600,
+                'value': {'preference': 10, 'exchange': 'foo.bar.com'},
+            },
         )
 
         # exchange must be a valid FQDN
@@ -317,7 +317,8 @@ class TestMxValue(TestCase):
                 'ttl': 1800,
                 'value': {
                     'preference': 10,
-                    # Exchange is missing trailing dot
+                    # Exchange is missing trailing dot — legacy only checks
+                    # format, not trailing dot (that's a best-practice check)
                     'exchange': '{zone_name}example.com',
                 },
             },
@@ -325,12 +326,7 @@ class TestMxValue(TestCase):
         )
         zone.add_record(mx, replace=True)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['MX exchange "unit.tests.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+        templ.process_source_and_target_zones(zone, None, None)
 
     def test_rfc_value_validator_not_in_defaults(self):
         registered = Record.registered_validators()
@@ -409,6 +405,25 @@ class TestMxValue(TestCase):
         self.assertEqual(
             ['missing exchange'], validate(MxValue, [{'preference': 10}], 'MX')
         )
+
+    def test_best_practice_validator(self):
+        validate = MxValueBestPracticeValidator(
+            'mx-value-best-practice'
+        ).validate
+
+        # exchange with trailing dot passes
+        self.assertEqual(
+            [],
+            validate(
+                MxValue,
+                [{'preference': 10, 'exchange': 'mx.unit.tests.'}],
+                'MX',
+            ),
+        )
+        # null MX passes
+        self.assertEqual(
+            [], validate(MxValue, [{'preference': 0, 'exchange': '.'}], 'MX')
+        )
         # exchange missing trailing dot
         self.assertEqual(
             ['MX exchange "mx.unit.tests" missing trailing .'],
@@ -416,6 +431,50 @@ class TestMxValue(TestCase):
                 MxValue, [{'preference': 10, 'exchange': 'mx.unit.tests'}], 'MX'
             ),
         )
+        # legacy alias for exchange
+        self.assertEqual(
+            ['MX exchange "mx.unit.tests" missing trailing .'],
+            validate(
+                MxValue, [{'preference': 10, 'value': 'mx.unit.tests'}], 'MX'
+            ),
+        )
+        # missing exchange — no error (format validator handles presence)
+        self.assertEqual([], validate(MxValue, [{'preference': 10}], 'MX'))
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('mx-value-best-practice', types=['MX'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'test',
+                    {
+                        'type': 'MX',
+                        'ttl': 600,
+                        'value': {
+                            'preference': 10,
+                            'exchange': 'mx.unit.tests',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['MX exchange "mx.unit.tests" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot passes
+            Record.new(
+                zone,
+                'test',
+                {
+                    'type': 'MX',
+                    'ttl': 600,
+                    'value': {'preference': 10, 'exchange': 'mx.unit.tests.'},
+                },
+            )
+        finally:
+            Record.disable_validator('mx-value-best-practice', types=['MX'])
 
     def test_rfc_value_validator_opt_in(self):
         zone = Zone('unit.tests.', [])

--- a/tests/test_octodns_record_mx.py
+++ b/tests/test_octodns_record_mx.py
@@ -9,7 +9,7 @@ from helpers import SimpleProvider
 from octodns.processor.templating import Templating
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.mx import MxRecord, MxValue
+from octodns.record.mx import MxRecord, MxValue, MxValueRfcValidator
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
 
@@ -331,3 +331,139 @@ class TestMxValue(TestCase):
             ['MX exchange "unit.tests.example.com" missing trailing .'],
             ctx.exception.reasons,
         )
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        mx_value_ids = set(v.id for v in registered['value'].get('MX', []))
+        self.assertNotIn('mx-value-rfc', mx_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = MxValueRfcValidator('mx-value-rfc').validate
+
+        # valid records
+        self.assertEqual(
+            [],
+            validate(
+                MxValue, [{'preference': 0, 'exchange': 'mx.unit.tests.'}], 'MX'
+            ),
+        )
+        self.assertEqual(
+            [],
+            validate(
+                MxValue,
+                [{'preference': 65535, 'exchange': 'mx.unit.tests.'}],
+                'MX',
+            ),
+        )
+        # null MX: exchange "." with preference 0
+        self.assertEqual(
+            [], validate(MxValue, [{'preference': 0, 'exchange': '.'}], 'MX')
+        )
+        # legacy priority/value aliases are accepted
+        self.assertEqual(
+            [],
+            validate(
+                MxValue, [{'priority': 10, 'value': 'mx.unit.tests.'}], 'MX'
+            ),
+        )
+
+        # preference out of range
+        self.assertEqual(
+            ['preference "65536" out of range 0-65535'],
+            validate(
+                MxValue,
+                [{'preference': 65536, 'exchange': 'mx.unit.tests.'}],
+                'MX',
+            ),
+        )
+        self.assertEqual(
+            ['preference "-1" out of range 0-65535'],
+            validate(
+                MxValue,
+                [{'preference': -1, 'exchange': 'mx.unit.tests.'}],
+                'MX',
+            ),
+        )
+
+        # null MX requires preference 0
+        self.assertEqual(
+            ['preference must be 0 for null MX (exchange ".")'],
+            validate(MxValue, [{'preference': 10, 'exchange': '.'}], 'MX'),
+        )
+
+        # missing preference
+        self.assertEqual(
+            ['missing preference'],
+            validate(MxValue, [{'exchange': 'mx.unit.tests.'}], 'MX'),
+        )
+        # invalid preference
+        self.assertEqual(
+            ['invalid preference "nope"'],
+            validate(
+                MxValue,
+                [{'preference': 'nope', 'exchange': 'mx.unit.tests.'}],
+                'MX',
+            ),
+        )
+        # missing exchange
+        self.assertEqual(
+            ['missing exchange'], validate(MxValue, [{'preference': 10}], 'MX')
+        )
+        # exchange missing trailing dot
+        self.assertEqual(
+            ['MX exchange "mx.unit.tests" missing trailing .'],
+            validate(
+                MxValue, [{'preference': 10, 'exchange': 'mx.unit.tests'}], 'MX'
+            ),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('mx-value-rfc', types=['MX'])
+        try:
+            # preference out of range
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'test',
+                    {
+                        'type': 'MX',
+                        'ttl': 600,
+                        'value': {
+                            'preference': 70000,
+                            'exchange': 'mx.unit.tests.',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['preference "70000" out of range 0-65535'],
+                ctx.exception.reasons,
+            )
+            # null MX with non-zero preference
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'test',
+                    {
+                        'type': 'MX',
+                        'ttl': 600,
+                        'value': {'preference': 10, 'exchange': '.'},
+                    },
+                )
+            self.assertEqual(
+                ['preference must be 0 for null MX (exchange ".")'],
+                ctx.exception.reasons,
+            )
+            # valid null MX passes
+            Record.new(
+                zone,
+                'test',
+                {
+                    'type': 'MX',
+                    'ttl': 600,
+                    'value': {'preference': 0, 'exchange': '.'},
+                },
+            )
+        finally:
+            Record.disable_validator('mx-value-rfc', types=['MX'])

--- a/tests/test_octodns_record_naptr.py
+++ b/tests/test_octodns_record_naptr.py
@@ -8,7 +8,12 @@ from helpers import SimpleProvider
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.naptr import NaptrRecord, NaptrValue, NaptrValueRfcValidator
+from octodns.record.naptr import (
+    NaptrRecord,
+    NaptrValue,
+    NaptrValueBestPracticeValidator,
+    NaptrValueRfcValidator,
+)
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
 
@@ -491,6 +496,123 @@ class TestRecordNaptr(TestCase):
                 [f'unrecognized flags "{invalid_flag}"'], ctx.exception.reasons
             )
 
+    def test_best_practice_validator(self):
+        validate = NaptrValueBestPracticeValidator(
+            'naptr-value-best-practice'
+        ).validate
+
+        # replacement with trailing dot passes
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'A',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': 'target.example.com.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+        # null replacement "." passes
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'S',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+        # replacement missing trailing dot
+        self.assertEqual(
+            ['NAPTR replacement "example.com" missing trailing .'],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'A',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': 'example.com',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+        # missing replacement — no error (format validator handles presence)
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [{'order': 10, 'preference': 20, 'flags': 'S'}],
+                'NAPTR',
+            ),
+        )
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('naptr-value-best-practice', types=['NAPTR'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'NAPTR',
+                        'ttl': 600,
+                        'value': {
+                            'order': 10,
+                            'preference': 20,
+                            'flags': 'A',
+                            'service': 'svc',
+                            'regexp': '',
+                            'replacement': 'example.com',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['NAPTR replacement "example.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'NAPTR',
+                    'ttl': 600,
+                    'value': {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'S',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': 'target.example.com.',
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator(
+                'naptr-value-best-practice', types=['NAPTR']
+            )
+
     def test_rfc_value_validator_not_in_defaults(self):
         registered = Record.registered_validators()
         naptr_value_ids = set(
@@ -631,25 +753,6 @@ class TestRecordNaptr(TestCase):
             ),
         )
 
-        # replacement missing trailing dot
-        self.assertEqual(
-            ['NAPTR replacement "example.com" missing trailing .'],
-            validate(
-                NaptrValue,
-                [
-                    {
-                        'order': 10,
-                        'preference': 20,
-                        'flags': 'A',
-                        'service': 'svc',
-                        'regexp': '',
-                        'replacement': 'example.com',
-                    }
-                ],
-                'NAPTR',
-            ),
-        )
-
         # missing all fields
         self.assertEqual(
             [
@@ -668,28 +771,6 @@ class TestRecordNaptr(TestCase):
         Record.enable_validators(['legacy'])
         Record.enable_validator('naptr-value-rfc', types=['NAPTR'])
         try:
-            # replacement missing trailing dot
-            with self.assertRaises(ValidationError) as ctx:
-                Record.new(
-                    zone,
-                    '',
-                    {
-                        'type': 'NAPTR',
-                        'ttl': 600,
-                        'value': {
-                            'order': 10,
-                            'preference': 20,
-                            'flags': 'A',
-                            'service': 'svc',
-                            'regexp': '',
-                            'replacement': 'example.com',
-                        },
-                    },
-                )
-            self.assertEqual(
-                ['NAPTR replacement "example.com" missing trailing .'],
-                ctx.exception.reasons,
-            )
             # order out of range
             with self.assertRaises(ValidationError) as ctx:
                 Record.new(

--- a/tests/test_octodns_record_naptr.py
+++ b/tests/test_octodns_record_naptr.py
@@ -8,7 +8,7 @@ from helpers import SimpleProvider
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.naptr import NaptrRecord, NaptrValue
+from octodns.record.naptr import NaptrRecord, NaptrValue, NaptrValueRfcValidator
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
 
@@ -490,6 +490,247 @@ class TestRecordNaptr(TestCase):
             self.assertEqual(
                 [f'unrecognized flags "{invalid_flag}"'], ctx.exception.reasons
             )
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        naptr_value_ids = set(
+            v.id for v in registered['value'].get('NAPTR', [])
+        )
+        self.assertNotIn('naptr-value-rfc', naptr_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = NaptrValueRfcValidator('naptr-value-rfc').validate
+
+        # valid: all fields, replacement is "."
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'S',
+                        'service': 'SIP+D2U',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+        # valid: replacement is a FQDN
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 0,
+                        'preference': 65535,
+                        'flags': 'A',
+                        'service': 'http',
+                        'regexp': '.*',
+                        'replacement': 'target.example.com.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+        # valid: lowercase flags accepted
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'u',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+        # valid: empty flags accepted
+        self.assertEqual(
+            [],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': '',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+
+        # order out of range
+        self.assertEqual(
+            ['invalid order "70000"; must be 0-65535'],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 70000,
+                        'preference': 20,
+                        'flags': 'S',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+
+        # preference non-integer
+        self.assertEqual(
+            ['invalid preference "nope"'],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 'nope',
+                        'flags': 'S',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+
+        # invalid flags
+        self.assertEqual(
+            ['unrecognized flags "X"'],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'X',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': '.',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+
+        # replacement missing trailing dot
+        self.assertEqual(
+            ['NAPTR replacement "example.com" missing trailing .'],
+            validate(
+                NaptrValue,
+                [
+                    {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'A',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': 'example.com',
+                    }
+                ],
+                'NAPTR',
+            ),
+        )
+
+        # missing all fields
+        self.assertEqual(
+            [
+                'missing order',
+                'missing preference',
+                'missing flags',
+                'missing service',
+                'missing regexp',
+                'missing replacement',
+            ],
+            validate(NaptrValue, [{}], 'NAPTR'),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('naptr-value-rfc', types=['NAPTR'])
+        try:
+            # replacement missing trailing dot
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'NAPTR',
+                        'ttl': 600,
+                        'value': {
+                            'order': 10,
+                            'preference': 20,
+                            'flags': 'A',
+                            'service': 'svc',
+                            'regexp': '',
+                            'replacement': 'example.com',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['NAPTR replacement "example.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # order out of range
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'NAPTR',
+                        'ttl': 600,
+                        'value': {
+                            'order': 70000,
+                            'preference': 20,
+                            'flags': 'S',
+                            'service': 'svc',
+                            'regexp': '',
+                            'replacement': '.',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['invalid order "70000"; must be 0-65535'],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'NAPTR',
+                    'ttl': 600,
+                    'value': {
+                        'order': 10,
+                        'preference': 20,
+                        'flags': 'S',
+                        'service': 'svc',
+                        'regexp': '',
+                        'replacement': 'target.example.com.',
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('naptr-value-rfc', types=['NAPTR'])
 
 
 class TestNaptrValue(TestCase):

--- a/tests/test_octodns_record_ns.py
+++ b/tests/test_octodns_record_ns.py
@@ -62,15 +62,6 @@ class TestRecordNs(TestCase):
             Record.new(self.zone, '', {'type': 'NS', 'ttl': 600})
         self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
-        # no trailing .
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone, '', {'type': 'NS', 'ttl': 600, 'value': 'foo.bar'}
-            )
-        self.assertEqual(
-            ['NS value "foo.bar" missing trailing .'], ctx.exception.reasons
-        )
-
         # exchange must be a valid FQDN
         with self.assertRaises(ValidationError) as ctx:
             Record.new(
@@ -106,16 +97,47 @@ class TestRecordNs(TestCase):
             {
                 'type': 'NS',
                 'ttl': 600,
-                # Value is missing ending trailing
+                # Value is missing trailing dot — no error without best-practice
                 'value': '{zone_name}example.com',
             },
             lenient=False,
         )
         zone.add_record(ns, replace=True)
+        templ.process_source_and_target_zones(zone, None, None)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['NS value "unit.tests.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+    def test_best_practice_validator(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('targets-value-best-practice', types=['NS'])
+        try:
+            # missing trailing dot is caught
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone, '', {'type': 'NS', 'ttl': 600, 'value': 'foo.bar'}
+                )
+            self.assertEqual(
+                ['NS value "foo.bar" missing trailing .'], ctx.exception.reasons
+            )
+            # trailing dot caught after template substitution
+            templ = Templating('test')
+            ns = Record.new(
+                zone,
+                '',
+                {'type': 'NS', 'ttl': 600, 'value': '{zone_name}example.com'},
+                lenient=False,
+            )
+            zone.add_record(ns, replace=True)
+            with self.assertRaises(ValidationError) as ctx:
+                templ.process_source_and_target_zones(zone, None, None)
+            self.assertEqual(
+                ['NS value "unit.tests.example.com" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone, '', {'type': 'NS', 'ttl': 600, 'value': 'foo.bar.'}
+            )
+        finally:
+            Record.disable_validator(
+                'targets-value-best-practice', types=['NS']
+            )

--- a/tests/test_octodns_record_ptr.py
+++ b/tests/test_octodns_record_ptr.py
@@ -53,15 +53,6 @@ class TestRecordPtr(TestCase):
             ['PTR value "_." is not a valid FQDN'], ctx.exception.reasons
         )
 
-        # no trailing .
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone, '', {'type': 'PTR', 'ttl': 600, 'value': 'foo.bar'}
-            )
-        self.assertEqual(
-            ['PTR value "foo.bar" missing trailing .'], ctx.exception.reasons
-        )
-
     def test_ptr_rdata_text(self):
         # anything goes, we're a noop
         for s in (
@@ -110,16 +101,50 @@ class TestRecordPtr(TestCase):
             {
                 'type': 'PTR',
                 'ttl': 600,
-                # Value is missing ending dot.
+                # Value is missing trailing dot — no error without best-practice
                 'value': '{zone_name}example.com',
             },
             lenient=False,
         )
         zone.add_record(ptr, replace=True)
+        templ.process_source_and_target_zones(zone, None, None)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['PTR value "0.0.10.in-addr.arpa.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+    def test_best_practice_validator(self):
+        zone = Zone('0.0.10.in-addr.arpa.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('targets-value-best-practice', types=['PTR'])
+        try:
+            # missing trailing dot is caught
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone, '1', {'type': 'PTR', 'ttl': 600, 'value': 'foo.bar'}
+                )
+            self.assertEqual(
+                ['PTR value "foo.bar" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot caught after template substitution
+            templ = Templating('test')
+            ptr = Record.new(
+                zone,
+                '2',
+                {'type': 'PTR', 'ttl': 600, 'value': '{zone_name}example.com'},
+                lenient=False,
+            )
+            zone.add_record(ptr, replace=True)
+            with self.assertRaises(ValidationError) as ctx:
+                templ.process_source_and_target_zones(zone, None, None)
+            self.assertEqual(
+                [
+                    'PTR value "0.0.10.in-addr.arpa.example.com" missing trailing .'
+                ],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone, '1', {'type': 'PTR', 'ttl': 600, 'value': 'foo.bar.'}
+            )
+        finally:
+            Record.disable_validator(
+                'targets-value-best-practice', types=['PTR']
+            )

--- a/tests/test_octodns_record_srv.py
+++ b/tests/test_octodns_record_srv.py
@@ -14,6 +14,7 @@ from octodns.record.srv import (
     SrvNameRfcValidator,
     SrvRecord,
     SrvValue,
+    SrvValueBestPracticeValidator,
     SrvValueRfcValidator,
 )
 from octodns.zone import Zone
@@ -397,25 +398,20 @@ class TestRecordSrv(TestCase):
                 },
             )
         self.assertEqual(['missing target'], ctx.exception.reasons)
-        # invalid target
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone,
-                '_srv._tcp',
-                {
-                    'type': 'SRV',
-                    'ttl': 600,
-                    'value': {
-                        'priority': 1,
-                        'weight': 2,
-                        'port': 3,
-                        'target': 'foo.bar.baz',
-                    },
+        # missing trailing . is a best-practice check, not legacy
+        Record.new(
+            self.zone,
+            '_srv._tcp',
+            {
+                'type': 'SRV',
+                'ttl': 600,
+                'value': {
+                    'priority': 1,
+                    'weight': 2,
+                    'port': 3,
+                    'target': 'foo.bar.baz',
                 },
-            )
-        self.assertEqual(
-            ['SRV target "foo.bar.baz" missing trailing .'],
-            ctx.exception.reasons,
+            },
         )
 
         # falsey target
@@ -483,6 +479,95 @@ class TestSrvValue(TestCase):
         got = value.template({'needle': 42})
         self.assertIsNot(value, got)
         self.assertEqual('has_42_placeholder', got.target)
+
+    def test_best_practice_validator(self):
+        validate = SrvValueBestPracticeValidator(
+            'srv-value-best-practice'
+        ).validate
+
+        # target with trailing dot passes
+        self.assertEqual(
+            [],
+            validate(
+                SrvValue,
+                [{'priority': 1, 'weight': 2, 'port': 80, 'target': 'h.u.t.'}],
+                'SRV',
+            ),
+        )
+        # null target "." passes
+        self.assertEqual(
+            [],
+            validate(
+                SrvValue,
+                [{'priority': 0, 'weight': 0, 'port': 0, 'target': '.'}],
+                'SRV',
+            ),
+        )
+        # target missing trailing dot
+        self.assertEqual(
+            ['SRV target "foo.bar.baz" missing trailing .'],
+            validate(
+                SrvValue,
+                [
+                    {
+                        'priority': 1,
+                        'weight': 2,
+                        'port': 80,
+                        'target': 'foo.bar.baz',
+                    }
+                ],
+                'SRV',
+            ),
+        )
+        # missing target — no error (format validator handles presence)
+        self.assertEqual(
+            [],
+            validate(
+                SrvValue, [{'priority': 1, 'weight': 2, 'port': 80}], 'SRV'
+            ),
+        )
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('srv-value-best-practice', types=['SRV'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '_sip._tcp',
+                    {
+                        'type': 'SRV',
+                        'ttl': 600,
+                        'value': {
+                            'priority': 1,
+                            'weight': 2,
+                            'port': 80,
+                            'target': 'foo.bar.baz',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['SRV target "foo.bar.baz" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot passes
+            Record.new(
+                zone,
+                '_sip._tcp',
+                {
+                    'type': 'SRV',
+                    'ttl': 600,
+                    'value': {
+                        'priority': 1,
+                        'weight': 2,
+                        'port': 80,
+                        'target': 'foo.bar.baz.',
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('srv-value-best-practice', types=['SRV'])
 
     def test_rfc_validators_not_in_defaults(self):
         # confirm the RFC validators are opt-in and not registered for SRV

--- a/tests/test_octodns_record_sshfp.py
+++ b/tests/test_octodns_record_sshfp.py
@@ -9,7 +9,7 @@ from helpers import SimpleProvider
 from octodns.record.base import Record
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
-from octodns.record.sshfp import SshfpRecord, SshfpValue
+from octodns.record.sshfp import SshfpRecord, SshfpValue, SshfpValueRfcValidator
 from octodns.zone import Zone
 
 
@@ -398,6 +398,232 @@ class TestRecordSshfp(TestCase):
                 },
             },
         )
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        sshfp_value_ids = set(
+            v.id for v in registered['value'].get('SSHFP', [])
+        )
+        self.assertNotIn('sshfp-value-rfc', sshfp_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = SshfpValueRfcValidator('sshfp-value-rfc').validate
+
+        sha1_fp = 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
+        sha256_fp = (
+            'a87f1b687ac0e57d2a081a2f282672334d90ed316d2b818ca9580ea384d92401'
+        )
+
+        # valid: SHA-1
+        self.assertEqual(
+            [],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # valid: SHA-256
+        self.assertEqual(
+            [],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 2,
+                        'fingerprint_type': 2,
+                        'fingerprint': sha256_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # valid: unknown fingerprint_type — no length check applied
+        self.assertEqual(
+            [],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 4,
+                        'fingerprint_type': 3,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # algorithm out of range
+        self.assertEqual(
+            ['invalid algorithm "256"; must be 0-255'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 256,
+                        'fingerprint_type': 1,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # fingerprint_type out of range
+        self.assertEqual(
+            ['invalid fingerprint_type "300"; must be 0-255'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 300,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # algorithm non-integer
+        self.assertEqual(
+            ['invalid algorithm "nope"'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 'nope',
+                        'fingerprint_type': 1,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # fingerprint_type non-integer
+        self.assertEqual(
+            ['invalid fingerprint_type "bad"'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 'bad',
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # fingerprint not hex
+        self.assertEqual(
+            ['invalid fingerprint "notahex!!"; must be hex'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': 'notahex!!',
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # SHA-1 fingerprint wrong length (too short)
+        self.assertEqual(
+            ['fingerprint must be 40 hex characters for fingerprint_type 1'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': sha256_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # SHA-256 fingerprint wrong length (too short)
+        self.assertEqual(
+            ['fingerprint must be 64 hex characters for fingerprint_type 2'],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 2,
+                        'fingerprint_type': 2,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # missing all fields
+        self.assertEqual(
+            [
+                'missing algorithm',
+                'missing fingerprint_type',
+                'missing fingerprint',
+            ],
+            validate(SshfpValue, [{}], 'SSHFP'),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('sshfp-value-rfc', types=['SSHFP'])
+        try:
+            # right length for SHA-1 but non-hex chars — only RFC validator catches
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'SSHFP',
+                        'ttl': 600,
+                        'value': {
+                            'algorithm': 1,
+                            'fingerprint_type': 1,
+                            'fingerprint': 'z' * 40,
+                        },
+                    },
+                )
+            self.assertEqual(
+                [f'invalid fingerprint "{"z" * 40}"; must be hex'],
+                ctx.exception.reasons,
+            )
+            # valid: SHA-1 passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'SSHFP',
+                    'ttl': 600,
+                    'value': {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73',
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('sshfp-value-rfc', types=['SSHFP'])
 
     def test_fingerprint_case_insensitive(self):
         target = SimpleProvider()

--- a/tests/test_octodns_record_svcb.py
+++ b/tests/test_octodns_record_svcb.py
@@ -9,8 +9,13 @@ from helpers import SimpleProvider
 from octodns.processor.templating import Templating
 from octodns.record import Record
 from octodns.record.exception import ValidationError
+from octodns.record.https import HttpsValue
 from octodns.record.rr import RrParseError
-from octodns.record.svcb import SvcbRecord, SvcbValue
+from octodns.record.svcb import (
+    SvcbRecord,
+    SvcbValue,
+    SvcbValueBestPracticeValidator,
+)
 from octodns.zone import Zone
 
 
@@ -350,20 +355,15 @@ class TestRecordSvcb(TestCase):
             )
         self.assertEqual(['missing targetname'], ctx.exception.reasons)
 
-        # invalid target
-        with self.assertRaises(ValidationError) as ctx:
-            Record.new(
-                self.zone,
-                'foo',
-                {
-                    'type': 'SVCB',
-                    'ttl': 600,
-                    'value': {'svcpriority': 1, 'targetname': 'foo.bar.baz'},
-                },
-            )
-        self.assertEqual(
-            ['SVCB targetname "foo.bar.baz" missing trailing .'],
-            ctx.exception.reasons,
+        # missing trailing . is a best-practice check, not legacy
+        Record.new(
+            self.zone,
+            'foo',
+            {
+                'type': 'SVCB',
+                'ttl': 600,
+                'value': {'svcpriority': 1, 'targetname': 'foo.bar.baz'},
+            },
         )
 
         # falsey target
@@ -676,6 +676,110 @@ class TestRecordSvcb(TestCase):
         )
 
 
+class TestSvcbBestPractice(TestCase):
+
+    def test_best_practice_validator(self):
+        validate = SvcbValueBestPracticeValidator(
+            'svcb-value-best-practice'
+        ).validate
+
+        # targetname with trailing dot passes
+        self.assertEqual(
+            [],
+            validate(
+                SvcbValue,
+                [{'svcpriority': 1, 'targetname': 'foo.example.com.'}],
+                'SVCB',
+            ),
+        )
+        # root label "." passes
+        self.assertEqual(
+            [],
+            validate(
+                SvcbValue, [{'svcpriority': 1, 'targetname': '.'}], 'SVCB'
+            ),
+        )
+        # targetname missing trailing dot
+        self.assertEqual(
+            ['SVCB targetname "foo.example.com" missing trailing .'],
+            validate(
+                SvcbValue,
+                [{'svcpriority': 1, 'targetname': 'foo.example.com'}],
+                'SVCB',
+            ),
+        )
+        # HTTPS uses same validator class with different _type
+        self.assertEqual(
+            ['HTTPS targetname "foo.example.com" missing trailing .'],
+            validate(
+                HttpsValue,
+                [{'svcpriority': 1, 'targetname': 'foo.example.com'}],
+                'HTTPS',
+            ),
+        )
+
+        # opt-in via Record.enable_validator for SVCB
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('svcb-value-best-practice', types=['SVCB'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'foo',
+                    {
+                        'type': 'SVCB',
+                        'ttl': 600,
+                        'value': {
+                            'svcpriority': 1,
+                            'targetname': 'foo.bar.baz',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['SVCB targetname "foo.bar.baz" missing trailing .'],
+                ctx.exception.reasons,
+            )
+            # trailing dot passes
+            Record.new(
+                zone,
+                'foo',
+                {
+                    'type': 'SVCB',
+                    'ttl': 600,
+                    'value': {'svcpriority': 1, 'targetname': 'foo.bar.baz.'},
+                },
+            )
+        finally:
+            Record.disable_validator('svcb-value-best-practice', types=['SVCB'])
+
+        # opt-in via Record.enable_validator for HTTPS
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('https-value-best-practice', types=['HTTPS'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'foo',
+                    {
+                        'type': 'HTTPS',
+                        'ttl': 600,
+                        'value': {
+                            'svcpriority': 1,
+                            'targetname': 'foo.bar.baz',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['HTTPS targetname "foo.bar.baz" missing trailing .'],
+                ctx.exception.reasons,
+            )
+        finally:
+            Record.disable_validator(
+                'https-value-best-practice', types=['HTTPS']
+            )
+
+
 class TestSrvValue(TestCase):
 
     def test_template(self):
@@ -729,7 +833,8 @@ class TestSrvValue(TestCase):
                 'ttl': 600,
                 'value': {
                     'svcpriority': 1,
-                    # "targetname" is missing an trailing dot
+                    # "targetname" is missing a trailing dot — legacy only
+                    # checks format, not trailing dot (best-practice check)
                     'targetname': '{zone_name}example.com',
                     'svcparams': {
                         'alpn': ['h3', 'h2'],
@@ -744,9 +849,4 @@ class TestSrvValue(TestCase):
 
         zone.add_record(svcb, replace=True)
 
-        with self.assertRaises(ValidationError) as ctx:
-            templ.process_source_and_target_zones(zone, None, None)
-        self.assertEqual(
-            ['SVCB targetname "unit.tests.example.com" missing trailing .'],
-            ctx.exception.reasons,
-        )
+        templ.process_source_and_target_zones(zone, None, None)

--- a/tests/test_octodns_record_target.py
+++ b/tests/test_octodns_record_target.py
@@ -5,7 +5,12 @@
 from unittest import TestCase
 
 from octodns.record.alias import AliasRecord
-from octodns.record.target import _TargetsValue, _TargetValue
+from octodns.record.target import (
+    TargetsValueBestPracticeValidator,
+    TargetValueBestPracticeValidator,
+    _TargetsValue,
+    _TargetValue,
+)
 from octodns.zone import Zone
 
 
@@ -58,3 +63,60 @@ class TestTargetsValue(TestCase):
         got = value.template({'needle': 42})
         self.assertIsNot(value, got)
         self.assertEqual('this.does.42.have.templating.', got)
+
+
+class TestTargetBestPracticeValidators(TestCase):
+
+    def test_target_value_best_practice_validator(self):
+        validate = TargetValueBestPracticeValidator(
+            'target-value-best-practice'
+        ).validate
+
+        # valid: trailing dot present
+        self.assertEqual([], validate(_TargetValue, 'foo.bar.com.', 'CNAME'))
+
+        # missing/empty value — no error (format validator handles that)
+        self.assertEqual([], validate(_TargetValue, None, 'CNAME'))
+        self.assertEqual([], validate(_TargetValue, '', 'CNAME'))
+
+        # null target for permitted types — exempt
+        self.assertEqual([], validate(_TargetValue, '.', 'SRV'))
+
+        # template variable — exempt until after substitution
+        self.assertEqual(
+            [], validate(_TargetValue, '{zone_name}example.com', 'CNAME')
+        )
+
+        # missing trailing dot
+        self.assertEqual(
+            ['CNAME value "foo.bar.com" missing trailing .'],
+            validate(_TargetValue, 'foo.bar.com', 'CNAME'),
+        )
+
+    def test_targets_value_best_practice_validator(self):
+        validate = TargetsValueBestPracticeValidator(
+            'targets-value-best-practice'
+        ).validate
+
+        # valid
+        self.assertEqual(
+            [], validate(_TargetsValue, ['ns1.foo.com.', 'ns2.foo.com.'], 'NS')
+        )
+
+        # empty list — no errors
+        self.assertEqual([], validate(_TargetsValue, [], 'NS'))
+
+        # template variable — exempt
+        self.assertEqual([], validate(_TargetsValue, ['{zone_name}ns1'], 'NS'))
+
+        # missing trailing dot
+        self.assertEqual(
+            ['NS value "foo.bar" missing trailing .'],
+            validate(_TargetsValue, ['foo.bar'], 'NS'),
+        )
+
+        # multiple values, one bad
+        self.assertEqual(
+            ['NS value "ns2.foo.com" missing trailing .'],
+            validate(_TargetsValue, ['ns1.foo.com.', 'ns2.foo.com'], 'NS'),
+        )

--- a/tests/test_octodns_record_tlsa.py
+++ b/tests/test_octodns_record_tlsa.py
@@ -9,7 +9,7 @@ from helpers import SimpleProvider
 from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
-from octodns.record.tlsa import TlsaRecord, TlsaValue
+from octodns.record.tlsa import TlsaRecord, TlsaValue, TlsaValueRfcValidator
 from octodns.zone import Zone
 
 
@@ -467,6 +467,247 @@ class TestRecordTlsa(TestCase):
         )
         self.assertFalse(upper.changes(lower, target))
         self.assertFalse(lower.changes(upper, target))
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        tlsa_value_ids = set(v.id for v in registered['value'].get('TLSA', []))
+        self.assertNotIn('tlsa-value-rfc', tlsa_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = TlsaValueRfcValidator('tlsa-value-rfc').validate
+
+        sha256 = 'a' * 64
+        sha512 = 'b' * 128
+
+        # valid: matching_type 0, any hex data
+        self.assertEqual(
+            [],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 0,
+                        'certificate_association_data': 'deadbeef',
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+        # valid: matching_type 1, 64 hex chars
+        self.assertEqual(
+            [],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 1,
+                        'selector': 0,
+                        'matching_type': 1,
+                        'certificate_association_data': sha256,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+        # valid: matching_type 2, 128 hex chars
+        self.assertEqual(
+            [],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 0,
+                        'selector': 1,
+                        'matching_type': 2,
+                        'certificate_association_data': sha512,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # invalid certificate_usage (out of uint8 range)
+        self.assertEqual(
+            ['invalid certificate_usage "256"; must be 0-255'],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 256,
+                        'selector': 0,
+                        'matching_type': 0,
+                        'certificate_association_data': 'deadbeef',
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # invalid selector (non-integer)
+        self.assertEqual(
+            ['invalid selector "bad"'],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 0,
+                        'selector': 'bad',
+                        'matching_type': 0,
+                        'certificate_association_data': 'deadbeef',
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # invalid matching_type (out of range)
+        self.assertEqual(
+            ['invalid matching_type "300"; must be 0-255'],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 0,
+                        'selector': 0,
+                        'matching_type': 300,
+                        'certificate_association_data': 'deadbeef',
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # invalid certificate_association_data (not hex)
+        self.assertEqual(
+            ['invalid certificate_association_data "notahex"; must be hex'],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 0,
+                        'selector': 0,
+                        'matching_type': 0,
+                        'certificate_association_data': 'notahex',
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # matching_type 1 with wrong length
+        self.assertEqual(
+            [
+                'certificate_association_data must be 64 hex characters for matching_type 1'
+            ],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 0,
+                        'selector': 0,
+                        'matching_type': 1,
+                        'certificate_association_data': 'deadbeef',
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # matching_type 2 with wrong length
+        self.assertEqual(
+            [
+                'certificate_association_data must be 128 hex characters for matching_type 2'
+            ],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 0,
+                        'selector': 0,
+                        'matching_type': 2,
+                        'certificate_association_data': sha256,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+
+        # missing fields
+        self.assertEqual(
+            [
+                'missing certificate_usage',
+                'missing selector',
+                'missing matching_type',
+                'missing certificate_association_data',
+            ],
+            validate(TlsaValue, [{}], 'TLSA'),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('tlsa-value-rfc', types=['TLSA'])
+        sha256 = 'a' * 64
+        try:
+            # non-hex certificate_association_data
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'TLSA',
+                        'ttl': 600,
+                        'value': {
+                            'certificate_usage': 3,
+                            'selector': 1,
+                            'matching_type': 1,
+                            'certificate_association_data': 'notahex',
+                        },
+                    },
+                )
+            self.assertIn(
+                'invalid certificate_association_data "notahex"; must be hex',
+                ctx.exception.reasons,
+            )
+            # wrong length for SHA-256
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'TLSA',
+                        'ttl': 600,
+                        'value': {
+                            'certificate_usage': 3,
+                            'selector': 1,
+                            'matching_type': 1,
+                            'certificate_association_data': 'deadbeef',
+                        },
+                    },
+                )
+            self.assertIn(
+                'certificate_association_data must be 64 hex characters for matching_type 1',
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TLSA',
+                    'ttl': 600,
+                    'value': {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 1,
+                        'certificate_association_data': sha256,
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('tlsa-value-rfc', types=['TLSA'])
 
 
 class TestTlsaValue(TestCase):

--- a/tests/test_octodns_record_uri.py
+++ b/tests/test_octodns_record_uri.py
@@ -9,7 +9,7 @@ from helpers import SimpleProvider
 from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
-from octodns.record.uri import UriRecord, UriValue
+from octodns.record.uri import UriNameRfcValidator, UriRecord, UriValue
 from octodns.zone import Zone
 
 
@@ -341,6 +341,115 @@ class TestRecordUri(TestCase):
         self.assertEqual(['missing target'], ctx.exception.reasons)
 
         # target must be a valid URI
+
+    def test_rfc_name_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        uri_record_ids = set(v.id for v in registered['record'].get('URI', []))
+        self.assertNotIn('uri-name-rfc', uri_record_ids)
+
+    def test_name_rfc_validator(self):
+        validate = UriNameRfcValidator('uri-name-rfc').validate
+
+        for name in (
+            '_ftp._tcp',
+            '_http._tcp',
+            '_xmpp-client._tcp',
+            '_a._tcp',
+            '_ftp._tcp.region1',
+            '*._tcp',
+            '_a1._tcp',
+        ):
+            self.assertEqual(
+                [], validate(UriRecord, name, f'{name}.unit.tests.', {}), name
+            )
+
+        # single-label name
+        self.assertEqual(
+            ['URI name must have at least two labels (_service._proto)'],
+            validate(UriRecord, '_ftp', '_ftp.unit.tests.', {}),
+        )
+        # empty name
+        self.assertEqual(
+            ['URI name must have at least two labels (_service._proto)'],
+            validate(UriRecord, '', 'unit.tests.', {}),
+        )
+
+        # service label missing underscore
+        self.assertEqual(
+            ['invalid URI service label "ftp"'],
+            validate(UriRecord, 'ftp._tcp', 'ftp._tcp.unit.tests.', {}),
+        )
+        # service label too long (>15 chars after underscore)
+        long_svc = '_' + ('a' * 16)
+        self.assertEqual(
+            [f'invalid URI service label "{long_svc}"'],
+            validate(
+                UriRecord, f'{long_svc}._tcp', f'{long_svc}._tcp.u.t.', {}
+            ),
+        )
+        # service label starts with digit
+        self.assertEqual(
+            ['invalid URI service label "_1ftp"'],
+            validate(UriRecord, '_1ftp._tcp', '_1ftp._tcp.unit.tests.', {}),
+        )
+        # service label ends with hyphen
+        self.assertEqual(
+            ['invalid URI service label "_ftp-"'],
+            validate(UriRecord, '_ftp-._tcp', '_ftp-._tcp.unit.tests.', {}),
+        )
+        # service label contains consecutive hyphens
+        self.assertEqual(
+            ['invalid URI service label "_f--p"'],
+            validate(UriRecord, '_f--p._tcp', '_f--p._tcp.unit.tests.', {}),
+        )
+        # proto label missing underscore
+        self.assertEqual(
+            ['invalid URI proto label "tcp"'],
+            validate(UriRecord, '_ftp.tcp', '_ftp.tcp.unit.tests.', {}),
+        )
+        # both labels invalid
+        self.assertEqual(
+            [
+                'invalid URI service label "ftp"',
+                'invalid URI proto label "tcp"',
+            ],
+            validate(UriRecord, 'ftp.tcp', 'ftp.tcp.unit.tests.', {}),
+        )
+
+    def test_rfc_name_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('uri-name-rfc', types=['URI'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '_1ftp._tcp',
+                    {
+                        'type': 'URI',
+                        'ttl': 600,
+                        'value': {
+                            'priority': 1,
+                            'weight': 2,
+                            'target': 'ftp://x.',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['invalid URI service label "_1ftp"'], ctx.exception.reasons
+            )
+
+            Record.new(
+                zone,
+                '_ftp._tcp',
+                {
+                    'type': 'URI',
+                    'ttl': 600,
+                    'value': {'priority': 1, 'weight': 2, 'target': 'ftp://x.'},
+                },
+            )
+        finally:
+            Record.disable_validator('uri-name-rfc', types=['URI'])
 
 
 class TestUriValue(TestCase):

--- a/tests/test_octodns_record_uri.py
+++ b/tests/test_octodns_record_uri.py
@@ -9,7 +9,12 @@ from helpers import SimpleProvider
 from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
-from octodns.record.uri import UriNameRfcValidator, UriRecord, UriValue
+from octodns.record.uri import (
+    UriNameRfcValidator,
+    UriRecord,
+    UriValue,
+    UriValueRfcValidator,
+)
 from octodns.zone import Zone
 
 
@@ -341,6 +346,136 @@ class TestRecordUri(TestCase):
         self.assertEqual(['missing target'], ctx.exception.reasons)
 
         # target must be a valid URI
+
+    def test_rfc_value_validator_not_in_defaults(self):
+        registered = Record.registered_validators()
+        uri_value_ids = set(v.id for v in registered['value'].get('URI', []))
+        self.assertNotIn('uri-value-rfc', uri_value_ids)
+
+    def test_value_rfc_validator(self):
+        validate = UriValueRfcValidator('uri-value-rfc').validate
+
+        # valid
+        self.assertEqual(
+            [],
+            validate(
+                UriValue,
+                [{'priority': 0, 'weight': 65535, 'target': 'http://x.'}],
+                'URI',
+            ),
+        )
+
+        # priority out of range
+        self.assertEqual(
+            ['invalid priority "70000"; must be 0-65535'],
+            validate(
+                UriValue,
+                [{'priority': 70000, 'weight': 2, 'target': 'http://x.'}],
+                'URI',
+            ),
+        )
+
+        # weight out of range
+        self.assertEqual(
+            ['invalid weight "70000"; must be 0-65535'],
+            validate(
+                UriValue,
+                [{'priority': 1, 'weight': 70000, 'target': 'http://x.'}],
+                'URI',
+            ),
+        )
+
+        # priority non-integer
+        self.assertEqual(
+            ['invalid priority "nope"'],
+            validate(
+                UriValue,
+                [{'priority': 'nope', 'weight': 2, 'target': 'http://x.'}],
+                'URI',
+            ),
+        )
+
+        # weight non-integer
+        self.assertEqual(
+            ['invalid weight "nope"'],
+            validate(
+                UriValue,
+                [{'priority': 1, 'weight': 'nope', 'target': 'http://x.'}],
+                'URI',
+            ),
+        )
+
+        # missing target
+        self.assertEqual(
+            ['missing target'],
+            validate(UriValue, [{'priority': 1, 'weight': 2}], 'URI'),
+        )
+
+        # missing all fields
+        self.assertEqual(
+            ['missing priority', 'missing weight', 'missing target'],
+            validate(UriValue, [{}], 'URI'),
+        )
+
+    def test_rfc_value_validator_opt_in(self):
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('uri-value-rfc', types=['URI'])
+        try:
+            # priority out of range — only RFC validator catches
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '_uri._tcp',
+                    {
+                        'type': 'URI',
+                        'ttl': 600,
+                        'value': {
+                            'priority': 70000,
+                            'weight': 2,
+                            'target': 'http://x.',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['invalid priority "70000"; must be 0-65535'],
+                ctx.exception.reasons,
+            )
+            # weight out of range — only RFC validator catches
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '_uri._tcp',
+                    {
+                        'type': 'URI',
+                        'ttl': 600,
+                        'value': {
+                            'priority': 1,
+                            'weight': 70000,
+                            'target': 'http://x.',
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['invalid weight "70000"; must be 0-65535'],
+                ctx.exception.reasons,
+            )
+            # valid passes
+            Record.new(
+                zone,
+                '_uri._tcp',
+                {
+                    'type': 'URI',
+                    'ttl': 600,
+                    'value': {
+                        'priority': 1,
+                        'weight': 2,
+                        'target': 'http://x.',
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('uri-value-rfc', types=['URI'])
 
     def test_rfc_name_validator_not_in_defaults(self):
         registered = Record.registered_validators()

--- a/tests/test_octodns_record_validators.py
+++ b/tests/test_octodns_record_validators.py
@@ -510,5 +510,7 @@ class TestValidatorRegistry(TestCase):
             'ip-value-rfc',
             'target-value-rfc',
             'targets-value-rfc',
+            'target-value-best-practice',
+            'targets-value-best-practice',
         ):
             self.assertIn(expected, seen)

--- a/tests/test_octodns_record_validators.py
+++ b/tests/test_octodns_record_validators.py
@@ -499,16 +499,16 @@ class TestValidatorRegistry(TestCase):
                 )
 
         for expected in (
-            'name',
-            'ttl',
+            'name-rfc',
+            'ttl-rfc',
             'healthcheck',
             '_values-type',
             '_value-type',
-            'cname-root',
+            'cname-root-rfc',
             'alias-root',
             'mx-value',
-            'ip-value',
-            'target-value',
-            'targets-value',
+            'ip-value-rfc',
+            'target-value-rfc',
+            'targets-value-rfc',
         ):
             self.assertIn(expected, seen)


### PR DESCRIPTION
This adds/extends two new sets, `strict` and `best-practice`. The first include RFC compliance checks and the latter includes general best practice validation, e.g. trailing `.`. 

/cc https://github.com/octodns/octodns/pull/1380