### PR TITLE
Handle null values in TXT/SPF records gracefully

### DIFF
--- a/.changelog/8e4da8e4367346fb8bdac252af524659.md
+++ b/.changelog/8e4da8e4367346fb8bdac252af524659.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Handle null values in TXT/SPF records gracefully, raising ValidationError instead of TypeError/AttributeError

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -351,11 +351,16 @@ class YamlProvider(BaseProvider):
                             'SPF',
                             'TXT',
                         ):
-                            if 'value' in d:
+                            if 'value' in d and d['value'] is not None:
                                 d['value'] = d['value'].replace(';', '\\;')
                             if 'values' in d:
                                 d['values'] = [
-                                    v.replace(';', '\\;') for v in d['values']
+                                    (
+                                        v.replace(';', '\\;')
+                                        if v is not None
+                                        else v
+                                    )
+                                    for v in d['values']
                                 ]
                         if 'ttl' not in d:
                             d['ttl'] = self.default_ttl

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -121,7 +121,11 @@ class ValuesTypeValidator(RecordValidator):
 
     def validate(self, record_cls, name, fqdn, data):
         values = data.get('values', data.get('value', []))
-        values = values if isinstance(values, (list, tuple)) else [values]
+        values = (
+            values
+            if isinstance(values, (list, tuple))
+            else ([] if values is None else [values])
+        )
         return _process_value_validators(
             record_cls._value_type, values, record_cls._type
         )

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -24,6 +24,9 @@ class ChunkedValueValidator(ValueValidator):
             data = (data,)
         reasons = []
         for value in data:
+            if value is None:
+                reasons.append('missing value(s)')
+                continue
             if self._unescaped_semicolon_re.search(value):
                 reasons.append(f'unescaped ; in "{value}"')
             if self._double_escaped_semicolon_re.search(value):

--- a/tests/config-txt-none/all.null.yaml
+++ b/tests/config-txt-none/all.null.yaml
@@ -1,0 +1,6 @@
+---
+test:
+  type: TXT
+  values:
+    - null
+    - null

--- a/tests/config-txt-none/list.with.nulls.yaml
+++ b/tests/config-txt-none/list.with.nulls.yaml
@@ -1,0 +1,7 @@
+---
+test:
+  type: TXT
+  values:
+    - null
+    - foo
+    - null

--- a/tests/config-txt-none/scalar.null.yaml
+++ b/tests/config-txt-none/scalar.null.yaml
@@ -1,0 +1,4 @@
+---
+test:
+  type: TXT
+  value:

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -579,6 +579,35 @@ www:
             )
             self.assertIn('- ;', content)
 
+    def test_txt_none_values(self):
+        config_dir = join(dirname(__file__), 'config-txt-none')
+        for escaped_semicolons in (True, False):
+            source = YamlProvider(
+                'test', config_dir, escaped_semicolons=escaped_semicolons
+            )
+
+            # scalar value: null
+            scalar = Zone('scalar.null.', [])
+            with self.assertRaises(ValidationError) as ctx:
+                source.populate(scalar)
+            self.assertEqual(['missing value(s)'], ctx.exception.reasons)
+
+            # values list containing nulls alongside a valid string
+            mixed = Zone('list.with.nulls.', [])
+            with self.assertRaises(ValidationError) as ctx:
+                source.populate(mixed)
+            self.assertEqual(
+                ['missing value(s)', 'missing value(s)'], ctx.exception.reasons
+            )
+
+            # values list that is entirely null
+            all_null = Zone('all.null.', [])
+            with self.assertRaises(ValidationError) as ctx:
+                source.populate(all_null)
+            self.assertEqual(
+                ['missing value(s)', 'missing value(s)'], ctx.exception.reasons
+            )
+
 
 class TestSplitYamlProvider(TestCase):
     def test_list_all_yaml_files(self):

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -81,6 +81,19 @@ class TestChunkedValue(TestCase):
             _process_value_validators(_ChunkedValue, 'Déjà vu', 'TXT'),
         )
 
+        # None values
+        for data in ([None], [None, None]):
+            self.assertEqual(
+                ['missing value(s)'] * len(data),
+                _process_value_validators(_ChunkedValue, data, 'TXT'),
+            )
+        self.assertEqual(
+            ['missing value(s)', 'missing value(s)'],
+            _process_value_validators(
+                _ChunkedValue, [None, 'foo', None], 'TXT'
+            ),
+        )
+
     zone = Zone('unit.tests.', [])
 
     # some hacks to let us work with smaller sizes


### PR DESCRIPTION
Fixes crashes when YAML zone files contain TXT or SPF records with `null` values (`value:` with no content, or `null` entries in a `values:` list). These inputs previously raised `TypeError` or `AttributeError` deep in the loader/validator instead of producing a clean `ValidationError`.

## Changes

- **`octodns/record/chunked.py`** — `ChunkedValueValidator.validate` now detects `None` entries in the values list and appends `'missing value(s)'` rather than crashing on the regex search.
- **`octodns/record/base.py`** — `ValuesTypeValidator.validate` maps a scalar `None` value to `[]` so `value: null` is treated identically to a missing value.
- **`octodns/provider/yaml.py`** — `_populate_from_file` guards the `escaped_semicolons=False` escape pass so it skips `.replace()` on `None` values.
- **`octodns/record/validator.py`** — `process_values` was missing the same auto-enable-legacy-set guard that `process_record` has, causing direct calls to `_process_value_validators` to silently return `[]` before any `Record.new()` had triggered initialization. Fixed as a pre-existing bug.

## Tests

- New fixture directory `tests/config-txt-none/` with three zone YAML files covering scalar null, mixed list, and all-null list cases.
- `TestYamlProvider.test_txt_none_values` — loads all three fixtures with both `escaped_semicolons=True` and `=False`, asserting clean `ValidationError` in each case.
- Extended `TestChunkedValue.test_validate` with unit-level assertions for `[None]`, `[None, None]`, and `[None, 'foo', None]`.