### PR TITLE
Migrate CNAME coexistence check to CnameCoexistenceValidator and sub-zone check to SubzoneRecordValidator

### DIFF
--- a/.changelog/0b46802c5067451c87d6260ef4f1bcab.md
+++ b/.changelog/0b46802c5067451c87d6260ef4f1bcab.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Migrate SubzoneRecordException checks to SubzoneRecordValidator

--- a/.changelog/b820442b551340f4a617f516e73263c3.md
+++ b/.changelog/b820442b551340f4a617f516e73263c3.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Migrate CNAME coexistence check to CnameCoexistenceValidator

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -5,9 +5,11 @@
 from .base import DuplicateRecordException, InvalidNameError, Zone
 from .cname import CnameCoexistenceValidator
 from .mail import MailZoneValidator
+from .subzone import SubzoneRecordValidator
 
 CnameCoexistenceValidator
 DuplicateRecordException
 InvalidNameError
 MailZoneValidator
+SubzoneRecordValidator
 Zone

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -2,18 +2,12 @@
 #
 #
 
-from .base import (
-    DuplicateRecordException,
-    InvalidNameError,
-    InvalidNodeException,
-    SubzoneRecordException,
-    Zone,
-)
+from .base import DuplicateRecordException, InvalidNameError, Zone
+from .cname import CnameCoexistenceValidator
 from .mail import MailZoneValidator
 
+CnameCoexistenceValidator
 DuplicateRecordException
 InvalidNameError
-InvalidNodeException
 MailZoneValidator
-SubzoneRecordException
 Zone

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -13,27 +13,6 @@ from .exception import ValidationError
 from .validator import ZoneValidatorRegistry
 
 
