### PR TITLE
Implement NS-related zone validators

### DIFF
--- a/.changelog/fe66fcda80994d009673045a97a030e6.md
+++ b/.changelog/fe66fcda80994d009673045a97a030e6.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Implement GlueForInZoneNsZoneValidator and MultiValueApexNsZoneValidator

--- a/octodns/zone/ns.py
+++ b/octodns/zone/ns.py
@@ -1,0 +1,78 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class GlueForInZoneNsZoneValidator(ZoneValidator):
+    '''
+    Checks that NS records pointing to targets within the same zone have
+    corresponding A or AAAA "glue" records. Without these address records,
+    resolvers cannot follow the delegation because they would need to resolve
+    the name server's address using the very name servers they are trying to
+    locate.
+
+    Example:
+      - Zone ``example.com.`` has ``NS ns1.example.com.``
+      - This validator ensures an ``A`` or ``AAAA`` record exists for
+        ``ns1.example.com.`` within the ``example.com.`` zone.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc1033 (Operations)
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            if record._type == 'NS':
+                for target in record.values:
+                    # Is target in zone?
+                    if zone.owns('A', target):
+                        # Check if address records exist at this target
+                        hostname = zone.hostname_from_fqdn(target)
+                        # We need at least one A or AAAA
+                        addresses = zone.get(hostname, type='A') | zone.get(
+                            hostname, type='AAAA'
+                        )
+                        if not addresses:
+                            reasons.append(
+                                ValidationReason(
+                                    f'NS record "{record.fqdn}" points to '
+                                    f'in-zone target "{target}" without '
+                                    'glue records (A/AAAA)',
+                                    [record],
+                                )
+                            )
+        return reasons
+
+
+class MultiValueApexNsZoneValidator(ZoneValidator):
+    '''
+    Checks that the zone apex has at least two ``NS`` records. Having multiple
+    name servers is a fundamental best practice for DNS redundancy and
+    availability.
+    '''
+
+    def validate(self, zone):
+        ns_records = zone.get('', type='NS')
+        if ns_records:
+            count = sum(len(r.values) for r in ns_records)
+            if count < 2:
+                return [
+                    ValidationReason(
+                        f'zone "{zone.decoded_name}" has only {count} NS '
+                        'record at the apex; at least 2 are recommended for '
+                        'redundancy',
+                        list(ns_records),
+                    )
+                ]
+        return []
+
+
+Zone.register_zone_validator(
+    GlueForInZoneNsZoneValidator('glue-for-in-zone-ns', sets={'strict'})
+)
+Zone.register_zone_validator(
+    MultiValueApexNsZoneValidator('multi-value-apex-ns', sets={'best-practice'})
+)

--- a/octodns/zone/ns.py
+++ b/octodns/zone/ns.py
@@ -47,32 +47,31 @@ class GlueForInZoneNsZoneValidator(ZoneValidator):
         return reasons
 
 
-class MultiValueApexNsZoneValidator(ZoneValidator):
+class MultiValueNsZoneValidator(ZoneValidator):
     '''
-    Checks that the zone apex has at least two ``NS`` records. Having multiple
+    Checks that all ``NS`` records have at least two values. Having multiple
     name servers is a fundamental best practice for DNS redundancy and
