### PR TITLE
Version 1.17.0 bump & changelog update

### DIFF
--- a/.changelog/0e340f8428c9404d8371303a268453c7.md
+++ b/.changelog/0e340f8428c9404d8371303a268453c7.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Dynamic validator registration and config-driven management

--- a/.changelog/158961ce0b6d49389442d2a1cf842e0d.md
+++ b/.changelog/158961ce0b6d49389442d2a1cf842e0d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Remove stray debug and print, add lint check for prints

--- a/.changelog/1611271de41340a893573ac38d4da488.md
+++ b/.changelog/1611271de41340a893573ac38d4da488.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add REFERENCES tuple to Zone and each Record type pointing to the RFCs (and for ALIAS an IETF draft) that define them

--- a/.changelog/23088495a46f46458e4cf5ed967f7ead.md
+++ b/.changelog/23088495a46f46458e4cf5ed967f7ead.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Normalize hex data fields (TLSA certificate_association_data, SSHFP fingerprint, DS digest) to lowercase for case-insensitive comparison

--- a/.changelog/307ee403c7a54c5889257159c30c731a.md
+++ b/.changelog/307ee403c7a54c5889257159c30c731a.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Register UriRecord and UriValue

--- a/.changelog/4a83623af6ba4742b51b60e775467e39.md
+++ b/.changelog/4a83623af6ba4742b51b60e775467e39.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/4fb785e4cbf24d5aa76633cd20d5f70d.md
+++ b/.changelog/4fb785e4cbf24d5aa76633cd20d5f70d.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add `ignore_subzone_adds` zone option to silently drop records overlapping a configured sub-zone

--- a/.changelog/50da5214d3334a32bebd00054daca600.md
+++ b/.changelog/50da5214d3334a32bebd00054daca600.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Support 3rd-party record types in JSON Schema

--- a/.changelog/7edd4ce3eec447a7af5e63875a93dcbb.md
+++ b/.changelog/7edd4ce3eec447a7af5e63875a93dcbb.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add new strict validators set and include existing rfc-compliant validators in it

--- a/.changelog/833f8b012fcd4e49bc8213896dd7f1db.md
+++ b/.changelog/833f8b012fcd4e49bc8213896dd7f1db.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Reject unknown top-level keys on records in JSON Schema

--- a/.changelog/8fbdc64c7fb641c087dbcafe9bf2fcb4.md
+++ b/.changelog/8fbdc64c7fb641c087dbcafe9bf2fcb4.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Validate SSHFP fingerprint length matches fingerprint_type

--- a/.changelog/9f22a5e5249c4d11b481d0d592988721.md
+++ b/.changelog/9f22a5e5249c4d11b481d0d592988721.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add named validator sets (legacy, rfc, etc.) and manager.enabled config key to opt into curated bundles

--- a/.changelog/a651c0848da24c7bbc01e1dec79d7919.md
+++ b/.changelog/a651c0848da24c7bbc01e1dec79d7919.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add JSON Schema for the main config file and publish it alongside the renamed zone schema (octodns-zone.schema.json); octodns.schema.json remains as a legacy alias.

--- a/.changelog/b75fb51a1bf948ba8d56c2a2b922ba35.md
+++ b/.changelog/b75fb51a1bf948ba8d56c2a2b922ba35.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add best-practice validators for SSHFP, DS, TLSA, and CAA record types

--- a/.changelog/bad1a8ec4ed84b35bbc248abeeaa01cf.md
+++ b/.changelog/bad1a8ec4ed84b35bbc248abeeaa01cf.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-JSON schema file generation

--- a/.changelog/c490fd3328724cd692afffa943e43fe5.md
+++ b/.changelog/c490fd3328724cd692afffa943e43fe5.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Introduce RecordValidator/ValueValidator base classes, laying groundwork for extensible record and value validations. Overriding `validate` on a `Record` subclass or defining a `validate` classmethod on a value class is DEPRECATED; declare validators via the `VALIDATORS` class attribute instead. Will be removed in 2.0.