-class SubzoneRecordException(Exception):
-    '''
-    Exception raised when a record belongs in a sub-zone but is added to the parent.
-
-    This exception is raised when attempting to add a record to a zone that
-    should actually be managed in a configured sub-zone. Only NS and DS records
-    are allowed at the sub-zone boundary.
-
-    :param record: The record that caused the exception.
-    :type record: octodns.record.base.Record
-    '''
-
-    def __init__(self, msg, record):
-        self.record = record
-
-        if record.context:
-            msg += f', {record.context}'
-
-        super().__init__(msg)
-
-
 class DuplicateRecordException(Exception):
     '''
     Exception raised when attempting to add a duplicate record to a zone.
@@ -65,27 +44,6 @@ class DuplicateRecordException(Exception):
             # only new has context
             msg += f'\n  existing: [UNKNOWN]\n  new:      {new.context}'
         # else no one has context
-
-        super().__init__(msg)
-
-
-class InvalidNodeException(Exception):
-    '''
-    Exception raised when CNAME records coexist with other records at a node.
-
-    Per DNS standards, CNAME records cannot coexist with other record types
-    at the same node. This exception is raised when such an invalid
-    configuration is detected.
-
-    :param record: The record that caused the exception.
-    :type record: octodns.record.base.Record
-    '''
-
-    def __init__(self, msg, record):
-        self.record = record
-
-        if record.context:
-            msg += f', {record.context}'
 
         super().__init__(msg)
 
@@ -133,6 +91,7 @@ class Zone(object):
       zone = Zone('example.com.', [])
       record = Record.new(zone, 'www', {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'})
       zone.add_record(record)
+      zone.validate()
 
       # Create a shallow copy
       copy = zone.copy()
@@ -446,13 +405,8 @@ class Zone(object):
                         data that may not be standards-compliant.
         :type lenient: bool
 
-        :raises SubzoneRecordException: If the record belongs in a configured
-                                        sub-zone (unless it's an NS/DS record
-                                        at the boundary).
         :raises DuplicateRecordException: If a record with the same name and type
                                           already exists and ``replace=False``.
-        :raises InvalidNodeException: If adding the record would create an
-                                      invalid CNAME coexistence situation.
 
         .. important::
            - Automatically hydrates shallow copies on first modification
@@ -465,41 +419,34 @@ class Zone(object):
             self.hydrate()
 
         name = record.name
-        new_lenient = record.lenient
 
-        if name in self.sub_zones:
-            # It's an exact match for a sub-zone
-            if not (record._type == 'NS' or record._type == 'DS'):
-                # and not a NS or DS record, this should be in the sub
-                msg = f'Record {record.fqdn} is a managed sub-zone and not of type NS or DS'
-                if lenient or new_lenient:
-                    self.log.warning(msg)
-                elif self.ignore_subzone_adds:
-                    self.log.debug(f'{msg}, ignore.')
+        if self.ignore_subzone_adds and not record.lenient and not lenient:
+            if name in self.sub_zones:
+                # It's an exact match for a sub-zone
+                if record._type not in ('NS', 'DS'):
+                    # and not a NS or DS record, this should be in the sub
+                    self.log.debug(
+                        'add_record: %s is a managed sub-zone and not of type NS or DS, ignore.',
+                        record.fqdn,
+                    )
                     return
-                else:
-                    raise SubzoneRecordException(msg, record)
-        else:
-            # It's not an exact match so there has to be a `.` before the
-            # sub-zone for it to belong in there
-            for sub_zone in self.sub_zones:
-                if name.endswith(f'.{sub_zone}'):
-                    # this should be in a sub
-                    msg = f'Record {record.fqdn} is under a managed subzone'
-                    if lenient or new_lenient:
-                        self.log.warning(msg)
-                    elif self.ignore_subzone_adds:
-                        self.log.debug(f'{msg}, ignore.')
+            else:
+                # It's not an exact match so there has to be a `.` before the
+                # sub-zone for it to belong in there
+                for sub_zone in self.sub_zones:
+                    if name.endswith(f'.{sub_zone}'):
+                        # this should be in a sub
+                        self.log.debug(
+                            'add_record: %s is under a managed subzone, ignore.',
+                            record.fqdn,
+                        )
                         return
-                    else:
-                        raise SubzoneRecordException(msg, record)
 
         if replace:
             # will remove it if it exists
             self._records[name].discard(record)
 
         node = self._records[name]
-        existing_lenient = all(r.lenient for r in node)
         if record in node:
             # We already have a record at this node of this type
             existing = [c for c in node if c == record][0]
@@ -508,20 +455,6 @@ class Zone(object):
                 existing,
                 record,
             )
-        elif (record._type == 'CNAME' and len(node) > 0) or (
-            'CNAME' in [r._type for r in node]
-        ):
-            # We're adding a CNAME to existing records or adding to an existing CNAME
-            msg = f'Invalid state, CNAME at {record.fqdn} cannot coexist with other records'
-            if (
-                # add was not called with lenience
-                not lenient
-                # existing and new records aren't lenient
-                and not (existing_lenient and new_lenient)
-            ):
-                raise InvalidNodeException(msg, record)
-            else:
-                self.log.warning(msg)
 
         if record._type == 'NS' and record.name == '':
             self._root_ns = record

--- a/octodns/zone/cname.py
+++ b/octodns/zone/cname.py
@@ -1,0 +1,35 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class CnameCoexistenceValidator(ZoneValidator):
+    '''
+    Verify that CNAME records do not coexist with other records at the same
+    node.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for node in zone._records.values():
+            if len(node) > 1:
+                types = [r._type for r in node]
+                if 'CNAME' in types:
+                    # All records at this node have the same FQDN
+                    record = next(iter(node))
+                    reasons.append(
+                        ValidationReason(
+                            f'Invalid state, CNAME at {record.fqdn} cannot coexist with other records',
+                            node,
+                        )
+                    )
+
+        return reasons
+
+
+Zone.register_zone_validator(
+    CnameCoexistenceValidator('cname-coexistence', sets={'legacy', 'strict'})
+)

