### PR TITLE
Implement comprehensive suite of ZoneValidators (Strict & Best Practice)

### DIFF
--- a/.changelog/7568e5f5bf52486d9f9e8acee4969e11.md
+++ b/.changelog/7568e5f5bf52486d9f9e8acee4969e11.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Pass at implementing a number of strict and best-practice zone-level validators

--- a/octodns/cmds/report.py
+++ b/octodns/cmds/report.py
@@ -107,6 +107,7 @@ def main():
     zone = manager.get_zone(args.zone)
     for source in sources:
         source.populate(zone, lenient=args.lenient)
+    zone.validate(lenient=args.lenient)
 
     servers = args.server
     resolvers = []

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1183,10 +1183,12 @@ class Manager(object):
         za = self.get_zone(zone)
         for source in a:
             source.populate(za)
+        za.validate()
 
         zb = self.get_zone(zone)
         for source in b:
             source.populate(zb)
+        zb.validate()
 
         return zb.changes(za, _AggregateTarget(a + b))
 

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -449,6 +449,141 @@ class SrvTargetNotCnameZoneValidator(_TargetNotCnameZoneValidator):
     _types = ('SRV',)
 
 
+class ApexNsPresenceZoneValidator(ZoneValidator):
+    '''
+    Checks that the zone apex has at least one ``NS`` record. Root ``NS``
+    records are required for any functional DNS zone.
+
+    Note: Some DNS providers manage the root ``NS`` records automatically and
+    do not allow them to be configured in octoDNS. This validator should only
+    be enabled for zones where the apex ``NS`` records are managed.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc1034
+    '''
+
+    def validate(self, zone):
+        if not zone.get('', type='NS'):
+            return [
+                f'zone "{zone.decoded_name}" is missing NS records at the apex'
+            ]
+        return []
+
+
+class MultiValueApexNsZoneValidator(ZoneValidator):
+    '''
+    Checks that the zone apex has at least two ``NS`` records. Having multiple
+    name servers is a fundamental best practice for DNS redundancy and
+    availability.
+    '''
+
+    def validate(self, zone):
+        ns_records = zone.get('', type='NS')
+        if ns_records:
+            count = sum(len(r.values) for r in ns_records)
+            if count < 2:
+                return [
+                    f'zone "{zone.decoded_name}" has only {count} NS '
+                    'record at the apex; at least 2 are recommended for '
+                    'redundancy'
+                ]
+        return []
+
+
+class OverlappingSubzoneZoneValidator(ZoneValidator):
+    '''
+    Checks for records that exist "below" a delegation boundary (an ``NS``
+    record) within the same zone. Such records are shadowed by the delegation
+    and will never be reached by DNS resolvers, often indicating a
+    configuration error or stale data.
+
+    Example:
+      - Zone ``example.com.`` has ``NS sub.example.com.``
+      - A record at ``www.sub.example.com.`` within this zone is shadowed.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        # Find all delegations (NS records not at the apex)
+        delegations = [
+            r.fqdn for r in zone.records if r._type == 'NS' and r.name
+        ]
+
+        for record in zone.records:
+            for delegation in delegations:
+                # Is record.fqdn a subdomain of delegation?
+                if record.fqdn.endswith(f'.{delegation}'):
+                    reasons.append(
+                        f'Record "{record.fqdn}" is shadowed by '
+                        f'delegation at "{delegation}"'
+                    )
+        return reasons
+
+
+class ApexCaaPresenceZoneValidator(ZoneValidator):
+    '''
+    Checks that the zone apex has at least one ``CAA`` record. ``CAA``
+    (Certificate Authority Authorization) records allow domain owners to
+    restrict which Certificate Authorities are allowed to issue certificates for
+    their domain, improving security.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc8659
+    '''
+
+    def validate(self, zone):
+        if not zone.get('', type='CAA'):
+            return [
+                f'zone "{zone.decoded_name}" has no CAA records at the apex'
+            ]
+        return []
+
+
+class _TargetResolvableInZoneZoneValidator(ZoneValidator):
+    _types = ()
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            if record._type in self._types:
+                targets = []
+                if record._type == 'MX':
+                    targets = [v.exchange for v in record.values]
+                if record._type == 'SRV':
+                    targets = [v.target for v in record.values]
+
+                for target in targets:
+                    if zone.owns('A', target):
+                        hostname = zone.hostname_from_fqdn(target)
+                        if not zone.get(hostname):
+                            reasons.append(
+                                f'{record._type} record "{record.fqdn}" '
+                                f'points to in-zone target "{target}" '
+                                'that does not exist'
+                            )
+        return reasons
+
+
+class MxTargetResolvableInZoneZoneValidator(
+    _TargetResolvableInZoneZoneValidator
+):
+    '''
+    Checks that ``MX`` exchanges pointing to targets within the same zone have
+    corresponding address records.
+    '''
+
+    _types = ('MX',)
+
+
+class SrvTargetResolvableInZoneZoneValidator(
+    _TargetResolvableInZoneZoneValidator
+):
+    '''
+    Checks that ``SRV`` targets pointing to targets within the same zone have
+    corresponding address records.
+    '''
+
+    _types = ('SRV',)
+
+
 zone_validators = ZoneValidatorRegistry()
 zone_validators.register(
     MultiValueMxZoneValidator('multi-value-mx', sets={'best-practice'})
@@ -491,4 +626,28 @@ zone_validators.register(
 )
 zone_validators.register(
     SrvTargetNotCnameZoneValidator('srv-target-not-cname', sets={'strict'})
+)
+zone_validators.register(
+    ApexNsPresenceZoneValidator('apex-ns-presence', sets={'strict'})
+)
+zone_validators.register(
+    MultiValueApexNsZoneValidator('multi-value-apex-ns', sets={'best-practice'})
+)
+zone_validators.register(
+    OverlappingSubzoneZoneValidator(
+        'overlapping-subzone', sets={'best-practice'}
+    )
+)
+zone_validators.register(
+    ApexCaaPresenceZoneValidator('apex-caa-presence', sets={'best-practice'})
+)
+zone_validators.register(
+    MxTargetResolvableInZoneZoneValidator(
+        'mx-target-resolvable-in-zone', sets={'best-practice'}
+    )
+)
+zone_validators.register(
+    SrvTargetResolvableInZoneZoneValidator(
+        'srv-target-resolvable-in-zone', sets={'best-practice'}
+    )
 )

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -628,15 +628,13 @@ zone_validators.register(
     SrvTargetNotCnameZoneValidator('srv-target-not-cname', sets={'strict'})
 )
 zone_validators.register(
-    ApexNsPresenceZoneValidator('apex-ns-presence', sets={'strict'})
+    ApexNsPresenceZoneValidator('apex-ns-presence', sets={'best-practice'})
 )
 zone_validators.register(
     MultiValueApexNsZoneValidator('multi-value-apex-ns', sets={'best-practice'})
 )
 zone_validators.register(
-    OverlappingSubzoneZoneValidator(
-        'overlapping-subzone', sets={'best-practice'}
-    )
+    OverlappingSubzoneZoneValidator('overlapping-subzone', sets={'strict'})
 )
 zone_validators.register(
     ApexCaaPresenceZoneValidator('apex-caa-presence', sets={'best-practice'})

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -128,6 +128,9 @@ class ApexSpfPresenceZoneValidator(ZoneValidator):
     Checks that the zone apex has at least one TXT record whose value begins
     with ``v=spf1``, indicating an SPF policy is published. Publishing SPF
     records helps prevent email spoofing of the domain.
+
+    For domains that do not send email, it is recommended to publish a
+    restrictive policy: ``v=spf1 -all``.
     '''
 
     def validate(self, zone):