--- a/.changelog/d35ad8d992bf4b7bb3c955635cdf6c52.md
+++ b/.changelog/d35ad8d992bf4b7bb3c955635cdf6c52.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add octodns-unifi provider to documentation

--- a/.changelog/dccef96101c244afa311fa0f28e316c6.md
+++ b/.changelog/dccef96101c244afa311fa0f28e316c6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Publish JSON Schema to Read the Docs under `_static/octodns.schema.json` for each built version

--- a/.changelog/ef85e6f9a3ef42a18044c485e62cbfed.md
+++ b/.changelog/ef85e6f9a3ef42a18044c485e62cbfed.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add new schema files to ignores

--- a/.changelog/fe3b237a4b1c45ca961e9536353a0c95.md
+++ b/.changelog/fe3b237a4b1c45ca961e9536353a0c95.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-Add opt-in strict SRV validators per RFC 2782 and RFC 6335 (`SrvNameRfcValidator` /
-`srv-name-rfc`, `SrvValueRfcValidator` / `srv-value-rfc`). Establishes the
-`RfcValidator` / `BpValidator` naming convention to distinguish RFC-mandated
-checks from best-practice ones.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
+## 1.17.0 - 2026-05-06 - Now with more validation
+
+Minor:
+
+* Add JSON Schema for the main config file and publish it alongside the renamed zone schema (octodns-zone.schema.json); octodns.schema.json remains as a legacy alias. - [#1393](https://github.com/octodns/octodns/pull/1393)
+* Validators Next - See documentation for a more cohesive picture of the new/improved functionality
+  * Introduce RecordValidator/ValueValidator base classes, laying groundwork for extensible record and value validations. Overriding `validate` on a `Record` subclass or defining a `validate` classmethod on a value class is DEPRECATED; declare validators via the `VALIDATORS` class attribute instead. Will be removed in 2.0. - [#1378](https://github.com/octodns/octodns/pull/1378)
+  * Dynamic validator registration and config-driven management - [#1380](https://github.com/octodns/octodns/pull/1380)
+  * Add best-practice validators for SSHFP, DS, TLSA, and CAA record types - [#1391](https://github.com/octodns/octodns/pull/1391)
+  * Add new strict validators set and include existing rfc-compliant validators in it - [#1390](https://github.com/octodns/octodns/pull/1390)
+  * Add named validator sets (legacy, rfc, etc.) and manager.enabled config key to opt into curated bundles - [#1387](https://github.com/octodns/octodns/pull/1387)
+  * Validate SSHFP fingerprint length matches fingerprint_type - [#1372](https://github.com/octodns/octodns/pull/1372)
+  * Add opt-in strict SRV validators per RFC 2782 and RFC 6335 (`SrvNameRfcValidator` / `srv-name-rfc`, `SrvValueRfcValidator` / `srv-value-rfc`). Establishes the `RfcValidator` / `BpValidator` naming convention to distinguish RFC-mandated checks from best-practice ones. - [#1379](https://github.com/octodns/octodns/pull/1379)
+* Add `ignore_subzone_adds` zone option to silently drop records overlapping a configured sub-zone - [#1381](https://github.com/octodns/octodns/pull/1381)
+* Normalize hex data fields (TLSA certificate_association_data, SSHFP fingerprint, DS digest) to lowercase for case-insensitive comparison - [#1389](https://github.com/octodns/octodns/pull/1389)
+* Add REFERENCES tuple to Zone and each Record type pointing to the RFCs (and for ALIAS an IETF draft) that define them - [#1377](https://github.com/octodns/octodns/pull/1377)
+* JSON schema file generation - [#1373](https://github.com/octodns/octodns/pull/1373)
+
+Patch:
+
+* Register UriRecord and UriValue - [#1374](https://github.com/octodns/octodns/pull/1374)
+
 ## 1.16.0 - 2026-03-22
 
 Minor:
+
 * Add support for default values to env ars, env/VAR_NAME/DEFAULT - [#1364](https://github.com/octodns/octodns/pull/1364)
 * Record level lenience now applies to sub-zone ownership exceptions - [#1363](https://github.com/octodns/octodns/pull/1363)
 * make NAPTR flags field case insensitive - [#1360](https://github.com/octodns/octodns/pull/1360)
@@ -15,15 +38,18 @@ Minor:
 ## 1.15.0 - 2025-11-23
 
 Minor:
+
 * Use dedicated Checksum logger so that checksum is visible in --quiet mode - [#1333](https://github.com/octodns/octodns/pull/1333)
 * Add merge syntax support to !include tag, `<<: !include file.yaml` - [#1315](https://github.com/octodns/octodns/pull/1315)
 
 Patch:
+
 * Use WARNING instead of deprecated WARN, fix log level alignment - [#1333](https://github.com/octodns/octodns/pull/1333)
 
 ## 1.14.0 - 2025-10-24
 
 Minor:
+
 * Full rewrite of octodns-report: support for IPv6 resolvers, async names resolution and JSON output - [#1321](https://github.com/octodns/octodns/pull/1321)
 * Add processor for clamping TTLs - [#1318](https://github.com/octodns/octodns/pull/1318)
 * Add processor support to octodns-dump - [#1309](https://github.com/octodns/octodns/pull/1309)
@@ -35,6 +61,7 @@ Minor:
 ## 1.13.0 - 2025-08-06 - And then there was changelet
 
 Minor:
+
 * Quote NAPTR 'flags', 'service' and 'regexp' values as required by RFC2915 - [#1284](https://github.com/octodns/octodns/pull/1284)
 * Add new provider parameter root_ns_warnings to disable root NS related warnings - [#1282](https://github.com/octodns/octodns/pull/1282)
 * Fix issues with using Templating processor on alias zones - [#1279](https://github.com/octodns/octodns/pull/1279)
@@ -45,12 +72,14 @@ Minor:
 * Add kwags to filter processors __init__ - [#1274](https://github.com/octodns/octodns/pull/1274)
 
 Patch:
+
 * Fix encoding and decoding of mixed idna fqdns - [#1285](https://github.com/octodns/octodns/pull/1285)
 * Improve error messaging for unknown templating parameters - [#1280](https://github.com/octodns/octodns/pull/1280)
 
 ## 1.12.0 - 2025-06-25 - Automated changelogs
 
 Minor:
+
 * Templating processor added [#1259](https://github.com/octodns/octodns/pull/1259)
 * Update geo-data, Türkiye [#1263](https://github.com/octodns/octodns/pull/1263)
 * New provider: Bunny DNS [#1262](https://github.com/octodns/octodns/pull/1262)
@@ -196,9 +225,9 @@ Minor:
 * Record.from_rrs supports `source` parameter
 * Record.parse_rdata_text unquotes any quoted (string) values
 * Fix crash bug when using the YamlProvider with a directory that contains a
-  mix of split and non-split zone yamls. See https://github.com/octodns/octodns/issues/1066
+  mix of split and non-split zone yamls. See <https://github.com/octodns/octodns/issues/1066>
 * Fix discovery of zones from different sources when there are multiple dynamic
-  zones. See https://github.com/octodns/octodns/issues/1068
+  zones. See <https://github.com/octodns/octodns/issues/1068>
 
 ## v1.1.1 - 2023-09-16 - Doh! Fix that one little thing
 
@@ -226,7 +255,7 @@ Minor:
 * SpfRecord is formally deprecated with an warning and will become a
   ValidationError in 2.x
 * SpfDnsLookupProcessor is formally deprcated in favor of the version relocated
-  into https://github.com/octodns/octodns-spf and will be removed in 2.x
+  into <https://github.com/octodns/octodns-spf> and will be removed in 2.x
 * MetaProcessor added to enable some useful/cool options for debugging/tracking
   DNS changes. Specifically timestamps/uuid so you can track whether changes
   that have been pushed to providers have propogated/transferred correctly.
@@ -276,28 +305,28 @@ long (years) overdue.
 ### Noteworthy changes
 
 * 1.x Deprecation removals
-   * Provider, Source, and Processor shims removed, they've been warnings for >
+  * Provider, Source, and Processor shims removed, they've been warnings for >
      1yr.  Everything should be using and referring to provider-specific
      modules now.
-   * Provider.strict_supports defaults to true, can be returned to the old
+  * Provider.strict_supports defaults to true, can be returned to the old
      behavior by setting strict_supports=False in your provider params.
 * octodns.record has been broken up into multiple files/modules. Most of the
   primary things that were available at that module path still will be, but if
   you are importing things like idna_encode/decode that actually live elsewhere
   from octodns.record you'll need to update and pull them from their actual
-  home. Classes beginning with _ are not exported from octodns.record any
+  home. Classes beginning with_ are not exported from octodns.record any
   longer as they were considered private/protected.
 * Beta support for auto-arpa has been added
 * Support for subnet targeting in dynamic records
 * Enhanced validations on dynamic rules to encourage best practices
-   * The last rule must be a catch-all w/o any targeted geos or subnets
-   * Geos must not be repeated in multiple rules
-   * Geos in rules and subsequent rules must be ordered most to least specific,
+  * The last rule must be a catch-all w/o any targeted geos or subnets
+  * Geos must not be repeated in multiple rules
+  * Geos in rules and subsequent rules must be ordered most to least specific,
      e.g. NA-US-TN must come before NA-US, which must occur before NA
-   * Similarly, subnets must not be repeated in multiple rules, and various
+  * Similarly, subnets must not be repeated in multiple rules, and various
      subnet rules must be ordered such that most specific subnets appear before
      less specific ones; e.g. 10.1.1.0/24 must appear before 10.1.0.0/16.
-   * Subnet targeting is considered to be more specific than geo targeting, so
+  * Subnet targeting is considered to be more specific than geo targeting, so
      subnet-only rules must appear before any subnet+geo rules, followed by
      geo-only rules (and catch-all rule w/o any geos/subnets in the end)
 
@@ -312,7 +341,7 @@ long (years) overdue.
 ## v0.9.21 - 2022-10-16 - Last of the oughts
 
 * Shim AxfrSource and ZoneFileSource post extraction into
-  https://github.com/octodns/octodns-bind
+  <https://github.com/octodns/octodns-bind>
 
 ## v0.9.20 - 2022-10-05 - International friendly
 
@@ -355,9 +384,9 @@ long (years) overdue.
   at info
 * --logging-config command line option added to allow complete logging config
   customization, see
-  https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+  <https://docs.python.org/3/library/logging.config.html#logging-config-dictschema>
   for file format and
-  https://github.com/octodns/octodns/pull/945#issuecomment-1262839550 for an
+  <https://github.com/octodns/octodns/pull/945#issuecomment-1262839550> for an
   example config
 
 ## v0.9.19 - 2022-08-14 - Subzone handling
@@ -406,15 +435,15 @@ long (years) overdue.
 ### Noteworthy changes
 
 * Foundational support for root NS record management.
-   * YamlProvider has it enabled and in general everyone should add root NS
+  * YamlProvider has it enabled and in general everyone should add root NS
      records that match what is in their provider(s) as of this release if they
      aren't already there.
-   * Other providers will add root NS support over time following this release
+  * Other providers will add root NS support over time following this release
      once they have had the chance to investigate the functionality and
      implement management if possible with whatever accomidations are required.
-   * Watch your providers README.md and CHANGELOG.md for support and more
+  * Watch your providers README.md and CHANGELOG.md for support and more
      information.
-   * Root NS record changes will always require `--force` indicating that they
+  * Root NS record changes will always require `--force` indicating that they
      are impactful changes that need a careful :eyes:
 
 ### Stuff
@@ -429,32 +458,32 @@ long (years) overdue.
 ### Noteworthy changes
 
 * Providers extracted from octoDNS core into individual repos
-  https://github.com/octodns/octodns/issues/622 &
-  https://github.com/octodns/octodns/pull/822 for more information.
-   * [AzureProvider](https://github.com/octodns/octodns-azure/)
-   * [AkamaiProvider](https://github.com/octodns/octodns-edgedns/)
-   * [CloudflareProvider](https://github.com/octodns/octodns-cloudflare/)
-   * [ConstellixProvider](https://github.com/octodns/octodns-constellix/)
-   * [DigitalOceanProvider](https://github.com/octodns/octodns-digitalocean/)
-   * [DnsimpleProvider](https://github.com/octodns/octodns-dnsimple/)
-   * [DnsMadeEasyProvider](https://github.com/octodns/octodns-dnsmadeeasy/)
-   * [DynProvider](https://github.com/octodns/octodns-dynprovider/)
-   * [EasyDnsProvider](https://github.com/octodns/octodns-easydns/)
-   * [EtcHostsProvider](https://github.com/octodns/octodns-etchosts/)
-   * [GandiProvider](https://github.com/octodns/octodns-gandi/)
-   * [GcoreProvider](https://github.com/octodns/octodns-gcore/)
-   * [GoogleCloudProvider](https://github.com/octodns/octodns-googlecloud/)
-   * [HetznerProvider](https://github.com/octodns/octodns-hetzner/)
-   * [MythicBeastsProvider](https://github.com/octodns/octodns-mythicbeasts/)
-   * [Ns1Provider](https://github.com/octodns/octodns-ns1/)
-   * [OvhProvider](https://github.com/octodns/octodns-ovh/)
-   * [PowerDnsProvider](https://github.com/octodns/octodns-powerdns/)
-   * [RackspaceProvider](https://github.com/octodns/octodns-rackspace/)
-   * [Route53Provider](https://github.com/octodns/octodns-route53/) also
+  <https://github.com/octodns/octodns/issues/622> &
+  <https://github.com/octodns/octodns/pull/822> for more information.
+  * [AzureProvider](https://github.com/octodns/octodns-azure/)
+  * [AkamaiProvider](https://github.com/octodns/octodns-edgedns/)
+  * [CloudflareProvider](https://github.com/octodns/octodns-cloudflare/)
+  * [ConstellixProvider](https://github.com/octodns/octodns-constellix/)
+  * [DigitalOceanProvider](https://github.com/octodns/octodns-digitalocean/)
+  * [DnsimpleProvider](https://github.com/octodns/octodns-dnsimple/)
+  * [DnsMadeEasyProvider](https://github.com/octodns/octodns-dnsmadeeasy/)
+  * [DynProvider](https://github.com/octodns/octodns-dynprovider/)
+  * [EasyDnsProvider](https://github.com/octodns/octodns-easydns/)
+  * [EtcHostsProvider](https://github.com/octodns/octodns-etchosts/)
+  * [GandiProvider](https://github.com/octodns/octodns-gandi/)
+  * [GcoreProvider](https://github.com/octodns/octodns-gcore/)
+  * [GoogleCloudProvider](https://github.com/octodns/octodns-googlecloud/)
+  * [HetznerProvider](https://github.com/octodns/octodns-hetzner/)
+  * [MythicBeastsProvider](https://github.com/octodns/octodns-mythicbeasts/)
+  * [Ns1Provider](https://github.com/octodns/octodns-ns1/)
+  * [OvhProvider](https://github.com/octodns/octodns-ovh/)
+  * [PowerDnsProvider](https://github.com/octodns/octodns-powerdns/)
+  * [RackspaceProvider](https://github.com/octodns/octodns-rackspace/)
+  * [Route53Provider](https://github.com/octodns/octodns-route53/) also
      AwsAcmMangingProcessor
-   * [SelectelProvider](https://github.com/octodns/octodns-selectel/)
-   * [TransipProvider](https://github.com/octodns/octodns-transip/)
-   * [UltraDnsProvider](https://github.com/octodns/octodns-ultradns/)
+  * [SelectelProvider](https://github.com/octodns/octodns-selectel/)
+  * [TransipProvider](https://github.com/octodns/octodns-transip/)
+  * [UltraDnsProvider](https://github.com/octodns/octodns-ultradns/)
 * As part of the extraction work octoDNS's requirements (setup.py and .txt
   files) have been updated and minimized and a helper script,
   script/update-requirements has been added to help manage the txt files going
@@ -467,7 +496,7 @@ long (years) overdue.
   created or updated using this version will show an update.
 * An edge-case bug related to geo rules involving continents in NS1 provider
   has been fixed in this version. However, it will not show/fix the records that
-  match this edge-case. See https://github.com/octodns/octodns/pull/809 for
+  match this edge-case. See <https://github.com/octodns/octodns/pull/809> for
   more information. If octoDNS is downgraded from this version, any dynamic
   records created or updated using this version and matching the said edge-case
   will not be read/parsed correctly by the older version and will show a diff.
@@ -501,11 +530,11 @@ long (years) overdue.
   list. It should be safe to enable this functionality, but existing records
   will not be converted. Note: Once this option is enabled downgrades to
   previous versions of octoDNS are discouraged and may result in undefined
-  behavior and broken records. See https://github.com/octodns/octodns/pull/749
+  behavior and broken records. See <https://github.com/octodns/octodns/pull/749>
   for related discussion.
 * TransipProvider removed as it currently relies on `suds` which is broken in
   new python versions and hasn't seen a release since 2010. May return with
-  https://github.com/octodns/octodns/pull/762
+  <https://github.com/octodns/octodns/pull/762>
 
 ### Stuff
 
@@ -538,7 +567,7 @@ long (years) overdue.
   directory for examples. The change has been designed to have no impact on the
   process unless the `processors` key is present in zone configs.
 * Fixes NS1 provider's geotarget limitation of using `NA` continent. Now, when
-  `NA` is used in geos it considers **all** the countries of `North America`
+  `NA` is used in geos it considers __all__ the countries of `North America`
   instead of just `us-east`, `us-west` and `us-central` regions
 * `SX' &amp; 'UM` country support added to NS1Provider, not yet in the North
    America list for backwards compatibility reasons. They will be added in the
@@ -623,28 +652,28 @@ long (years) overdue.
 ## v0.9.9 - 2019-11-04 - Python 3.7 Support
 
 * Extensive pass through the whole codebase to support Python 3
-   * Tons of updates to replace `def __cmp__` with `__eq__` and friends to
+  * Tons of updates to replace `def __cmp__` with `__eq__` and friends to
      preserve custom equality and ordering behaviors that are essential to
      octoDNS's processes.
-   * Quite a few objects required the addition of `__eq__` and friends so that
+  * Quite a few objects required the addition of `__eq__` and friends so that
      they're sortable in Python 3 now that those things are more strict. A few
      places this required jumping through hoops of sorts. Thankfully our tests
      are pretty thorough and caught a lot of issues and hopefully the whole
      plan, review, apply process will backstop that.
-   * Explicit ordering of changes by (name, type) to address inconsistent
+  * Explicit ordering of changes by (name, type) to address inconsistent
      ordering for a number of providers that just convert changes into API
      calls as they come. Python 2 sets ordered consistently, Python 3 they do
-     not. https://github.com/octodns/octodns/pull/384/commits/7958233fccf9ea22d95e2fd06c48d7d0a4529e26
-   * Route53 `_mod_keyer` ordering wasn't 100% complete and thus unreliable and
+     not. <https://github.com/octodns/octodns/pull/384/commits/7958233fccf9ea22d95e2fd06c48d7d0a4529e26>
+  * Route53 `_mod_keyer` ordering wasn't 100% complete and thus unreliable and
      random in Python 3. This has been addressed and may result in value
      reordering on next plan, no actual changes in behavior should occur.
-   * `incf.countryutils` (in pypi) was last released in 2009 is not python 3
+  * `incf.countryutils` (in pypi) was last released in 2009 is not python 3
      compatible (it's country data is also pretty stale.) `pycountry_convert`
      appears to have the functionality required to replace its usage so it has
      been removed as a dependency/requirement.
-   * Bunch of additional unit tests and supporting config to exercise new code
+  * Bunch of additional unit tests and supporting config to exercise new code
      and verify things that were run into during the Python 3 work
-   * lots of `six`ing of things
+  * lots of `six`ing of things
 * Validate Record name & fqdn length
 
 ## v0.9.8 - 2019-09-30 - One with no changes b/c PyPi description problems
@@ -771,7 +800,7 @@ all health checks are passing before the first sync with `--doit`. See
 
 Adds an OVH provider.
 
-## v0.8.6 - 2017-09-06 - CAA record type,
+## v0.8.6 - 2017-09-06 - CAA record type
 
 Misc fixes and improvements.
 
@@ -799,7 +828,7 @@ from our OSS users. There's too much to list out since the previous release was
 cut, but I'll try to cover the highlights/important bits and promise to do
 better in the future :fingers_crossed:
 
-### Major:
+### Major
 
 * Complete rework of record validation with lenient mode support added to
   octodns-dump so that data with validation problems can be dumped to config

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.16.0'
+__version__ = __VERSION__ = '1.17.0'


### PR DESCRIPTION
## 1.17.0 - 2026-05-06 - Now with more validation

Minor:

* Add JSON Schema for the main config file and publish it alongside the renamed zone schema (octodns-zone.schema.json); octodns.schema.json remains as a legacy alias. - [#1393](https://github.com/octodns/octodns/pull/1393)
* Validators Next - See documentation for a more cohesive picture of the new/improved functionality
  * Introduce RecordValidator/ValueValidator base classes, laying groundwork for extensible record and value validations. Overriding `validate` on a `Record` subclass or defining a `validate` classmethod on a value class is DEPRECATED; declare validators via the `VALIDATORS` class attribute instead. Will be removed in 2.0. - [#1378](https://github.com/octodns/octodns/pull/1378)
  * Dynamic validator registration and config-driven management - [#1380](https://github.com/octodns/octodns/pull/1380)
  * Add best-practice validators for SSHFP, DS, TLSA, and CAA record types - [#1391](https://github.com/octodns/octodns/pull/1391)
  * Add new strict validators set and include existing rfc-compliant validators in it - [#1390](https://github.com/octodns/octodns/pull/1390)
  * Add named validator sets (legacy, rfc, etc.) and manager.enabled config key to opt into curated bundles - [#1387](https://github.com/octodns/octodns/pull/1387)
  * Validate SSHFP fingerprint length matches fingerprint_type - [#1372](https://github.com/octodns/octodns/pull/1372)
  * Add opt-in strict SRV validators per RFC 2782 and RFC 6335 (`SrvNameRfcValidator` / `srv-name-rfc`, `SrvValueRfcValidator` / `srv-value-rfc`). Establishes the `RfcValidator` / `BpValidator` naming convention to distinguish RFC-mandated checks from best-practice ones. - [#1379](https://github.com/octodns/octodns/pull/1379)
* Add `ignore_subzone_adds` zone option to silently drop records overlapping a configured sub-zone - [#1381](https://github.com/octodns/octodns/pull/1381)
* Normalize hex data fields (TLSA certificate_association_data, SSHFP fingerprint, DS digest) to lowercase for case-insensitive comparison - [#1389](https://github.com/octodns/octodns/pull/1389)
* Add REFERENCES tuple to Zone and each Record type pointing to the RFCs (and for ALIAS an IETF draft) that define them - [#1377](https://github.com/octodns/octodns/pull/1377)
* JSON schema file generation - [#1373](https://github.com/octodns/octodns/pull/1373)

Patch:

* Register UriRecord and UriValue - [#1374](https://github.com/octodns/octodns/pull/1374)