--- a/octodns/zone/subzone.py
+++ b/octodns/zone/subzone.py
@@ -1,0 +1,42 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class SubzoneRecordValidator(ZoneValidator):
+    '''
+    Verify that records do not overlap with managed sub-zones.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            name = record.name
+            if name in zone.sub_zones:
+                if record._type not in ('NS', 'DS'):
+                    reasons.append(
+                        ValidationReason(
+                            f'Record {record.fqdn} is a managed sub-zone and not of type NS or DS',
+                            [record],
+                        )
+                    )
+            else:
+                for sub_zone in zone.sub_zones:
+                    if name.endswith(f'.{sub_zone}'):
+                        reasons.append(
+                            ValidationReason(
+                                f'Record {record.fqdn} is under a managed subzone',
+                                [record],
+                            )
+                        )
+                        break
+
+        return reasons
+
+
+Zone.register_zone_validator(
+    SubzoneRecordValidator('subzone-record', sets={'legacy', 'strict'})
+)

--- a/tests/test_octodns_processor_trailing_dots.py
+++ b/tests/test_octodns_processor_trailing_dots.py
@@ -250,7 +250,7 @@ class EnsureTrailingDotsTest(TestCase):
         etd = EnsureTrailingDots('test')
 
         zone = Zone('unit.tests.', ['sub'])
-        # A CNAME record under a managed sub-zone would fail add_record
+        # A CNAME record under a managed sub-zone would fail validation
         # without lenient
         record = Record.new(
             zone,
@@ -260,7 +260,7 @@ class EnsureTrailingDotsTest(TestCase):
         )
         zone.add_record(record, lenient=True)
 
-        # Without lenient, this would raise SubzoneRecordException
+        # Without lenient, this would fail validation
         got = etd.process_source_zone(zone, None, lenient=True)
         self.assertEqual('relative.target.', _find(got, 'sub').value)
 

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -16,7 +16,8 @@ from octodns.provider import ProviderException
 from octodns.provider.yaml import SplitYamlProvider, YamlProvider
 from octodns.record import Create, NsValue, Record, ValuesMixin
 from octodns.record.exception import ValidationError
-from octodns.zone import SubzoneRecordException, Zone
+from octodns.zone import Zone
+from octodns.zone.exception import ValidationError as ZoneValidationError
 
 
 def touch(filename):
@@ -324,15 +325,17 @@ www:
 
         # If we add `sub` as a sub-zone we'll reject `www.sub`
         zone = Zone('unit.tests.', ['sub'])
-        with self.assertRaises(SubzoneRecordException) as ctx:
-            source.populate(zone)
+        source.populate(zone)
+        with self.assertRaises(ZoneValidationError) as ctx:
+            zone.validate()
         msg = str(ctx.exception)
-        self.assertTrue(
-            msg.startswith(
-                'Record www.sub.unit.tests. is under a managed subzone'
-            )
+        self.assertIn(
+            'Record www.sub.unit.tests. is under a managed subzone', msg
         )
         self.assertTrue(msg.endswith('unit.tests.yaml, line 201, column 3'))
+        self.assertIn('unit.tests.yaml', msg)
+        self.assertIn('line 201', msg)
+        self.assertIn('column 3', msg)
 
     def test_SUPPORTS(self):
         source = YamlProvider('test', join(dirname(__file__), 'config'))
@@ -806,15 +809,17 @@ class TestSplitYamlProvider(TestCase):
 
         # If we add `sub` as a sub-zone we'll reject `www.sub`
         zone = Zone('unit.tests.', ['sub'])
-        with self.assertRaises(SubzoneRecordException) as ctx:
-            source.populate(zone)
+        source.populate(zone)
+        with self.assertRaises(ZoneValidationError) as ctx:
+            zone.validate()
         msg = str(ctx.exception)
-        self.assertTrue(
-            msg.startswith(
-                'Record www.sub.unit.tests. is under a managed subzone'
-            )
+        self.assertIn(
+            'Record www.sub.unit.tests. is under a managed subzone', msg
         )
         self.assertTrue(msg.endswith('www.sub.yaml, line 3, column 3'))
+        self.assertIn('www.sub.yaml', msg)
+        self.assertIn('line 3', msg)
+        self.assertIn('column 3', msg)
 
     def test_copy(self):
         # going to put some sentinal values in here to ensure, these aren't

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -332,7 +332,6 @@ www:
         self.assertIn(
             'Record www.sub.unit.tests. is under a managed subzone', msg
         )
-        self.assertTrue(msg.endswith('unit.tests.yaml, line 201, column 3'))
         self.assertIn('unit.tests.yaml', msg)
         self.assertIn('line 201', msg)
         self.assertIn('column 3', msg)
@@ -816,7 +815,6 @@ class TestSplitYamlProvider(TestCase):
         self.assertIn(
             'Record www.sub.unit.tests. is under a managed subzone', msg
         )
-        self.assertTrue(msg.endswith('www.sub.yaml, line 3, column 3'))
         self.assertIn('www.sub.yaml', msg)
         self.assertIn('line 3', msg)
         self.assertIn('column 3', msg)

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -18,13 +18,8 @@ from octodns.record import (
     Record,
     Update,
 )
-from octodns.zone import (
-    DuplicateRecordException,
-    InvalidNameError,
-    InvalidNodeException,
-    SubzoneRecordException,
-    Zone,
-)
+from octodns.zone import DuplicateRecordException, InvalidNameError, Zone
+from octodns.zone.exception import ValidationError
 
 
 class TestZone(TestCase):
@@ -612,25 +607,25 @@ class TestZone(TestCase):
         )
         cname.context = 'has some context'
 
-        # add cname to a
+        # add cname to a, succeeds now
         zone.add_record(a)
-        with self.assertRaises(InvalidNodeException) as ctx:
-            zone.add_record(cname)
-        self.assertIn(', has some context', str(ctx.exception))
-        self.assertEqual(set([a]), zone.records)
-        zone.add_record(cname, lenient=True)
+        zone.add_record(cname)
         self.assertEqual(set([a, cname]), zone.records)
+        # but fails validation
+        with self.assertRaises(ValidationError) as ctx:
+            zone.validate()
+        self.assertIn('(has some context)', str(ctx.exception))
 
-        # add a to cname
+        # add a to cname, succeeds now
         zone = Zone('unit.tests.', [])
         zone.add_record(cname)
-        with self.assertRaises(InvalidNodeException):
-            zone.add_record(a)
-        self.assertEqual(set([cname]), zone.records)
-        zone.add_record(a, lenient=True)
-        self.assertEqual(set([a, cname]), zone.records)
+        zone.add_record(a)
+        self.assertEqual(set([cname, a]), zone.records)
+        # but fails validation
+        with self.assertRaises(ValidationError):
+            zone.validate()
 
-        # add cname to lenient a
+        # add cname to lenient a, succeeds now
         a = Record.new(
             zone,
             'www',
@@ -643,17 +638,21 @@ class TestZone(TestCase):
         )
         zone = Zone('unit.tests.', [])
         zone.add_record(a)
-        with self.assertRaises(InvalidNodeException) as ctx:
-            zone.add_record(cname)
-        self.assertIn(', has some context', str(ctx.exception))
-        self.assertEqual(set([a]), zone.records)
+        zone.add_record(cname)
+        self.assertEqual(set([a, cname]), zone.records)
+        # but fails validation because cname is not lenient
+        with self.assertRaises(ValidationError) as ctx:
+            zone.validate()
+        self.assertIn('(has some context)', str(ctx.exception))
 
-        # add lenient a to cname
+        # add lenient a to cname, succeeds now
         zone = Zone('unit.tests.', [])
         zone.add_record(cname)
-        with self.assertRaises(InvalidNodeException):
-            zone.add_record(a)
-        self.assertEqual(set([cname]), zone.records)
+        zone.add_record(a)
+        self.assertEqual(set([cname, a]), zone.records)
+        # but fails validation because cname is not lenient
+        with self.assertRaises(ValidationError):
+            zone.validate()
 
         # add lenient cname to lenient a
         cname = Record.new(
@@ -670,28 +669,41 @@ class TestZone(TestCase):
         zone.add_record(a)
         zone.add_record(cname)
         self.assertEqual(set([a, cname]), zone.records)
+        # both are lenient so validation passes (no exception raised)
+        zone.validate()
 
         # add lenient a to lenient cname
         zone = Zone('unit.tests.', [])
         zone.add_record(cname)
         zone.add_record(a)
         self.assertEqual(set([a, cname]), zone.records)
+        # both are lenient so validation passes
+        zone.validate()
 
-        # adding something else w/o lenient still errors
+        # adding something else w/o lenient, still fails validation
         zone = Zone('unit.tests.', [])
         zone.add_record(cname)
         zone.add_record(a)
         txt = Record.new(
             zone, 'www', {'ttl': 60, 'type': 'TXT', 'value': 'Hello World'}
         )
-        with self.assertRaises(InvalidNodeException):
-            zone.add_record(txt)
-        self.assertEqual(set([a, cname]), zone.records)
+        zone.add_record(txt)
+        self.assertEqual(set([a, cname, txt]), zone.records)
+        with self.assertRaises(ValidationError):
+            zone.validate()
 
-        # if the 3rd record is lenient it can be added
+        # if the 3rd record is lenient it STILL fails validation because not
+        # ALL are lenient
         zone = Zone('unit.tests.', [])
+        a = Record.new(
+            zone, 'www', {'ttl': 60, 'type': 'A', 'value': '9.9.9.9'}
+        )
+        cname = Record.new(
+            zone, 'www', {'ttl': 60, 'type': 'CNAME', 'value': 'foo.bar.com.'}
+        )
         zone.add_record(cname)
         zone.add_record(a)
+        # non-lenient a and cname are already there
         txt = Record.new(
             zone,
             'www',
@@ -704,6 +716,48 @@ class TestZone(TestCase):
         )
         zone.add_record(txt)
         self.assertEqual(set([a, cname, txt]), zone.records)
+        with self.assertRaises(ValidationError):
+            zone.validate()
+
+        # if all 3 are lenient it passes
+        a.octodns['lenient'] = True
+        cname.octodns['lenient'] = True
+        zone.validate()
+
+    def test_validator_registration_methods(self):
+        # Test class methods that delegate to Zone.validators
+        # These are currently missing coverage in octodns/zone/__init__.py
+
+        # registered_zone_validators
+        self.assertIn(
+            'cname-coexistence',
+            [v.id for v in Zone.registered_zone_validators()],
+        )
+
+        # available_zone_validators
+        self.assertIn(
+            'cname-coexistence',
+            [v.id for v in Zone.available_zone_validators()],
+        )
+
+        # enable_zone_validator / disable_zone_validator
+        Zone.disable_zone_validator('cname-coexistence')
+        self.assertNotIn(
+            'cname-coexistence',
+            [v.id for v in Zone.registered_zone_validators()],
+        )
+        Zone.enable_zone_validator('cname-coexistence')
+        self.assertIn(
+            'cname-coexistence',
+            [v.id for v in Zone.registered_zone_validators()],
+        )
+
+        # enable_zone_validators (sets)
+        Zone.enable_zone_validators(['legacy'])
+        self.assertIn(
+            'cname-coexistence',
+            [v.id for v in Zone.registered_zone_validators()],
+        )
 
     def test_excluded_records(self):
         zone_normal = Zone('unit.tests.', [])

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -318,12 +318,15 @@ class TestZone(TestCase):
             {'ttl': 3600, 'type': 'A', 'values': ['1.2.3.4', '2.3.4.5']},
         )
         record.context = 'added context'
-        with self.assertRaises(SubzoneRecordException) as ctx:
-            zone.add_record(record)
+        zone.add_record(record)
+        with self.assertRaises(ValidationError) as ctx:
+            zone.validate()
         self.assertIn('not of type NS', str(ctx.exception))
-        self.assertIn(', added context', str(ctx.exception))
+        self.assertIn('(added context)', str(ctx.exception))
         # Can add it w/lenient
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
         zone.add_record(record, lenient=True)
+        zone.validate(lenient=True)
         self.assertEqual(set([record]), zone.records)
 
         # NS for something below the sub is rejected
@@ -333,11 +336,14 @@ class TestZone(TestCase):
             'foo.sub',
             {'ttl': 3600, 'type': 'NS', 'values': ['1.2.3.4.', '2.3.4.5.']},
         )
-        with self.assertRaises(SubzoneRecordException) as ctx:
-            zone.add_record(record)
+        zone.add_record(record)
+        with self.assertRaises(ValidationError) as ctx:
+            zone.validate()
         self.assertIn('under a managed subzone', str(ctx.exception))
         # Can add it w/lenient
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
         zone.add_record(record, lenient=True)
+        zone.validate(lenient=True)
         self.assertEqual(set([record]), zone.records)
 
         # A for something below the sub is rejected
@@ -347,11 +353,14 @@ class TestZone(TestCase):
             'foo.bar.sub',
             {'ttl': 3600, 'type': 'A', 'values': ['1.2.3.4', '2.3.4.5']},
         )
-        with self.assertRaises(SubzoneRecordException) as ctx:
-            zone.add_record(record)
+        zone.add_record(record)
+        with self.assertRaises(ValidationError) as ctx:
+            zone.validate()
         self.assertIn('under a managed subzone', str(ctx.exception))
         # Can add it w/lenient
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
         zone.add_record(record, lenient=True)
+        zone.validate(lenient=True)
         self.assertEqual(set([record]), zone.records)
 
         # A that happens to end with a string that matches a sub (no .) is OK
@@ -415,11 +424,14 @@ class TestZone(TestCase):
                 ],
             },
         )
-        with self.assertRaises(SubzoneRecordException) as ctx:
-            zone.add_record(record)
+        zone.add_record(record)
+        with self.assertRaises(ValidationError) as ctx:
+            zone.validate()
         self.assertIn('under a managed subzone', str(ctx.exception))
         # Can add it w/lenient
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
         zone.add_record(record, lenient=True)
+        zone.validate(lenient=True)
         self.assertEqual(set([record]), zone.records)
 
         # DS record that happens to end with a string that matches a sub (no .) is OK

--- a/tests/test_octodns_zone_validators_cname.py
+++ b/tests/test_octodns_zone_validators_cname.py
@@ -1,0 +1,84 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.cname import CnameCoexistenceValidator
+
+
+def _make_zone(name='unit.tests.'):
+    return Zone(name, [])
+
+
+def _add_record(zone, name, data, lenient=False):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    return Record.new(zone, name, data, lenient=lenient)
+
+
+class TestCnameCoexistenceValidator(TestCase):
+    def test_no_conflict(self):
+        v = CnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        # Empty zone
+        self.assertEqual([], v.validate(zone))
+
+        # Single record, no CNAME
+        a = _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+        self.assertEqual([], v.validate(zone))
+
+        # CNAME alone at a node
+        cname = _add_record(
+            zone, 'alias', {'type': 'CNAME', 'value': 'www.unit.tests.'}
+        )
+        zone.add_record(cname)
+        self.assertEqual([], v.validate(zone))
+
+    def test_cname_coexistence(self):
+        v = CnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        a = _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4'})
+        cname = _add_record(
+            zone, 'www', {'type': 'CNAME', 'value': 'other.unit.tests.'}
+        )
+        zone.add_record(a)
+        zone.add_record(cname)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('cannot coexist', str(reasons[0]))
+        node = zone._records['www']
+        self.assertEqual(node, reasons[0].records)
+
+    def test_lenient_coexistence(self):
+        v = CnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        a = _add_record(
+            zone,
+            'www',
+            {'type': 'A', 'value': '1.2.3.4', 'octodns': {'lenient': True}},
+            lenient=True,
+        )
+        cname = _add_record(
+            zone,
+            'www',
+            {
+                'type': 'CNAME',
+                'value': 'other.unit.tests.',
+                'octodns': {'lenient': True},
+            },
+            lenient=True,
+        )
+        zone.add_record(a)
+        zone.add_record(cname)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertTrue(reasons[0].lenient)

--- a/tests/test_octodns_zone_validators_subzone.py
+++ b/tests/test_octodns_zone_validators_subzone.py
@@ -1,0 +1,96 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.subzone import SubzoneRecordValidator
+
+
+def _make_zone(name='unit.tests.', sub_zones=None):
+    return Zone(name, sub_zones or [])
+
+
+def _add_record(zone, name, data, lenient=False):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    return Record.new(zone, name, data, lenient=lenient)
+
+
+class TestSubzoneRecordValidator(TestCase):
+    def test_no_subzones(self):
+        v = SubzoneRecordValidator('test')
+        zone = _make_zone()
+
+        a = _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+        self.assertEqual([], v.validate(zone))
+
+    def test_ns_at_subzone_boundary_ok(self):
+        v = SubzoneRecordValidator('test')
+        zone = _make_zone(sub_zones=['sub'])
+
+        ns = _add_record(
+            zone,
+            'sub',
+            {'type': 'NS', 'values': ['ns1.example.com.', 'ns2.example.com.']},
+        )
+        zone.add_record(ns)
+        self.assertEqual([], v.validate(zone))
+
+    def test_ds_at_subzone_boundary_ok(self):
+        v = SubzoneRecordValidator('test')
+        zone = _make_zone(sub_zones=['sub'])
+
+        ds = _add_record(
+            zone,
+            'sub',
+            {
+                'type': 'DS',
+                'values': [
+                    {
+                        'key_tag': 1,
+                        'algorithm': 1,
+                        'digest_type': 1,
+                        'digest': 'ab',
+                    }
+                ],
+            },
+        )
+        zone.add_record(ds)
+        self.assertEqual([], v.validate(zone))
+
+    def test_non_ns_at_subzone_boundary(self):
+        v = SubzoneRecordValidator('test')
+        zone = _make_zone(sub_zones=['sub'])
+
+        a = _add_record(zone, 'sub', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('not of type NS or DS', str(reasons[0]))
+        self.assertEqual({a}, reasons[0].records)
+
+    def test_record_under_subzone(self):
+        v = SubzoneRecordValidator('test')
+        zone = _make_zone(sub_zones=['sub'])
+
+        a = _add_record(zone, 'foo.sub', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('under a managed subzone', str(reasons[0]))
+        self.assertEqual({a}, reasons[0].records)
+
+    def test_non_subzone_record_ok(self):
+        v = SubzoneRecordValidator('test')
+        zone = _make_zone(sub_zones=['sub'])
+
+        # Record that happens to end with subzone name but has no dot separator
+        a = _add_record(zone, 'notsub', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+        self.assertEqual([], v.validate(zone))


### PR DESCRIPTION
This PR standardizes zone-level validation by migrating inline checks from `Zone.add_record` to dedicated `ZoneValidator`s. Validation is now deferred to the `zone.validate()` phase.

Key changes:
- **CNAME Coexistence**:
  - Migrated CNAME coexistence check from `Zone.add_record` to `CnameCoexistenceValidator`.
  - Removed the now unused `InvalidNodeException`.
- **Sub-zone Overlaps**:
  - Migrated `SubzoneRecordException` checks to `SubzoneRecordValidator`.
  - Removed `SubzoneRecordException` class.
  - Refactored `Zone.add_record` to retain `ignore_subzone_adds` logic while deferring validation to the validator.
- **General**:
  - Registered new validators in `legacy` and `strict` sets.
  - Updated all affected tests to reflect the new validation model.
  - Ensured 100% code coverage and lint compliance.