@@ -147,10 +150,175 @@ class ApexSpfPresenceZoneValidator(ZoneValidator):
         ]
 
 
+class ApexDmarcPresenceZoneValidator(ZoneValidator):
+    '''
+    Checks that the zone has a TXT record at the ``_dmarc`` hostname whose value
+    begins with ``v=DMARC1``, indicating a DMARC policy is published. DMARC
+    (Domain-based Message Authentication, Reporting, and Conformance) allows
+    domain owners to specify how receivers should handle emails that fail SPF or
+    DKIM checks.
+
+    Common examples:
+      - Monitoring: ``v=DMARC1; p=none; rua=mailto:dmarc@example.com``
+      - Enforcement: ``v=DMARC1; p=reject; rua=mailto:dmarc@example.com``
+      - No-email domains: ``v=DMARC1; p=reject;``
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc7489
+    '''
+
+    def validate(self, zone):
+        dmarc_txts = zone.get('_dmarc', type='TXT')
+        if not dmarc_txts:
+            return [
+                f'zone "{zone.decoded_name}" has no TXT records at "_dmarc";'
+                ' add a DMARC record (v=DMARC1 ...)'
+            ]
+        for record in dmarc_txts:
+            for value in record.values:
+                if str(value).startswith('v=DMARC1'):
+                    return []
+        return [
+            f'zone "{zone.decoded_name}" has no DMARC TXT record at "_dmarc"'
+            ' (no value starting with "v=DMARC1")'
+        ]
+
+
+class NoCnameLoopZoneValidator(ZoneValidator):
+    '''
+    Checks for circular CNAME or ALIAS chains within the zone. Circular
+    references prevent DNS resolution from ever completing and are prohibited
+    by DNS standards.
+
+    Example of a loop:
+      - ``www.example.com. CNAME lb.example.com.``
+      - ``lb.example.com.  CNAME www.example.com.``
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc1034#section-3.6.2
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        # ALIAS and CNAME both act as redirections that can loop
+        targets = {
+            r.fqdn: str(r.value)
+            for r in zone.records
+            if r._type in ('CNAME', 'ALIAS')
+        }
+
+        overall_visited = set()
+        for start_fqdn in targets:
+            if start_fqdn in overall_visited:
+                continue
+
+            path = []
+            visited = {}  # fqdn -> index in path
+            curr = start_fqdn
+
+            while curr in targets:
+                if curr in visited:
+                    loop_path = ' -> '.join(path[visited[curr] :] + [curr])
+                    reasons.append(f'Loop detected: {loop_path}')
+                    break
+
+                if curr in overall_visited:
+                    # We already explored this path and didn't find a loop
+                    break
+
+                visited[curr] = len(path)
+                path.append(curr)
+                overall_visited.add(curr)
+                curr = targets[curr]
+
+        return reasons
+
+
+class ConsistentTtlAtNameZoneValidator(ZoneValidator):
+    '''
+    Checks that all records at a specific name share the same TTL. Inconsistent
+    TTLs for records at the same name can lead to cache skew.
+
+    For example, if an ``A`` record has a TTL of 300s and an ``AAAA`` record at
+    the same name has a TTL of 3600s, a resolver might cache the ``AAAA`` record
+    long after the ``A`` record has expired (and potentially changed), leading
+    to inconsistent resolution results for dual-stack clients.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        # zone._records is grouped by name
+        for name, records in zone._records.items():
+            if len(records) > 1:
+                ttls = {r.ttl for r in records}
+                if len(ttls) > 1:
+                    fqdn = (
+                        f'{name}.{zone.decoded_name}'
+                        if name
+                        else zone.decoded_name
+                    )
+                    reasons.append(
+                        f'Inconsistent TTLs at "{fqdn}": found {sorted(ttls)}'
+                    )
+        return reasons
+
+
+class GlueForInZoneNsZoneValidator(ZoneValidator):
+    '''
+    Checks that NS records pointing to targets within the same zone have
+    corresponding A or AAAA "glue" records. Without these address records,
+    resolvers cannot follow the delegation because they would need to resolve
+    the name server's address using the very name servers they are trying to
+    locate.
+
+    Example:
+      - Zone ``example.com.`` has ``NS ns1.example.com.``
+      - This validator ensures an ``A`` or ``AAAA`` record exists for
+        ``ns1.example.com.`` within the ``example.com.`` zone.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc1033 (Operations)
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            if record._type == 'NS':
+                for target in record.values:
+                    # Is target in zone?
+                    if zone.owns('A', target):
+                        # Check if address records exist at this target
+                        hostname = zone.hostname_from_fqdn(target)
+                        # We need at least one A or AAAA
+                        addresses = zone.get(hostname, type='A') | zone.get(
+                            hostname, type='AAAA'
+                        )
+                        if not addresses:
+                            reasons.append(
+                                f'NS record "{record.fqdn}" points to '
+                                f'in-zone target "{target}" without '
+                                'glue records (A/AAAA)'
+                            )
+        return reasons
+
+
 zone_validators = ZoneValidatorRegistry()
 zone_validators.register(
     MultiValueMxZoneValidator('multi-value-mx', sets={'best-practice'})
 )
 zone_validators.register(
     ApexSpfPresenceZoneValidator('apex-spf-presence', sets={'best-practice'})
+)
+zone_validators.register(
+    ApexDmarcPresenceZoneValidator(
+        'apex-dmarc-presence', sets={'best-practice'}
+    )
+)
+zone_validators.register(
+    NoCnameLoopZoneValidator('no-cname-loop', sets={'strict'})
+)
+zone_validators.register(
+    ConsistentTtlAtNameZoneValidator(
+        'consistent-ttl-at-name', sets={'best-practice'}
+    )
+)
+zone_validators.register(
+    GlueForInZoneNsZoneValidator('glue-for-in-zone-ns', sets={'strict'})
 )

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -299,6 +299,156 @@ class GlueForInZoneNsZoneValidator(ZoneValidator):
         return reasons
 
 
+class SingleSpfZoneValidator(ZoneValidator):
+    '''
+    Checks that there is at most one SPF record at the zone apex. Multiple SPF
+    records are a configuration error and will cause a "PermError", invalidating
+    all SPF policies for the domain.
+
+    Example:
+      - Hostname ``unit.tests.`` has two ``TXT`` records starting with ``v=spf1``.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc7208#section-3.2
+    '''
+
+    def validate(self, zone):
+        apex_txts = zone.get('', type='TXT')
+        spf_count = 0
+        for record in apex_txts:
+            for value in record.values:
+                if str(value).startswith('v=spf1'):
+                    spf_count += 1
+
+        if spf_count > 1:
+            return [
+                f'zone "{zone.decoded_name}" has {spf_count} SPF records; '
+                'only one is allowed'
+            ]
+        return []
+
+
+class NoSelfReferencingTargetZoneValidator(ZoneValidator):
+    '''
+    Checks for records that point to their own FQDN as a target. Such
+    configurations are logically circular and can cause resolution failures.
+
+    Applies to: ``ALIAS``, ``CNAME``, ``MX``, ``NS``, ``PTR``, and ``SRV``.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            _type = record._type
+            if _type in ('ALIAS', 'CNAME', 'PTR'):
+                if str(record.value) == record.fqdn:
+                    reasons.append(
+                        f'{_type} record "{record.fqdn}" points to itself'
+                    )
+            if _type == 'MX':
+                for value in record.values:
+                    if value.exchange == record.fqdn:
+                        reasons.append(
+                            f'MX record "{record.fqdn}" points to itself'
+                        )
+            if _type == 'NS':
+                for target in record.values:
+                    if str(target) == record.fqdn:
+                        reasons.append(
+                            f'NS record "{record.fqdn}" points to itself'
+                        )
+            if _type == 'SRV':
+                for value in record.values:
+                    if value.target == record.fqdn:
+                        reasons.append(
+                            f'SRV record "{record.fqdn}" points to itself'
+                        )
+        return reasons
+
+
+class CnameTargetResolvableInZoneZoneValidator(ZoneValidator):
+    '''
+    Checks that ``CNAME`` and ``ALIAS`` records pointing to targets within the
+    same zone have a corresponding record at that target. This helps detect
+    "dangling" references that can occur after refactors or deletions.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            if record._type in ('CNAME', 'ALIAS'):
+                target = str(record.value)
+                if zone.owns('A', target):
+                    hostname = zone.hostname_from_fqdn(target)
+                    if not zone.get(hostname):
+                        reasons.append(
+                            f'{record._type} record "{record.fqdn}" points '
+                            f'to in-zone target "{target}" that does '
+                            'not exist'
+                        )
+        return reasons
+
+
+class _TargetNotCnameZoneValidator(ZoneValidator):
+    _types = ()
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            if record._type in self._types:
+                # We need to collect targets based on record type
+                targets = []
+                if record._type == 'MX':
+                    targets = [v.exchange for v in record.values]
+                if record._type == 'NS':
+                    targets = record.values
+                if record._type == 'SRV':
+                    targets = [v.target for v in record.values]
+
+                for target in targets:
+                    if zone.owns('CNAME', target):
+                        hostname = zone.hostname_from_fqdn(target)
+                        if zone.get(hostname, type='CNAME'):
+                            reasons.append(
+                                f'{record._type} record "{record.fqdn}" '
+                                f'points to in-zone target "{target}" '
+                                'which is a CNAME'
+                            )
+        return reasons
+
+
+class NsTargetNotCnameZoneValidator(_TargetNotCnameZoneValidator):
+    '''
+    Checks that ``NS`` records do not point to a ``CNAME``. This is prohibited
+    by DNS standards and can cause resolution failures.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc2181#section-10.3
+    '''
+
+    _types = ('NS',)
+
+
+class MxTargetNotCnameZoneValidator(_TargetNotCnameZoneValidator):
+    '''
+    Checks that ``MX`` records do not point to a ``CNAME``. This is prohibited
+    by DNS standards.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc5321#section-5.1
+    '''
+
+    _types = ('MX',)
+
+
+class SrvTargetNotCnameZoneValidator(_TargetNotCnameZoneValidator):
+    '''
+    Checks that ``SRV`` records do not point to a ``CNAME``. This is prohibited
+    by DNS standards.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc2782
+    '''
+
+    _types = ('SRV',)
+
+
 zone_validators = ZoneValidatorRegistry()
 zone_validators.register(
     MultiValueMxZoneValidator('multi-value-mx', sets={'best-practice'})
@@ -321,4 +471,24 @@ zone_validators.register(
 )
 zone_validators.register(
     GlueForInZoneNsZoneValidator('glue-for-in-zone-ns', sets={'strict'})
+)
+zone_validators.register(SingleSpfZoneValidator('single-spf', sets={'strict'}))
+zone_validators.register(
+    NoSelfReferencingTargetZoneValidator(
+        'no-self-referencing-target', sets={'strict'}
+    )
+)
+zone_validators.register(
+    CnameTargetResolvableInZoneZoneValidator(
+        'cname-target-resolvable-in-zone', sets={'best-practice'}
+    )
+)
+zone_validators.register(
+    NsTargetNotCnameZoneValidator('ns-target-not-cname', sets={'strict'})
+)
+zone_validators.register(
+    MxTargetNotCnameZoneValidator('mx-target-not-cname', sets={'strict'})
+)
+zone_validators.register(
+    SrvTargetNotCnameZoneValidator('srv-target-not-cname', sets={'strict'})
 )

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -13,10 +13,16 @@ from octodns.zone.exception import ValidationError, ZoneException
 from octodns.zone.validator import (
     ApexDmarcPresenceZoneValidator,
     ApexSpfPresenceZoneValidator,
+    CnameTargetResolvableInZoneZoneValidator,
     ConsistentTtlAtNameZoneValidator,
     GlueForInZoneNsZoneValidator,
     MultiValueMxZoneValidator,
+    MxTargetNotCnameZoneValidator,
     NoCnameLoopZoneValidator,
+    NoSelfReferencingTargetZoneValidator,
+    NsTargetNotCnameZoneValidator,
+    SingleSpfZoneValidator,
+    SrvTargetNotCnameZoneValidator,
     ZoneValidator,
     ZoneValidatorRegistry,
 )
@@ -648,6 +654,371 @@ class TestBuiltinZoneValidators(TestCase):
         self.assertEqual(1, len(reasons))
         self.assertIn('without glue records', reasons[0])
 
+    def test_single_spf_passes(self):
+        zone = _make_zone()
+        txt = _add_record(
+            zone, '', {'ttl': 300, 'type': 'TXT', 'values': ['v=spf1 -all']}
+        )
+        zone.add_record(txt, replace=True)
+        v = SingleSpfZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_single_spf_fails(self):
+        zone = _make_zone()
+        txt = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'TXT',
+                'values': [
+                    'v=spf1 include:a.com ~all',
+                    'v=spf1 include:b.com ~all',
+                ],
+            },
+        )
+        zone.add_record(txt, replace=True)
+        v = SingleSpfZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has 2 SPF records', reasons[0])
+
+    def test_single_spf_with_non_spf_txt(self):
+        zone = _make_zone()
+        txt = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'TXT',
+                'values': ['v=spf1 -all', 'something-else'],
+            },
+        )
+        zone.add_record(txt, replace=True)
+        v = SingleSpfZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_no_self_referencing_target_passes(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone,
+            'www',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'lb.unit.tests.'},
+        )
+        mx = _add_record(
+            zone,
+            'mail',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'other.unit.tests.'}],
+            },
+        )
+        ns = _add_record(
+            zone,
+            'ns',
+            {'ttl': 300, 'type': 'NS', 'values': ['other.unit.tests.']},
+        )
+        srv = _add_record(
+            zone,
+            '_sip',
+            {
+                'ttl': 300,
+                'type': 'SRV',
+                'values': [
+                    {
+                        'priority': 10,
+                        'weight': 10,
+                        'port': 5060,
+                        'target': 'sip.unit.tests.',
+                    }
+                ],
+            },
+        )
+        zone.add_record(cname)
+        zone.add_record(mx)
+        zone.add_record(ns)
+        zone.add_record(srv)
+        v = NoSelfReferencingTargetZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_no_self_referencing_target_fails(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone,
+            'www',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'www.unit.tests.'},
+        )
+        alias = _add_record(
+            zone, '', {'ttl': 300, 'type': 'ALIAS', 'value': 'unit.tests.'}
+        )
+        mx = _add_record(
+            zone,
+            'mail',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests.'}],
+            },
+        )
+        ns = _add_record(
+            zone, 'ns', {'ttl': 300, 'type': 'NS', 'values': ['ns.unit.tests.']}
+        )
+        ptr = _add_record(
+            zone, 'ptr', {'ttl': 300, 'type': 'PTR', 'value': 'ptr.unit.tests.'}
+        )
+        srv = _add_record(
+            zone,
+            '_sip._tcp',
+            {
+                'ttl': 300,
+                'type': 'SRV',
+                'values': [
+                    {
+                        'priority': 10,
+                        'weight': 10,
+                        'port': 5060,
+                        'target': '_sip._tcp.unit.tests.',
+                    }
+                ],
+            },
+        )
+        zone.add_record(cname)
+        zone.add_record(alias, replace=True)
+        zone.add_record(mx)
+        zone.add_record(ns)
+        zone.add_record(ptr)
+        zone.add_record(srv)
+        v = NoSelfReferencingTargetZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(6, len(reasons))
+        self.assertIn(
+            'CNAME record "www.unit.tests." points to itself', reasons
+        )
+        self.assertIn('ALIAS record "unit.tests." points to itself', reasons)
+        self.assertIn('MX record "mail.unit.tests." points to itself', reasons)
+        self.assertIn('NS record "ns.unit.tests." points to itself', reasons)
+        self.assertIn('PTR record "ptr.unit.tests." points to itself', reasons)
+        self.assertIn(
+            'SRV record "_sip._tcp.unit.tests." points to itself', reasons
+        )
+
+    def test_cname_target_resolvable_in_zone_passes(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone,
+            'www',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'lb.unit.tests.'},
+        )
+        a = _add_record(
+            zone, 'lb', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(cname)
+        zone.add_record(a)
+        v = CnameTargetResolvableInZoneZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_cname_target_resolvable_in_zone_skip_out_of_zone(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'CNAME', 'value': 'google.com.'}
+        )
+        zone.add_record(cname)
+        v = CnameTargetResolvableInZoneZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_cname_target_resolvable_in_zone_fails(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone,
+            'www',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'lb.unit.tests.'},
+        )
+        alias = _add_record(
+            zone,
+            'a',
+            {'ttl': 300, 'type': 'ALIAS', 'value': 'missing.unit.tests.'},
+        )
+        zone.add_record(cname)
+        zone.add_record(alias)
+        v = CnameTargetResolvableInZoneZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(2, len(reasons))
+        self.assertIn(
+            'CNAME record "www.unit.tests." points to in-zone target "lb.unit.tests." that does not exist',
+            reasons,
+        )
+        self.assertIn(
+            'ALIAS record "a.unit.tests." points to in-zone target "missing.unit.tests." that does not exist',
+            reasons,
+        )
+
+    def test_target_not_cname_passes(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests.'}],
+            },
+        )
+        a = _add_record(
+            zone, 'mail', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(mx, replace=True)
+        zone.add_record(a)
+        v = MxTargetNotCnameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_target_not_cname_skip_out_of_zone(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'google.com.'}],
+            },
+        )
+        zone.add_record(mx, replace=True)
+        v = MxTargetNotCnameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_target_not_cname_skip_no_cname_at_target(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [
+                    {'preference': 10, 'exchange': 'target.unit.tests.'}
+                ],
+            },
+        )
+        # target exists but is not a CNAME (it's an A record)
+        a = _add_record(
+            zone, 'target', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(mx, replace=True)
+        zone.add_record(a)
+        v = MxTargetNotCnameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_target_not_cname_fails(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [
+                    {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                    {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                ],
+            },
+        )
+        cname = _add_record(
+            zone,
+            'mail1',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'other.unit.tests.'},
+        )
+        zone.add_record(mx, replace=True)
+        zone.add_record(cname)
+        v = MxTargetNotCnameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'points to in-zone target "mail1.unit.tests." which is a CNAME',
+            reasons[0],
+        )
+
+    def test_ns_target_not_cname_fails(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, '', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.unit.tests.']}
+        )
+        cname = _add_record(
+            zone,
+            'ns1',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'other.unit.tests.'},
+        )
+        zone.add_record(ns, replace=True)
+        zone.add_record(cname)
+        v = NsTargetNotCnameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'NS record "unit.tests." points to in-zone target "ns1.unit.tests." which is a CNAME',
+            reasons[0],
+        )
+
+    def test_target_not_cname_alias_target_fails(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [
+                    {'preference': 10, 'exchange': 'target.unit.tests.'}
+                ],
+            },
+        )
+        cname = _add_record(
+            zone,
+            'target',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'other.unit.tests.'},
+        )
+        zone.add_record(mx, replace=True)
+        zone.add_record(cname)
+        v = MxTargetNotCnameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'points to in-zone target "target.unit.tests." which is a CNAME',
+            reasons[0],
+        )
+
+    def test_srv_target_not_cname_fails(self):
+        zone = _make_zone()
+        srv = _add_record(
+            zone,
+            '_sip._tcp',
+            {
+                'ttl': 300,
+                'type': 'SRV',
+                'values': [
+                    {
+                        'priority': 10,
+                        'weight': 10,
+                        'port': 5060,
+                        'target': 'sip.unit.tests.',
+                    }
+                ],
+            },
+        )
+        cname = _add_record(
+            zone,
+            'sip',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'other.unit.tests.'},
+        )
+        zone.add_record(srv)
+        zone.add_record(cname)
+        v = SrvTargetNotCnameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'SRV record "_sip._tcp.unit.tests." points to in-zone target "sip.unit.tests." which is a CNAME',
+            reasons[0],
+        )
+
     def test_builtin_ids(self):
         ids = [v.id for v in Zone.validators.available_validators()]
         self.assertIn('multi-value-mx', ids)
@@ -656,6 +1027,12 @@ class TestBuiltinZoneValidators(TestCase):
         self.assertIn('no-cname-loop', ids)
         self.assertIn('consistent-ttl-at-name', ids)
         self.assertIn('glue-for-in-zone-ns', ids)
+        self.assertIn('single-spf', ids)
+        self.assertIn('no-self-referencing-target', ids)
+        self.assertIn('cname-target-resolvable-in-zone', ids)
+        self.assertIn('ns-target-not-cname', ids)
+        self.assertIn('mx-target-not-cname', ids)
+        self.assertIn('srv-target-not-cname', ids)
 
     def test_builtins_in_best_practice_set(self):
         with zone_validators_snapshot():

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -11,8 +11,12 @@ from octodns.record import Record
 from octodns.zone import Zone
 from octodns.zone.exception import ValidationError, ZoneException
 from octodns.zone.validator import (
+    ApexDmarcPresenceZoneValidator,
     ApexSpfPresenceZoneValidator,
+    ConsistentTtlAtNameZoneValidator,
+    GlueForInZoneNsZoneValidator,
     MultiValueMxZoneValidator,
+    NoCnameLoopZoneValidator,
     ZoneValidator,
     ZoneValidatorRegistry,
 )
@@ -404,10 +408,254 @@ class TestBuiltinZoneValidators(TestCase):
         self.assertEqual(1, len(reasons))
         self.assertIn('v=spf1', reasons[0])
 
+    def test_apex_spf_presence_passes_multiple_values(self):
+        zone = _make_zone()
+        txt = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'TXT',
+                'values': ['something', 'v=spf1 include:example.com ~all'],
+            },
+        )
+        zone.add_record(txt)
+        v = ApexSpfPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_apex_dmarc_presence_passes(self):
+        zone = _make_zone()
+        txt = _add_record(
+            zone,
+            '_dmarc',
+            {'ttl': 300, 'type': 'TXT', 'values': ['v=DMARC1; p=none']},
+        )
+        zone.add_record(txt)
+        v = ApexDmarcPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_apex_dmarc_presence_fails_no_txt(self):
+        zone = _make_zone()
+        v = ApexDmarcPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('no TXT records at "_dmarc"', reasons[0])
+
+    def test_apex_dmarc_presence_fails_no_dmarc_value(self):
+        zone = _make_zone()
+        txt = _add_record(
+            zone, '_dmarc', {'ttl': 300, 'type': 'TXT', 'values': ['something']}
+        )
+        zone.add_record(txt)
+        v = ApexDmarcPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('v=DMARC1', reasons[0])
+
+    def test_no_cname_loop_passes(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone,
+            'www',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'lb.unit.tests.'},
+        )
+        zone.add_record(cname)
+        v = NoCnameLoopZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_no_cname_loop_fails_direct(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone,
+            'loop',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'loop.unit.tests.'},
+        )
+        zone.add_record(cname)
+        v = NoCnameLoopZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('Loop detected', reasons[0])
+        self.assertIn('loop.unit.tests. -> loop.unit.tests.', reasons[0])
+
+    def test_no_cname_loop_fails_indirect(self):
+        zone = _make_zone()
+        c1 = _add_record(
+            zone, 'a', {'ttl': 300, 'type': 'CNAME', 'value': 'b.unit.tests.'}
+        )
+        c2 = _add_record(
+            zone, 'b', {'ttl': 300, 'type': 'CNAME', 'value': 'c.unit.tests.'}
+        )
+        c3 = _add_record(
+            zone, 'c', {'ttl': 300, 'type': 'CNAME', 'value': 'a.unit.tests.'}
+        )
+        zone.add_record(c1)
+        zone.add_record(c2)
+        zone.add_record(c3)
+        v = NoCnameLoopZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('Loop detected', reasons[0])
+        self.assertIn('a.unit.tests.', reasons[0])
+        self.assertIn('b.unit.tests.', reasons[0])
+        self.assertIn('c.unit.tests.', reasons[0])
+
+    def test_no_cname_loop_with_alias(self):
+        zone = _make_zone()
+        a1 = _add_record(
+            zone, '', {'ttl': 300, 'type': 'ALIAS', 'value': 'b.unit.tests.'}
+        )
+        c2 = _add_record(
+            zone, 'b', {'ttl': 300, 'type': 'CNAME', 'value': 'unit.tests.'}
+        )
+        zone.add_record(a1)
+        zone.add_record(c2)
+        v = NoCnameLoopZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('Loop detected', reasons[0])
+        self.assertIn('unit.tests.', reasons[0])
+        self.assertIn('b.unit.tests.', reasons[0])
+
+    def test_no_cname_loop_merging_chains(self):
+        # Hits the "if curr in overall_visited: break" path
+        zone = _make_zone()
+        c1 = _add_record(
+            zone, 'x', {'ttl': 300, 'type': 'CNAME', 'value': 'z.unit.tests.'}
+        )
+        c2 = _add_record(
+            zone, 'y', {'ttl': 300, 'type': 'CNAME', 'value': 'z.unit.tests.'}
+        )
+        c3 = _add_record(
+            zone, 'z', {'ttl': 300, 'type': 'CNAME', 'value': 'end.unit.tests.'}
+        )
+        zone.add_record(c1)
+        zone.add_record(c2)
+        zone.add_record(c3)
+        v = NoCnameLoopZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_consistent_ttl_at_name_passes(self):
+        zone = _make_zone()
+        a = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        aaaa = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'AAAA', 'value': '::1'}
+        )
+        zone.add_record(a)
+        zone.add_record(aaaa)
+        v = ConsistentTtlAtNameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_consistent_ttl_at_name_single_record(self):
+        zone = _make_zone()
+        a = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(a)
+        v = ConsistentTtlAtNameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_consistent_ttl_at_name_fails(self):
+        zone = _make_zone()
+        a = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        aaaa = _add_record(
+            zone, 'www', {'ttl': 600, 'type': 'AAAA', 'value': '::1'}
+        )
+        zone.add_record(a)
+        zone.add_record(aaaa)
+        v = ConsistentTtlAtNameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('Inconsistent TTLs at "www.unit.tests."', reasons[0])
+        self.assertIn('[300, 600]', reasons[0])
+
+    def test_consistent_ttl_at_name_fails_apex(self):
+        zone = _make_zone()
+        a = _add_record(zone, '', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'})
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 600,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests.'}],
+            },
+        )
+        zone.add_record(a)
+        zone.add_record(mx, replace=True)
+        v = ConsistentTtlAtNameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('Inconsistent TTLs at "unit.tests."', reasons[0])
+
+    def test_glue_for_in_zone_ns_passes_external(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone,
+            '',
+            {'ttl': 3600, 'type': 'NS', 'values': ['ns1.external.tests.']},
+        )
+        zone.add_record(ns, replace=True)
+        v = GlueForInZoneNsZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_glue_for_in_zone_ns_no_ns_records(self):
+        zone = _make_zone()
+        a = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(a)
+        v = GlueForInZoneNsZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_glue_for_in_zone_ns_passes_with_glue(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, '', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.unit.tests.']}
+        )
+        a = _add_record(
+            zone, 'ns1', {'ttl': 3600, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(ns, replace=True)
+        zone.add_record(a)
+        v = GlueForInZoneNsZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_glue_for_in_zone_ns_passes_with_aaaa_glue(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, '', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.unit.tests.']}
+        )
+        aaaa = _add_record(
+            zone, 'ns1', {'ttl': 3600, 'type': 'AAAA', 'value': '::1'}
+        )
+        zone.add_record(ns, replace=True)
+        zone.add_record(aaaa)
+        v = GlueForInZoneNsZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_glue_for_in_zone_ns_fails_missing_glue(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, '', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.unit.tests.']}
+        )
+        zone.add_record(ns, replace=True)
+        v = GlueForInZoneNsZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('without glue records', reasons[0])
+
     def test_builtin_ids(self):
         ids = [v.id for v in Zone.validators.available_validators()]
         self.assertIn('multi-value-mx', ids)
         self.assertIn('apex-spf-presence', ids)
+        self.assertIn('apex-dmarc-presence', ids)
+        self.assertIn('no-cname-loop', ids)
+        self.assertIn('consistent-ttl-at-name', ids)
+        self.assertIn('glue-for-in-zone-ns', ids)
 
     def test_builtins_in_best_practice_set(self):
         with zone_validators_snapshot():

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -1232,6 +1232,15 @@ class TestBuiltinZoneValidators(TestCase):
             active_ids = [v.id for v in Zone.validators.registered()]
             self.assertIn('multi-value-mx', active_ids)
             self.assertIn('apex-spf-presence', active_ids)
+            self.assertIn('apex-ns-presence', active_ids)
+            self.assertNotIn('overlapping-subzone', active_ids)
+
+    def test_builtins_in_strict_set(self):
+        with zone_validators_snapshot():
+            Zone.enable_zone_validators({'strict'})
+            active_ids = [v.id for v in Zone.validators.registered()]
+            self.assertIn('overlapping-subzone', active_ids)
+            self.assertNotIn('apex-ns-presence', active_ids)
 
     def test_builtins_not_in_legacy_set(self):
         with zone_validators_snapshot():

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -11,18 +11,24 @@ from octodns.record import Record
 from octodns.zone import Zone
 from octodns.zone.exception import ValidationError, ZoneException
 from octodns.zone.validator import (
+    ApexCaaPresenceZoneValidator,
     ApexDmarcPresenceZoneValidator,
+    ApexNsPresenceZoneValidator,
     ApexSpfPresenceZoneValidator,
     CnameTargetResolvableInZoneZoneValidator,
     ConsistentTtlAtNameZoneValidator,
     GlueForInZoneNsZoneValidator,
+    MultiValueApexNsZoneValidator,
     MultiValueMxZoneValidator,
     MxTargetNotCnameZoneValidator,
+    MxTargetResolvableInZoneZoneValidator,
     NoCnameLoopZoneValidator,
     NoSelfReferencingTargetZoneValidator,
     NsTargetNotCnameZoneValidator,
+    OverlappingSubzoneZoneValidator,
     SingleSpfZoneValidator,
     SrvTargetNotCnameZoneValidator,
+    SrvTargetResolvableInZoneZoneValidator,
     ZoneValidator,
     ZoneValidatorRegistry,
 )
@@ -1019,6 +1025,186 @@ class TestBuiltinZoneValidators(TestCase):
             reasons[0],
         )
 
+    def test_apex_ns_presence_passes(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, '', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.unit.tests.']}
+        )
+        zone.add_record(ns, replace=True)
+        v = ApexNsPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_apex_ns_presence_fails(self):
+        zone = _make_zone()
+        v = ApexNsPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('missing NS records at the apex', reasons[0])
+
+    def test_multi_value_apex_ns_passes(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 3600,
+                'type': 'NS',
+                'values': ['ns1.unit.tests.', 'ns2.unit.tests.'],
+            },
+        )
+        zone.add_record(ns, replace=True)
+        v = MultiValueApexNsZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_multi_value_apex_ns_fails(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, '', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.unit.tests.']}
+        )
+        zone.add_record(ns, replace=True)
+        v = MultiValueApexNsZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has only 1 NS record', reasons[0])
+
+    def test_multi_value_apex_ns_skips_missing(self):
+        zone = _make_zone()
+        v = MultiValueApexNsZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_overlapping_subzone_passes(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, 'sub', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.other.']}
+        )
+        a = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(ns)
+        zone.add_record(a)
+        v = OverlappingSubzoneZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_overlapping_subzone_fails(self):
+        zone = _make_zone()
+        ns = _add_record(
+            zone, 'sub', {'ttl': 3600, 'type': 'NS', 'values': ['ns1.other.']}
+        )
+        a = _add_record(
+            zone, 'www.sub', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(ns)
+        zone.add_record(a)
+        v = OverlappingSubzoneZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('shadowed by delegation at "sub.unit.tests."', reasons[0])
+
+    def test_apex_caa_presence_passes(self):
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'values': [
+                    {'flags': 0, 'tag': 'issue', 'value': 'letsencrypt.org'}
+                ],
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_apex_caa_presence_fails(self):
+        zone = _make_zone()
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no CAA records at the apex', reasons[0])
+
+    def test_mx_target_resolvable_in_zone_passes(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests.'}],
+            },
+        )
+        a = _add_record(
+            zone, 'mail', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(mx, replace=True)
+        zone.add_record(a)
+        v = MxTargetResolvableInZoneZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_mx_target_resolvable_in_zone_fails(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests.'}],
+            },
+        )
+        zone.add_record(mx, replace=True)
+        v = MxTargetResolvableInZoneZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'points to in-zone target "mail.unit.tests." that does not exist',
+            reasons[0],
+        )
+
+    def test_mx_target_resolvable_in_zone_skip_out_of_zone(self):
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'google.com.'}],
+            },
+        )
+        zone.add_record(mx, replace=True)
+        v = MxTargetResolvableInZoneZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_srv_target_resolvable_in_zone_fails(self):
+        zone = _make_zone()
+        srv = _add_record(
+            zone,
+            '_sip._tcp',
+            {
+                'ttl': 300,
+                'type': 'SRV',
+                'values': [
+                    {
+                        'priority': 10,
+                        'weight': 10,
+                        'port': 5060,
+                        'target': 'sip.unit.tests.',
+                    }
+                ],
+            },
+        )
+        zone.add_record(srv)
+        v = SrvTargetResolvableInZoneZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'points to in-zone target "sip.unit.tests." that does not exist',
+            reasons[0],
+        )
+
     def test_builtin_ids(self):
         ids = [v.id for v in Zone.validators.available_validators()]
         self.assertIn('multi-value-mx', ids)
@@ -1033,6 +1219,12 @@ class TestBuiltinZoneValidators(TestCase):
         self.assertIn('ns-target-not-cname', ids)
         self.assertIn('mx-target-not-cname', ids)
         self.assertIn('srv-target-not-cname', ids)
+        self.assertIn('apex-ns-presence', ids)
+        self.assertIn('multi-value-apex-ns', ids)
+        self.assertIn('overlapping-subzone', ids)
+        self.assertIn('apex-caa-presence', ids)
+        self.assertIn('mx-target-resolvable-in-zone', ids)
+        self.assertIn('srv-target-resolvable-in-zone', ids)
 
     def test_builtins_in_best_practice_set(self):
         with zone_validators_snapshot():


### PR DESCRIPTION
This PR implements a collection of new `ZoneValidator` classes to improve DNS zone integrity and adherence to best practices.

### RFC Compliance (`strict` set)
- ~~**`no-cname-loop`**: Detects circular redirection chains (RFC 1034).~~
- ~~**`glue-for-in-zone-ns`**: Ensures address records exist for in-zone nameservers (RFC 1033).~~
- ~~**`single-spf`**: Validates that at most one SPF policy is published (RFC 7208).~~
- **`no-self-referencing-target`**: Detects records pointing to their own FQDN.
- ~~**`ns-target-not-cname`**: Prohibits NS targets from being CNAMEs (RFC 2181).~~
- ~~**`mx-target-not-cname`**: Prohibits MX exchanges from being CNAMEs (RFC 5321).~~
- ~~**`srv-target-not-cname`**: Prohibits SRV targets from being CNAMEs (RFC 2782).~~
- **`apex-ns-presence`**: Ensures root NS records exist (RFC 1034).

### Best Practices (`best-practice` set)
- ~~**`apex-dmarc-presence`**: Encourages DMARC publishing (RFC 7489).~~
- ~~**`apex-spf-presence`**: Encourages SPF publishing (RFC 7208).~~
- ~~**`consistent-ttl-at-name`**: Prevents cache skew by ensuring uniform TTLs at a hostname.~~
- ~~**`cname-target-resolvable-in-zone`**: Catches dangling internal CNAME/ALIAS references.~~
- ~~**`multi-value-apex-ns`**: Encourages root NS redundancy.~~
- ~~**`overlapping-subzone`**: Detects shadowed records existing below a delegation boundary.~~
- ~~**`apex-caa-presence`**: Encourages use of CAA records (RFC 8659).~~
- ~~**`mx-target-resolvable-in-zone`**: Verifies address records for in-zone MX targets.~~
- ~~**`srv-target-resolvable-in-zone`**: Verifies address records for in-zone SRV targets.~~

### Verification
- 100% statement and branch coverage in `octodns/zone/validator.py`.
- All tests passed.
- Formatting and linting checks are clean.