### PR TITLE
Add NoCnameLoopZoneValidator

### DIFF
--- a/.changelog/9c95d5342c5f45259755b9c3007ee654.md
+++ b/.changelog/9c95d5342c5f45259755b9c3007ee654.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add NoCnameLoopZoneValidator to detect circular CNAME/ALIAS chains

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -9,11 +9,13 @@ from .base import (
     SubzoneRecordException,
     Zone,
 )
+from .cname_loops import NoCnameLoopZoneValidator
 from .mail import MailZoneValidator
 
 DuplicateRecordException
 InvalidNameError
 InvalidNodeException
 MailZoneValidator
+NoCnameLoopZoneValidator
 SubzoneRecordException
 Zone

--- a/octodns/zone/cname_loops.py
+++ b/octodns/zone/cname_loops.py
@@ -1,0 +1,60 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class NoCnameLoopZoneValidator(ZoneValidator):
+    '''
+    Checks for circular CNAME or ALIAS chains within the zone. Circular
+    references prevent DNS resolution from ever completing and are prohibited
+    by DNS standards.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc1034#section-3.6.2
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        targets = {
+            r.fqdn: r for r in zone.records if r._type in ('CNAME', 'ALIAS')
+        }
+
+        overall_visited = set()
+        for start_fqdn in targets:
+            if start_fqdn in overall_visited:
+                continue
+
+            path = []
+            visited = {}  # fqdn -> index in path
+            curr = start_fqdn
+
+            while curr in targets:
+                if curr in visited:
+                    cycle_fqdns = path[visited[curr] :] + [curr]
+                    loop_path = ' -> '.join(cycle_fqdns)
+                    cycle_records = {
+                        targets[f] for f in cycle_fqdns if f in targets
+                    }
+                    reasons.append(
+                        ValidationReason(
+                            f'Loop detected: {loop_path}', cycle_records
+                        )
+                    )
+                    break
+
+                if curr in overall_visited:
+                    break
+
+                visited[curr] = len(path)
+                path.append(curr)
+                overall_visited.add(curr)
+                curr = str(targets[curr].value)
+
+        return reasons
+
+
+Zone.register_zone_validator(
+    NoCnameLoopZoneValidator('no-cname-loop', sets={'strict'})
+)

--- a/tests/test_octodns_zone_validators_cname_loops.py
+++ b/tests/test_octodns_zone_validators_cname_loops.py
@@ -1,0 +1,90 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.cname_loops import NoCnameLoopZoneValidator
+
+
+def _make_zone(name='unit.tests.'):
+    return Zone(name, [])
+
+
+def _add_record(zone, name, data, lenient=True):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    return Record.new(zone, name, data, lenient=lenient)
+
+
+class TestNoCnameLoopZoneValidator(TestCase):
+    def test_passes(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone, 'www', {'type': 'CNAME', 'value': 'lb.unit.tests.'}
+        )
+        zone.add_record(cname)
+        v = NoCnameLoopZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_fails_direct(self):
+        zone = _make_zone()
+        cname = _add_record(
+            zone, 'loop', {'type': 'CNAME', 'value': 'loop.unit.tests.'}
+        )
+        zone.add_record(cname)
+        v = NoCnameLoopZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('Loop detected', str(reasons[0]))
+        self.assertIn('loop.unit.tests. -> loop.unit.tests.', str(reasons[0]))
+        self.assertIn(cname, reasons[0].records)
+
+    def test_fails_indirect(self):
+        zone = _make_zone()
+        c1 = _add_record(zone, 'a', {'type': 'CNAME', 'value': 'b.unit.tests.'})
+        c2 = _add_record(zone, 'b', {'type': 'CNAME', 'value': 'c.unit.tests.'})
+        c3 = _add_record(zone, 'c', {'type': 'CNAME', 'value': 'a.unit.tests.'})
+        zone.add_record(c1)
+        zone.add_record(c2)
+        zone.add_record(c3)
+        v = NoCnameLoopZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        msg = str(reasons[0])
+        self.assertIn('Loop detected', msg)
+        self.assertIn('a.unit.tests.', msg)
+        self.assertIn('b.unit.tests.', msg)
+        self.assertIn('c.unit.tests.', msg)
+        self.assertEqual({c1, c2, c3}, reasons[0].records)
+
+    def test_with_alias(self):
+        # apex ALIAS -> b, b CNAME -> apex
+        zone = _make_zone()
+        a1 = _add_record(zone, '', {'type': 'ALIAS', 'value': 'b.unit.tests.'})
+        c2 = _add_record(zone, 'b', {'type': 'CNAME', 'value': 'unit.tests.'})
+        zone.add_record(a1)
+        zone.add_record(c2)
+        v = NoCnameLoopZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        msg = str(reasons[0])
+        self.assertIn('Loop detected', msg)
+        self.assertIn('unit.tests.', msg)
+        self.assertIn('b.unit.tests.', msg)
+
+    def test_merging_chains(self):
+        # x -> z, y -> z, z -> end (no loop; exercises overall_visited break)
+        zone = _make_zone()
+        c1 = _add_record(zone, 'x', {'type': 'CNAME', 'value': 'z.unit.tests.'})
+        c2 = _add_record(zone, 'y', {'type': 'CNAME', 'value': 'z.unit.tests.'})
+        c3 = _add_record(
+            zone, 'z', {'type': 'CNAME', 'value': 'end.unit.tests.'}
+        )
+        zone.add_record(c1)
+        zone.add_record(c2)
+        zone.add_record(c3)
+        v = NoCnameLoopZoneValidator('test')
+        self.assertEqual([], v.validate(zone))


### PR DESCRIPTION
## Summary

- Ports `NoCnameLoopZoneValidator` from the experimental PR #1397 into the established zone-validator structure
- Detects circular CNAME/ALIAS chains within a zone (RFC 1034 §3.6.2); e.g. `a → b → c → a`
- Lives in its own module `octodns/zone/cname_loops.py`, auto-registered at import time via `Zone.register_zone_validator`
- Returns `ValidationReason` objects carrying the in-zone records on the cycle so `lenient` and zone `context` handling work correctly
- Registered into the `strict` set only (`sets={'strict'}`)

## Test plan

- [x] 5 unit tests covering: no-loop pass, direct self-loop, 3-node indirect cycle, ALIAS-in-loop, and the merging-chains early-break path
- [x] `./script/coverage` — 694 tests, 100% branch coverage
- [x] `./script/lint` and `./script/format --check` pass

/cc #1396 — this PR targets the `zone-validators` branch from that PR; both need to land together
/cc #1397 — source of the original `NoCnameLoopZoneValidator` implementation this ports