### PR TITLE
Add best-practice validators for SSHFP, DS, TLSA, and CAA

### DIFF
--- a/.changelog/b75fb51a1bf948ba8d56c2a2b922ba35.md
+++ b/.changelog/b75fb51a1bf948ba8d56c2a2b922ba35.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add best-practice validators for SSHFP, DS, TLSA, and CAA record types

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -73,12 +73,42 @@ class CaaValueRfcValidator(ValueValidator):
         return reasons
 
 
+class CaaValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that CAA records include an explicit ``issuewild`` property
+    whenever an ``issue`` property is present.
+
+    Per RFC 8659 §4.2, wildcard certificate issuance falls back to
+    ``issue`` policy when no ``issuewild`` record exists; omitting
+    ``issuewild`` makes the wildcard-issuance policy implicit rather
+    than explicit.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        tags = {v.get('tag') for v in data}
+        if 'issue' in tags and 'issuewild' not in tags:
+            return [
+                'CAA issue tag is present without issuewild; '
+                'add an explicit issuewild to clarify wildcard certificate policy'
+            ]
+        return []
+
+
 class CaaValue(EqualityTupleMixin, dict):
     # https://tools.ietf.org/html/rfc8659
 
     VALIDATORS = [
         CaaValueValidator('caa-value', sets={'legacy'}),
         CaaValueRfcValidator('caa-value-rfc', sets={'strict'}),
+        CaaValueBestPracticeValidator(
+            'caa-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -145,6 +145,58 @@ class DsValueRfcValidator(ValueValidator):
         return reasons
 
 
+class DsValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks DS records against deprecated algorithms and digest types per
+    RFC 8624.
+
+    - ``digest_type`` 1 (SHA-1) is NOT RECOMMENDED (§3.3); use
+      digest_type 2 (SHA-256).
+    - Signing ``algorithm`` values 1 (RSA/MD5), 3 (DSA/SHA1),
+      5 (RSA/SHA-1), 6 (DSA-NSEC3-SHA1), and 7 (RSASHA1-NSEC3-SHA1)
+      are deprecated (§3.1).
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    _deprecated_algorithms = {
+        1: 'RSA/MD5',
+        3: 'DSA/SHA1',
+        5: 'RSA/SHA-1',
+        6: 'DSA-NSEC3-SHA1',
+        7: 'RSASHA1-NSEC3-SHA1',
+    }
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            if 'public_key' in value or 'flags' in value:
+                continue
+            try:
+                algorithm = int(value['algorithm'])
+                if algorithm in self._deprecated_algorithms:
+                    name = self._deprecated_algorithms[algorithm]
+                    reasons.append(
+                        f'DS algorithm {algorithm} ({name}) is deprecated per RFC 8624'
+                    )
+            except (KeyError, ValueError, TypeError):
+                pass
+            try:
+                digest_type = int(value['digest_type'])
+                if digest_type == 1:
+                    reasons.append(
+                        'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; '
+                        'use digest_type 2 (SHA-256)'
+                    )
+            except (KeyError, ValueError, TypeError):
+                pass
+        return reasons
+
+
 class DsValue(EqualityTupleMixin, dict):
     # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
     log = getLogger('DsValue')
@@ -152,6 +204,9 @@ class DsValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         DsValueValidator('ds-value', sets={'legacy'}),
         DsValueRfcValidator('ds-value-rfc', sets={'strict'}),
+        DsValueBestPracticeValidator(
+            'ds-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -124,6 +124,36 @@ class SshfpValueRfcValidator(ValueValidator):
         return reasons
 
 
+class SshfpValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that SSHFP records use SHA-256 (fingerprint_type 2) rather
+    than the deprecated SHA-1 (fingerprint_type 1).
+
+    SHA-1 is cryptographically weak; RFC 8709 formalises Ed25519 support
+    and operational guidance consistently recommends SHA-256 fingerprints.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                fp_type = int(value['fingerprint_type'])
+            except (KeyError, ValueError, TypeError):
+                continue
+            if fp_type == 1:
+                reasons.append(
+                    'SSHFP fingerprint_type 1 (SHA-1) is deprecated; '
+                    'use fingerprint_type 2 (SHA-256)'
+                )
+        return reasons
+
+
 class SshfpValue(EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
@@ -131,6 +161,9 @@ class SshfpValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         SshfpValueValidator('sshfp-value', sets={'legacy'}),
         SshfpValueRfcValidator('sshfp-value-rfc', sets={'strict'}),
+        SshfpValueBestPracticeValidator(
+            'sshfp-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -117,10 +117,45 @@ class TlsaValueRfcValidator(ValueValidator):
         return reasons
 
 
+class TlsaValueBestPracticeValidator(ValueValidator):
+    '''
+    Checks that TLSA records do not use matching_type 0 (full
+    DER-encoded certificate or public key stored verbatim).
+
+    RFC 7671 §4.1 advises against matching_type 0 in production:
+    any certificate renewal requires a DNS update before the new
+    certificate can be used.  Use matching_type 1 (SHA-256) or
+    2 (SHA-512) instead.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            try:
+                matching_type = int(value['matching_type'])
+            except (KeyError, ValueError, TypeError):
+                continue
+            if matching_type == 0:
+                reasons.append(
+                    'TLSA matching_type 0 (full data) is not recommended; '
+                    'use matching_type 1 (SHA-256) or 2 (SHA-512)'
+                )
+        return reasons
+
+
 class TlsaValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         TlsaValueValidator('tlsa-value', sets={'legacy'}),
         TlsaValueRfcValidator('tlsa-value-rfc', sets={'strict'}),
+        TlsaValueBestPracticeValidator(
+            'tlsa-value-best-practice', sets={'best-practice'}
+        ),
     ]
 
     @classmethod

--- a/tests/test_octodns_record_caa.py
+++ b/tests/test_octodns_record_caa.py
@@ -7,7 +7,12 @@ from unittest import TestCase
 from helpers import SimpleProvider
 
 from octodns.record import Record
-from octodns.record.caa import CaaRecord, CaaValue, CaaValueRfcValidator
+from octodns.record.caa import (
+    CaaRecord,
+    CaaValue,
+    CaaValueBestPracticeValidator,
+    CaaValueRfcValidator,
+)
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
@@ -436,6 +441,151 @@ class TestRecordCaa(TestCase):
             )
         finally:
             Record.disable_validator('caa-value-rfc', types=['CAA'])
+
+
+class TestCaaBestPractice(TestCase):
+
+    def test_best_practice_validator(self):
+        validate = CaaValueBestPracticeValidator(
+            'caa-value-best-practice'
+        ).validate
+
+        # both issue and issuewild present — passes
+        self.assertEqual(
+            [],
+            validate(
+                CaaValue,
+                [
+                    {'flags': 0, 'tag': 'issue', 'value': 'letsencrypt.org'},
+                    {
+                        'flags': 0,
+                        'tag': 'issuewild',
+                        'value': 'letsencrypt.org',
+                    },
+                ],
+                'CAA',
+            ),
+        )
+        # issuewild only (no issue) — passes
+        self.assertEqual(
+            [],
+            validate(
+                CaaValue,
+                [{'flags': 0, 'tag': 'issuewild', 'value': 'letsencrypt.org'}],
+                'CAA',
+            ),
+        )
+        # iodef only — passes
+        self.assertEqual(
+            [],
+            validate(
+                CaaValue,
+                [
+                    {
+                        'flags': 128,
+                        'tag': 'iodef',
+                        'value': 'mailto:security@example.com',
+                    }
+                ],
+                'CAA',
+            ),
+        )
+        # issue with prohibition value (";") + no issuewild — still flagged
+        self.assertEqual(
+            [
+                'CAA issue tag is present without issuewild; '
+                'add an explicit issuewild to clarify wildcard certificate policy'
+            ],
+            validate(
+                CaaValue, [{'flags': 0, 'tag': 'issue', 'value': ';'}], 'CAA'
+            ),
+        )
+        # issue without issuewild triggers warning
+        self.assertEqual(
+            [
+                'CAA issue tag is present without issuewild; '
+                'add an explicit issuewild to clarify wildcard certificate policy'
+            ],
+            validate(
+                CaaValue,
+                [{'flags': 0, 'tag': 'issue', 'value': 'letsencrypt.org'}],
+                'CAA',
+            ),
+        )
+        # issue + iodef but no issuewild — warning
+        self.assertEqual(
+            [
+                'CAA issue tag is present without issuewild; '
+                'add an explicit issuewild to clarify wildcard certificate policy'
+            ],
+            validate(
+                CaaValue,
+                [
+                    {'flags': 0, 'tag': 'issue', 'value': 'letsencrypt.org'},
+                    {
+                        'flags': 128,
+                        'tag': 'iodef',
+                        'value': 'mailto:security@example.com',
+                    },
+                ],
+                'CAA',
+            ),
+        )
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('caa-value-best-practice', types=['CAA'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'CAA',
+                        'ttl': 600,
+                        'value': {
+                            'flags': 0,
+                            'tag': 'issue',
+                            'value': 'letsencrypt.org',
+                        },
+                    },
+                )
+            self.assertEqual(
+                [
+                    'CAA issue tag is present without issuewild; '
+                    'add an explicit issuewild to clarify wildcard certificate policy'
+                ],
+                ctx.exception.reasons,
+            )
+            # both issue and issuewild passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'CAA',
+                    'ttl': 600,
+                    'values': [
+                        {
+                            'flags': 0,
+                            'tag': 'issue',
+                            'value': 'letsencrypt.org',
+                        },
+                        {
+                            'flags': 0,
+                            'tag': 'issuewild',
+                            'value': 'letsencrypt.org',
+                        },
+                    ],
+                },
+            )
+        finally:
+            Record.disable_validator('caa-value-best-practice', types=['CAA'])
+
+    def test_best_practice_not_in_defaults(self):
+        registered = Record.registered_validators()
+        caa_value_ids = set(v.id for v in registered['value'].get('CAA', []))
+        self.assertNotIn('caa-value-best-practice', caa_value_ids)
 
 
 class TestCaaValue(TestCase):

--- a/tests/test_octodns_record_ds.py
+++ b/tests/test_octodns_record_ds.py
@@ -6,7 +6,12 @@ from unittest import TestCase
 
 from octodns.record import Record
 from octodns.record.base import _process_value_validators
-from octodns.record.ds import DsRecord, DsValue, DsValueRfcValidator
+from octodns.record.ds import (
+    DsRecord,
+    DsValue,
+    DsValueBestPracticeValidator,
+    DsValueRfcValidator,
+)
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
 from octodns.zone import Zone
@@ -627,6 +632,233 @@ class TestRecordDs(TestCase):
             )
         finally:
             Record.disable_validator('ds-value-rfc', types=['DS'])
+
+
+class TestDsBestPractice(TestCase):
+
+    def test_best_practice_validator(self):
+        validate = DsValueBestPracticeValidator(
+            'ds-value-best-practice'
+        ).validate
+
+        sha256 = 'a' * 64
+
+        # modern algorithm + SHA-256 digest passes
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 8,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # Ed25519 algorithm (15) + SHA-256 digest passes
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 15,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # old-style fields are skipped (deprecated format validator handles them)
+        self.assertEqual(
+            [],
+            validate(
+                DsValue,
+                [
+                    {
+                        'flags': 1234,
+                        'protocol': 3,
+                        'algorithm': 1,
+                        'public_key': 'abc',
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # deprecated algorithm 1 (RSA/MD5)
+        self.assertEqual(
+            ['DS algorithm 1 (RSA/MD5) is deprecated per RFC 8624'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 1,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # deprecated algorithm 3 (DSA/SHA1)
+        self.assertEqual(
+            ['DS algorithm 3 (DSA/SHA1) is deprecated per RFC 8624'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 3,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # deprecated algorithm 5 (RSA/SHA-1)
+        self.assertEqual(
+            ['DS algorithm 5 (RSA/SHA-1) is deprecated per RFC 8624'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 5,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # deprecated algorithm 6 (DSA-NSEC3-SHA1)
+        self.assertEqual(
+            ['DS algorithm 6 (DSA-NSEC3-SHA1) is deprecated per RFC 8624'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 6,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # deprecated algorithm 7 (RSASHA1-NSEC3-SHA1)
+        self.assertEqual(
+            ['DS algorithm 7 (RSASHA1-NSEC3-SHA1) is deprecated per RFC 8624'],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 7,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # digest_type 1 (SHA-1) not recommended
+        self.assertEqual(
+            [
+                'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; '
+                'use digest_type 2 (SHA-256)'
+            ],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 8,
+                        'digest_type': 1,
+                        'digest': 'a' * 40,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # both deprecated algorithm and SHA-1 digest — both reported
+        self.assertEqual(
+            [
+                'DS algorithm 5 (RSA/SHA-1) is deprecated per RFC 8624',
+                'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; '
+                'use digest_type 2 (SHA-256)',
+            ],
+            validate(
+                DsValue,
+                [
+                    {
+                        'key_tag': 1234,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': 'a' * 40,
+                    }
+                ],
+                'DS',
+            ),
+        )
+        # missing fields — no error (format validator handles presence)
+        self.assertEqual([], validate(DsValue, [{}], 'DS'))
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('ds-value-best-practice', types=['DS'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    'test',
+                    {
+                        'type': 'DS',
+                        'ttl': 600,
+                        'value': {
+                            'key_tag': 1234,
+                            'algorithm': 5,
+                            'digest_type': 2,
+                            'digest': sha256,
+                        },
+                    },
+                )
+            self.assertEqual(
+                ['DS algorithm 5 (RSA/SHA-1) is deprecated per RFC 8624'],
+                ctx.exception.reasons,
+            )
+            # modern algorithm + SHA-256 passes
+            Record.new(
+                zone,
+                'test',
+                {
+                    'type': 'DS',
+                    'ttl': 600,
+                    'value': {
+                        'key_tag': 1234,
+                        'algorithm': 13,
+                        'digest_type': 2,
+                        'digest': sha256,
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('ds-value-best-practice', types=['DS'])
+
+    def test_best_practice_not_in_defaults(self):
+        registered = Record.registered_validators()
+        ds_value_ids = set(v.id for v in registered['value'].get('DS', []))
+        self.assertNotIn('ds-value-best-practice', ds_value_ids)
 
 
 class TestDsValue(TestCase):

--- a/tests/test_octodns_record_sshfp.py
+++ b/tests/test_octodns_record_sshfp.py
@@ -9,7 +9,12 @@ from helpers import SimpleProvider
 from octodns.record.base import Record
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
-from octodns.record.sshfp import SshfpRecord, SshfpValue, SshfpValueRfcValidator
+from octodns.record.sshfp import (
+    SshfpRecord,
+    SshfpValue,
+    SshfpValueBestPracticeValidator,
+    SshfpValueRfcValidator,
+)
 from octodns.zone import Zone
 
 
@@ -663,6 +668,152 @@ class TestRecordSshfp(TestCase):
         )
         self.assertFalse(upper.changes(lower, target))
         self.assertFalse(lower.changes(upper, target))
+
+
+class TestSshfpBestPractice(TestCase):
+
+    def test_best_practice_validator(self):
+        validate = SshfpValueBestPracticeValidator(
+            'sshfp-value-best-practice'
+        ).validate
+
+        sha1_fp = 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
+        sha256_fp = (
+            'a87f1b687ac0e57d2a081a2f282672334d90ed316d2b818ca9580ea384d92401'
+        )
+
+        # SHA-256 fingerprint_type passes
+        self.assertEqual(
+            [],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 2,
+                        'fingerprint': sha256_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+        # unknown fingerprint_type passes (not our concern)
+        self.assertEqual(
+            [],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 4,
+                        'fingerprint_type': 3,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+        # missing fingerprint_type — no error (format validator handles it)
+        self.assertEqual(
+            [],
+            validate(
+                SshfpValue, [{'algorithm': 1, 'fingerprint': sha1_fp}], 'SSHFP'
+            ),
+        )
+        # SHA-1 fingerprint_type triggers warning
+        self.assertEqual(
+            [
+                'SSHFP fingerprint_type 1 (SHA-1) is deprecated; '
+                'use fingerprint_type 2 (SHA-256)'
+            ],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': sha1_fp,
+                    }
+                ],
+                'SSHFP',
+            ),
+        )
+        # multiple values — each SHA-1 value reported
+        self.assertEqual(
+            [
+                'SSHFP fingerprint_type 1 (SHA-1) is deprecated; '
+                'use fingerprint_type 2 (SHA-256)',
+                'SSHFP fingerprint_type 1 (SHA-1) is deprecated; '
+                'use fingerprint_type 2 (SHA-256)',
+            ],
+            validate(
+                SshfpValue,
+                [
+                    {
+                        'algorithm': 1,
+                        'fingerprint_type': 1,
+                        'fingerprint': sha1_fp,
+                    },
+                    {
+                        'algorithm': 2,
+                        'fingerprint_type': 1,
+                        'fingerprint': sha1_fp,
+                    },
+                ],
+                'SSHFP',
+            ),
+        )
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('sshfp-value-best-practice', types=['SSHFP'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '',
+                    {
+                        'type': 'SSHFP',
+                        'ttl': 600,
+                        'value': {
+                            'algorithm': 1,
+                            'fingerprint_type': 1,
+                            'fingerprint': sha1_fp,
+                        },
+                    },
+                )
+            self.assertEqual(
+                [
+                    'SSHFP fingerprint_type 1 (SHA-1) is deprecated; '
+                    'use fingerprint_type 2 (SHA-256)'
+                ],
+                ctx.exception.reasons,
+            )
+            # SHA-256 passes
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'SSHFP',
+                    'ttl': 600,
+                    'value': {
+                        'algorithm': 1,
+                        'fingerprint_type': 2,
+                        'fingerprint': sha256_fp,
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator(
+                'sshfp-value-best-practice', types=['SSHFP']
+            )
+
+    def test_best_practice_not_in_defaults(self):
+        registered = Record.registered_validators()
+        sshfp_value_ids = set(
+            v.id for v in registered['value'].get('SSHFP', [])
+        )
+        self.assertNotIn('sshfp-value-best-practice', sshfp_value_ids)
 
 
 class TestSshFpValue(TestCase):

--- a/tests/test_octodns_record_tlsa.py
+++ b/tests/test_octodns_record_tlsa.py
@@ -9,7 +9,12 @@ from helpers import SimpleProvider
 from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.rr import RrParseError
-from octodns.record.tlsa import TlsaRecord, TlsaValue, TlsaValueRfcValidator
+from octodns.record.tlsa import (
+    TlsaRecord,
+    TlsaValue,
+    TlsaValueBestPracticeValidator,
+    TlsaValueRfcValidator,
+)
 from octodns.zone import Zone
 
 
@@ -708,6 +713,160 @@ class TestRecordTlsa(TestCase):
             )
         finally:
             Record.disable_validator('tlsa-value-rfc', types=['TLSA'])
+
+
+class TestTlsaBestPractice(TestCase):
+
+    def test_best_practice_validator(self):
+        validate = TlsaValueBestPracticeValidator(
+            'tlsa-value-best-practice'
+        ).validate
+
+        cad = 'a' * 64
+
+        # matching_type 1 (SHA-256) passes
+        self.assertEqual(
+            [],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 1,
+                        'certificate_association_data': cad,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+        # matching_type 2 (SHA-512) passes
+        self.assertEqual(
+            [],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 2,
+                        'certificate_association_data': cad,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+        # missing matching_type — no error (format validator handles it)
+        self.assertEqual(
+            [],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'certificate_association_data': cad,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+        # matching_type 0 (full data) triggers warning
+        self.assertEqual(
+            [
+                'TLSA matching_type 0 (full data) is not recommended; '
+                'use matching_type 1 (SHA-256) or 2 (SHA-512)'
+            ],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 0,
+                        'certificate_association_data': cad,
+                    }
+                ],
+                'TLSA',
+            ),
+        )
+        # multiple values — each matching_type 0 is reported
+        self.assertEqual(
+            [
+                'TLSA matching_type 0 (full data) is not recommended; '
+                'use matching_type 1 (SHA-256) or 2 (SHA-512)',
+                'TLSA matching_type 0 (full data) is not recommended; '
+                'use matching_type 1 (SHA-256) or 2 (SHA-512)',
+            ],
+            validate(
+                TlsaValue,
+                [
+                    {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 0,
+                        'certificate_association_data': cad,
+                    },
+                    {
+                        'certificate_usage': 1,
+                        'selector': 0,
+                        'matching_type': 0,
+                        'certificate_association_data': cad,
+                    },
+                ],
+                'TLSA',
+            ),
+        )
+
+        # opt-in via Record.enable_validator
+        zone = Zone('unit.tests.', [])
+        Record.enable_validators(['legacy'])
+        Record.enable_validator('tlsa-value-best-practice', types=['TLSA'])
+        try:
+            with self.assertRaises(ValidationError) as ctx:
+                Record.new(
+                    zone,
+                    '_443._tcp',
+                    {
+                        'type': 'TLSA',
+                        'ttl': 600,
+                        'value': {
+                            'certificate_usage': 3,
+                            'selector': 1,
+                            'matching_type': 0,
+                            'certificate_association_data': cad,
+                        },
+                    },
+                )
+            self.assertEqual(
+                [
+                    'TLSA matching_type 0 (full data) is not recommended; '
+                    'use matching_type 1 (SHA-256) or 2 (SHA-512)'
+                ],
+                ctx.exception.reasons,
+            )
+            # matching_type 1 passes
+            Record.new(
+                zone,
+                '_443._tcp',
+                {
+                    'type': 'TLSA',
+                    'ttl': 600,
+                    'value': {
+                        'certificate_usage': 3,
+                        'selector': 1,
+                        'matching_type': 1,
+                        'certificate_association_data': cad,
+                    },
+                },
+            )
+        finally:
+            Record.disable_validator('tlsa-value-best-practice', types=['TLSA'])
+
+    def test_best_practice_not_in_defaults(self):
+        registered = Record.registered_validators()
+        tlsa_value_ids = set(v.id for v in registered['value'].get('TLSA', []))
+        self.assertNotIn('tlsa-value-best-practice', tlsa_value_ids)
 
 
 class TestTlsaValue(TestCase):


### PR DESCRIPTION
## Summary

- `sshfp-value-best-practice` — warns when `fingerprint_type 1` (SHA-1) is used; SHA-256 (type 2) is the modern standard
- `ds-value-best-practice` — warns on deprecated signing algorithms (1/RSA-MD5, 3/DSA, 5/RSA-SHA1, 6/DSA-NSEC3, 7/RSASHA1-NSEC3 per RFC 8624 §3.1) and `digest_type 1` (SHA-1, NOT RECOMMENDED per RFC 8624 §3.3)
- `tlsa-value-best-practice` — warns when `matching_type 0` (full DER-encoded data) is used; RFC 7671 §4.1 advises against it because cert renewals require a DNS update before the new cert can be used
- `caa-value-best-practice` — warns when an `issue` tag is present without a corresponding `issuewild`; per RFC 8659 §4.2, omitting `issuewild` leaves wildcard certificate issuance policy implicit rather than explicit

All four are opt-in via the `best-practice` validator set (or individually via `Record.enable_validator`) and are not active by default. Each ships with 100% branch coverage.

## Test plan

- [x] `./script/coverage` passes at 100%
- [x] Direct validator class tests covering valid, invalid, and edge-case inputs
- [x] Opt-in integration tests via `Record.enable_validator` / `Record.disable_validator`
- [x] `test_best_practice_not_in_defaults` asserting each validator is absent from the default active set

/cc https://github.com/octodns/octodns/pull/1380