-    availability.
+    availability, both at the apex and for sub-delegations.
     '''
 
     def validate(self, zone):
-        ns_records = zone.get('', type='NS')
-        if ns_records:
-            count = sum(len(r.values) for r in ns_records)
-            if count < 2:
-                return [
-                    ValidationReason(
-                        f'zone "{zone.decoded_name}" has only {count} NS '
-                        'record at the apex; at least 2 are recommended for '
-                        'redundancy',
-                        list(ns_records),
+        reasons = []
+        for record in zone.records:
+            if record._type == 'NS':
+                if len(record.values) < 2:
+                    reasons.append(
+                        ValidationReason(
+                            f'NS record "{record.fqdn}" has only {len(record.values)} '
+                            'value; at least 2 are recommended for redundancy',
+                            [record],
+                        )
                     )
-                ]
-        return []
+        return reasons
 
 
 Zone.register_zone_validator(
     GlueForInZoneNsZoneValidator('glue-for-in-zone-ns', sets={'strict'})
 )
 Zone.register_zone_validator(
-    MultiValueApexNsZoneValidator('multi-value-apex-ns', sets={'best-practice'})
+    MultiValueNsZoneValidator('multi-value-ns', sets={'best-practice'})
 )

--- a/tests/test_octodns_zone_validators_ns.py
+++ b/tests/test_octodns_zone_validators_ns.py
@@ -1,0 +1,101 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.ns import (
+    GlueForInZoneNsZoneValidator,
+    MultiValueApexNsZoneValidator,
+)
+
+
+def _make_zone(name='unit.tests.'):
+    return Zone(name, [])
+
+
+def _add_record(zone, name, data, lenient=True):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    return Record.new(zone, name, data, lenient=lenient)
+
+
+class TestGlueForInZoneNsZoneValidator(TestCase):
+    def test_glue_for_in_zone_ns(self):
+        v = GlueForInZoneNsZoneValidator('test')
+        zone = _make_zone('unit.tests.')
+
+        # Out-of-zone target
+        ns = _add_record(
+            zone, '', {'ttl': 300, 'type': 'NS', 'values': ['ns1.other.tests.']}
+        )
+        zone.add_record(ns)
+        self.assertEqual([], v.validate(zone))
+
+        # In-zone target with A record
+        ns = _add_record(
+            zone,
+            'sub',
+            {'ttl': 300, 'type': 'NS', 'values': ['ns1.unit.tests.']},
+        )
+        zone.add_record(ns)
+        a = _add_record(
+            zone, 'ns1', {'ttl': 300, 'type': 'A', 'values': ['1.2.3.4']}
+        )
+        zone.add_record(a)
+        self.assertEqual([], v.validate(zone))
+
+        # In-zone target with AAAA record
+        ns = _add_record(
+            zone,
+            'sub2',
+            {'ttl': 300, 'type': 'NS', 'values': ['ns2.unit.tests.']},
+        )
+        zone.add_record(ns)
+        aaaa = _add_record(
+            zone, 'ns2', {'ttl': 300, 'type': 'AAAA', 'values': ['::1']}
+        )
+        zone.add_record(aaaa)
+        self.assertEqual([], v.validate(zone))
+
+        # In-zone target with missing A/AAAA
+        ns_bad = _add_record(
+            zone,
+            'bad',
+            {'ttl': 300, 'type': 'NS', 'values': ['ns3.unit.tests.']},
+        )
+        zone.add_record(ns_bad)
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('without glue records', str(reasons[0]))
+        self.assertEqual({ns_bad}, reasons[0].records)
+
+
+class TestMultiValueApexNsZoneValidator(TestCase):
+    def test_multi_value_apex_ns(self):
+        v = MultiValueApexNsZoneValidator('test')
+        zone = _make_zone('unit.tests.')
+
+        # No NS at apex (not this validator's job to care if it's missing entirely)
+        self.assertEqual([], v.validate(zone))
+
+        # 2 NS values at apex
+        ns = _add_record(
+            zone,
+            '',
+            {'ttl': 300, 'type': 'NS', 'values': ['ns1.com.', 'ns2.com.']},
+        )
+        zone.add_record(ns)
+        self.assertEqual([], v.validate(zone))
+
+        # 1 NS value at apex
+        ns2 = _add_record(
+            zone, '', {'ttl': 300, 'type': 'NS', 'values': ['ns1.com.']}
+        )
+        zone.add_record(ns2, replace=True)
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('at least 2 are recommended', str(reasons[0]))
+        self.assertEqual({ns2}, reasons[0].records)

--- a/tests/test_octodns_zone_validators_ns.py
+++ b/tests/test_octodns_zone_validators_ns.py
@@ -8,7 +8,7 @@ from octodns.record import Record
 from octodns.zone import Zone
 from octodns.zone.ns import (
     GlueForInZoneNsZoneValidator,
-    MultiValueApexNsZoneValidator,
+    MultiValueNsZoneValidator,
 )
 
 
@@ -73,9 +73,9 @@ class TestGlueForInZoneNsZoneValidator(TestCase):
         self.assertEqual({ns_bad}, reasons[0].records)
 
 
-class TestMultiValueApexNsZoneValidator(TestCase):
-    def test_multi_value_apex_ns(self):
-        v = MultiValueApexNsZoneValidator('test')
+class TestMultiValueNsZoneValidator(TestCase):
+    def test_multi_value_ns(self):
+        v = MultiValueNsZoneValidator('test')
         zone = _make_zone('unit.tests.')
 
         # No NS at apex (not this validator's job to care if it's missing entirely)
@@ -88,6 +88,11 @@ class TestMultiValueApexNsZoneValidator(TestCase):
             {'ttl': 300, 'type': 'NS', 'values': ['ns1.com.', 'ns2.com.']},
         )
         zone.add_record(ns)
+        # Add a non-NS record to cover the branch in validate
+        a = _add_record(
+            zone, 'www', {'ttl': 300, 'type': 'A', 'values': ['1.2.3.4']}
+        )
+        zone.add_record(a)
         self.assertEqual([], v.validate(zone))
 
         # 1 NS value at apex
@@ -99,3 +104,16 @@ class TestMultiValueApexNsZoneValidator(TestCase):
         self.assertEqual(1, len(reasons))
         self.assertIn('at least 2 are recommended', str(reasons[0]))
         self.assertEqual({ns2}, reasons[0].records)
+
+        # 1 NS value for sub-delegation
+        ns_sub = _add_record(
+            zone, 'sub', {'ttl': 300, 'type': 'NS', 'values': ['ns3.com.']}
+        )
+        zone.add_record(ns_sub)
+        reasons = sorted(
+            v.validate(zone), key=lambda r: list(r.records)[0].fqdn
+        )
+        self.assertEqual(2, len(reasons))
+        self.assertIn('sub.unit.tests.', str(reasons[0]))
+        self.assertIn('unit.tests.', str(reasons[1]))
+        self.assertEqual({ns_sub}, reasons[0].records)


### PR DESCRIPTION
This PR adds GlueForInZoneNsZoneValidator (strict) and MultiValueApexNsZoneValidator (best-practice) to enforce circular dependency and redundancy checks for NS records.

/cc https://github.com/octodns/octodns/pull/1396