### PR TITLE
Extend MailZoneValidator to cover sub-domain mail handling

### DIFF
--- a/.changelog/0f98ccc556f64b64a955a24dec956822.md
+++ b/.changelog/0f98ccc556f64b64a955a24dec956822.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Extend MailZoneValidator to validate MX and SPF for sub-domains; explicit mode propagates, auto detects per-subdomain

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -174,6 +174,92 @@ class MailZoneValidator(ZoneValidator):
 
         return reasons
 
+    def _detect_subzone_mode(self, mx_record):
+        if (
+            len(mx_record.values) == 1
+            and mx_record.values[0].preference == 0
+            and str(mx_record.values[0].exchange) == '.'
+        ):
+            return 'no-mail'
+        return 'mail'
+
+    def _validate_subzone(self, zone, mx_record, mode):
+        reasons = []
+        name = mx_record.name
+        txt_record = zone.get_type(name, 'TXT')
+
+        spf_values = (
+            [
+                v
+                for v in [
+                    i.lower().replace('\\', '') for i in txt_record.values
+                ]
+                if v.startswith('v=spf1')
+            ]
+            if txt_record
+            else None
+        )
+        spf_value = None
+        if spf_values:
+            if len(spf_values) > 1:
+                reasons.append(
+                    ValidationReason(
+                        reason=f'"{mx_record.decoded_fqdn}" has multiple SPF values',
+                        records={txt_record},
+                    )
+                )
+            spf_value = spf_values[0]
+
+        records = {mx_record}
+        if txt_record:
+            records.add(txt_record)
+
+        if mode == 'mail':
+            if not spf_value:
+                reasons.append(
+                    ValidationReason(
+                        f'"{mx_record.decoded_fqdn}" handles mail but is missing an SPF TXT record',
+                        records,
+                    )
+                )
+            elif not (
+                spf_value.endswith(' -all') or spf_value.endswith(' ~all')
+            ):
+                reasons.append(
+                    ValidationReason(
+                        f'SPF record at "{mx_record.decoded_fqdn}" should terminate with "~all" or "-all"',
+                        {txt_record},
+                    )
+                )
+        else:
+            if not (
+                len(mx_record.values) == 1
+                and mx_record.values[0].preference == 0
+                and str(mx_record.values[0].exchange) == '.'
+            ):
+                reasons.append(
+                    ValidationReason(
+                        f'"{mx_record.decoded_fqdn}" disables mail and should have a single Null MX record (0 .)',
+                        {mx_record},
+                    )
+                )
+            if spf_value is None:
+                reasons.append(
+                    ValidationReason(
+                        f'"{mx_record.decoded_fqdn}" disables mail but is missing strict SPF TXT record "v=spf1 -all"',
+                        records,
+                    )
+                )
+            elif spf_value != 'v=spf1 -all':
+                reasons.append(
+                    ValidationReason(
+                        f'"{mx_record.decoded_fqdn}" disables mail and should have a strict SPF TXT record "v=spf1 -all"',
+                        {txt_record},
+                    )
+                )
+
+        return reasons
+
     def validate(self, zone):
         reasons = []
 
@@ -291,6 +377,16 @@ class MailZoneValidator(ZoneValidator):
                     dmarc_value=dmarc_value,
                 )
             )
+
+        for mx_record in [
+            r for r in zone.records if r.name != '' and r._type == 'MX'
+        ]:
+            sub_mode = (
+                self._detect_subzone_mode(mx_record)
+                if self.mode == 'auto'
+                else self.mode
+            )
+            reasons.extend(self._validate_subzone(zone, mx_record, sub_mode))
 
         return reasons
 

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -12,22 +12,34 @@ class MailZoneValidator(ZoneValidator):
     '''
     Comprehensive best-practice validator for mail records (MX, SPF, DMARC).
 
-    Can operate in two modes: 'mail' and 'no-mail'. In 'auto' mode (default), it
-    detects the mode based on the presence of mail-related records (MX anywhere
-    in the zone, SPF at the apex, or DMARC at _dmarc). If no mail-related
-    records are found, it is a no-op. If any are found, it detects the mode
-    based on the presence of non-null MX records at the apex.
+    Can operate in two modes: 'mail' and 'no-mail'. In 'auto' mode (default),
+    it detects the apex mode based on the presence of mail-related records (MX
+    anywhere in the zone, SPF at the apex, or DMARC at _dmarc). If no
+    mail-related records are found, it is a no-op for the apex. If any are
+    found, it detects the mode based on the presence of non-null MX records at
+    the apex.
+
+    Every non-apex sub-domain that has MX records is also validated (redundancy
+    + SPF). In 'auto' mode each sub-domain's mode is detected independently:
+    null MX → 'no-mail', otherwise → 'mail'. In explicit 'mail' or 'no-mail'
+    mode, the configured mode propagates to sub-domains.
 
     'mail' mode enforces:
     - Multiple MX records for redundancy (at apex and throughout the zone).
     - Presence of an SPF record at the apex.
     - SPF record terminates with ~all or -all.
     - Presence of a DMARC record at _dmarc.
+    - Each sub-domain with MX has an SPF record terminating with ~all or -all.
 
     'no-mail' mode enforces:
     - Presence of a single Null MX record (0 .) at the apex.
     - SPF record at the apex is exactly 'v=spf1 -all'.
     - DMARC record at _dmarc has p=reject.
+    - Each sub-domain with MX has a single Null MX (0 .) and strict SPF
+      'v=spf1 -all'.
+
+    DMARC is not required at the sub-domain level because it inherits from the
+    parent zone per RFC 7489 §6.6.3.
     '''
 
     def __init__(self, id, mode='auto', sets=None):
@@ -43,6 +55,21 @@ class MailZoneValidator(ZoneValidator):
             and mx_record.values[0].preference == 0
             and str(mx_record.values[0].exchange) == '.'
         )
+
+    def _extract_spf(self, txt_record, multi_msg):
+        if txt_record is None:
+            return None, None
+        values = [
+            v
+            for v in (i.lower().replace('\\', '') for i in txt_record.values)
+            if v.startswith('v=spf1')
+        ]
+        if not values:
+            return None, None
+        reason = None
+        if len(values) > 1:
+            reason = ValidationReason(reason=multi_msg, records={txt_record})
+        return values[0], reason
 
     def _validate_mail(
         self,
@@ -177,37 +204,20 @@ class MailZoneValidator(ZoneValidator):
 
         return reasons
 
-    def _detect_subzone_mode(self, mx_record):
+    def _detect_subdomain_mode(self, mx_record):
         if self._is_null_mx(mx_record):
             return 'no-mail'
         return 'mail'
 
-    def _validate_subzone(self, zone, mx_record, mode):
+    def _validate_subdomain(self, zone, mx_record, mode):
         reasons = []
-        name = mx_record.name
-        txt_record = zone.get_type(name, 'TXT')
+        txt_record = zone.get_type(mx_record.name, 'TXT')
 
-        spf_values = (
-            [
-                v
-                for v in [
-                    i.lower().replace('\\', '') for i in txt_record.values
-                ]
-                if v.startswith('v=spf1')
-            ]
-            if txt_record
-            else None
+        spf_value, spf_multi = self._extract_spf(
+            txt_record, f'"{mx_record.decoded_fqdn}" has multiple SPF values'
         )
-        spf_value = None
-        if spf_values:
-            if len(spf_values) > 1:
-                reasons.append(
-                    ValidationReason(
-                        reason=f'"{mx_record.decoded_fqdn}" has multiple SPF values',
-                        records={txt_record},
-                    )
-                )
-            spf_value = spf_values[0]
+        if spf_multi:
+            reasons.append(spf_multi)
 
         records = {mx_record}
         if txt_record:
@@ -260,12 +270,16 @@ class MailZoneValidator(ZoneValidator):
 
         mode = self.mode
 
+        non_apex_mx = [
+            r for r in zone.records if r.name != '' and r._type == 'MX'
+        ]
+
         apex_mx_record = zone.get_type('', 'MX')
 
         # MX redundancy (Apex and elsewhere)
-        for record in ([apex_mx_record] if apex_mx_record else []) + [
-            r for r in zone.records if r.name != '' and r._type == 'MX'
-        ]:
+        for record in (
+            [apex_mx_record] if apex_mx_record else []
+        ) + non_apex_mx:
             if self._is_null_mx(record):
                 continue
 
@@ -278,25 +292,11 @@ class MailZoneValidator(ZoneValidator):
                 )
 
         apex_txt = zone.get_type('', 'TXT')
-        apex_spf_value = (
-            [
-                v
-                for v in [i.lower().replace('\\', '') for i in apex_txt.values]
-                if v.startswith('v=spf1')
-            ]
-            # there can only be 0/1
-            if apex_txt
-            else None
+        apex_spf_value, apex_spf_multi = self._extract_spf(
+            apex_txt, f'zone "{zone.decoded_name}" has multiple SPF values'
         )
-        if apex_spf_value:
-            if len(apex_spf_value) > 1:
-                reasons.append(
-                    ValidationReason(
-                        reason=f'zone "{zone.decoded_name}" has multiple SPF values',
-                        records={apex_txt},
-                    )
-                )
-            apex_spf_value = apex_spf_value[0]
+        if apex_spf_multi:
+            reasons.append(apex_spf_multi)
 
         dmarc_txt = zone.get_type('_dmarc', 'TXT')
         dmarc_value = (
@@ -305,7 +305,6 @@ class MailZoneValidator(ZoneValidator):
                 for v in [v.lower().replace('\\', '') for v in dmarc_txt.values]
                 if v.startswith('v=dmarc1')
             ]
-            # there can only be 0/1
             if dmarc_txt
             else None
         )
@@ -377,15 +376,13 @@ class MailZoneValidator(ZoneValidator):
                 )
             )
 
-        for mx_record in [
-            r for r in zone.records if r.name != '' and r._type == 'MX'
-        ]:
+        for mx_record in non_apex_mx:
             sub_mode = (
-                self._detect_subzone_mode(mx_record)
+                self._detect_subdomain_mode(mx_record)
                 if self.mode == 'auto'
                 else self.mode
             )
-            reasons.extend(self._validate_subzone(zone, mx_record, sub_mode))
+            reasons.extend(self._validate_subdomain(zone, mx_record, sub_mode))
 
         return reasons
 

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -37,6 +37,13 @@ class MailZoneValidator(ZoneValidator):
             raise ValueError(f'Unknown mode "{mode}"')
         self.mode = mode
 
+    def _is_null_mx(self, mx_record):
+        return (
+            len(mx_record.values) == 1
+            and mx_record.values[0].preference == 0
+            and str(mx_record.values[0].exchange) == '.'
+        )
+
     def _validate_mail(
         self,
         zone,
@@ -128,11 +135,7 @@ class MailZoneValidator(ZoneValidator):
                     records,
                 )
             )
-        elif (
-            len(apex_mx_record.values) != 1
-            or apex_mx_record.values[0].preference != 0
-            or str(apex_mx_record.values[0].exchange) != '.'
-        ):
+        elif not self._is_null_mx(apex_mx_record):
             reasons.append(
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail and should have a single Null MX record (0 .)',
@@ -175,11 +178,7 @@ class MailZoneValidator(ZoneValidator):
         return reasons
 
     def _detect_subzone_mode(self, mx_record):
-        if (
-            len(mx_record.values) == 1
-            and mx_record.values[0].preference == 0
-            and str(mx_record.values[0].exchange) == '.'
-        ):
+        if self._is_null_mx(mx_record):
             return 'no-mail'
         return 'mail'
 
@@ -232,11 +231,7 @@ class MailZoneValidator(ZoneValidator):
                     )
                 )
         else:
-            if not (
-                len(mx_record.values) == 1
-                and mx_record.values[0].preference == 0
-                and str(mx_record.values[0].exchange) == '.'
-            ):
+            if not self._is_null_mx(mx_record):
                 reasons.append(
                     ValidationReason(
                         f'"{mx_record.decoded_fqdn}" disables mail and should have a single Null MX record (0 .)',
@@ -271,6 +266,9 @@ class MailZoneValidator(ZoneValidator):
         for record in ([apex_mx_record] if apex_mx_record else []) + [
             r for r in zone.records if r.name != '' and r._type == 'MX'
         ]:
+            if self._is_null_mx(record):
+                continue
+
             if len(record.values) < 2:
                 reasons.append(
                     ValidationReason(
@@ -333,26 +331,27 @@ class MailZoneValidator(ZoneValidator):
                 )
                 if apex_spf_value and apex_spf_value == 'v=spf1 -all':
                     self.log.debug(
-                        'validate: zone=%s, apex_spf_value indicates no-mail'
+                        'validate: zone=%s, apex_spf_value indicates no-mail',
+                        zone.decoded_name,
                     )
                     mode = 'no-mail'
                 elif dmarc_value and dmarc_value == 'v=dmarc1; p=reject;':
                     self.log.debug(
-                        'validate: zone=%s, dmarc_value indicates no-mail'
+                        'validate: zone=%s, dmarc_value indicates no-mail',
+                        zone.decoded_name,
                     )
                     mode = 'no-mail'
-                elif (
-                    apex_mx_record
-                    and len(apex_mx_record.values) == 1
-                    and apex_mx_record.values[0].preference == 0
-                    and apex_mx_record.values[0].exchange == '.'
-                ):
+                elif apex_mx_record and self._is_null_mx(apex_mx_record):
                     self.log.debug(
-                        'validate: zone=%s, apex_mx_record indicates'
+                        'validate: zone=%s, apex_mx_record indicates no-mail',
+                        zone.decoded_name,
                     )
                     mode = 'no-mail'
                 else:
-                    self.log.debug('validate: zone=%s, assuming mail handling')
+                    self.log.debug(
+                        'validate: zone=%s, assuming mail handling',
+                        zone.decoded_name,
+                    )
                     mode = 'mail'
 
         if mode == 'mail':

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -305,8 +305,7 @@ class TestMailZoneValidator(TestCase):
         reasons = v.validate(zone)
         self.assertIn('missing a Null MX record', str(reasons[0]))
 
-        # Non-apex MX alone does NOT trigger mail mode detection; only the
-        # redundancy check fires, not full mail/no-mail validation.
+        # Non-apex MX triggers redundancy check AND sub-zone SPF validation.
         zone = _make_zone()
         mx = _add_record(
             zone,
@@ -319,14 +318,353 @@ class TestMailZoneValidator(TestCase):
         )
         zone.add_record(mx)
         reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
+        self.assertEqual(2, len(reasons))
         self.assertIn(
             'should have at least 2 values for redundancy', str(reasons[0])
+        )
+        self.assertIn(
+            'handles mail but is missing an SPF TXT record', str(reasons[1])
         )
 
         # No-op with no signs
         zone = _make_zone()
         self.assertEqual([], v.validate(zone))
+
+    def test_subzone_mail_success(self):
+        # Use auto mode so apex auto-detection finds no apex signals and skips;
+        # sub-domain with MX+SPF validates clean.
+        zone = _make_zone()
+        mx = _add_record(
+            zone,
+            'sub',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [
+                    {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                    {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                ],
+            },
+        )
+        zone.add_record(mx)
+        spf = _add_record(
+            zone,
+            'sub',
+            {
+                'ttl': 300,
+                'type': 'TXT',
+                'values': ['V=SPF1 include:example.com -ALL'],
+            },
+        )
+        zone.add_record(spf)
+        # No _dmarc.sub record — DMARC is not required at the sub-domain level
+        v = MailZoneValidator('test', mode='auto')
+        self.assertEqual([], v.validate(zone))
+
+    def test_subzone_mail_failures(self):
+        # Use auto mode so apex validation does not interfere
+        v = MailZoneValidator('test', mode='auto')
+
+        # Missing SPF
+        zone = _make_zone()
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [
+                        {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                        {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                    ],
+                },
+            )
+        )
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'handles mail but is missing an SPF TXT record', str(reasons[0])
+        )
+
+        # Bad SPF terminator
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {'ttl': 300, 'type': 'TXT', 'values': ['v=spf1 include:a.com']},
+            )
+        )
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('terminate with "~all" or "-all"', str(reasons[0]))
+
+        # Multiple SPF values
+        zone = _make_zone()
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [
+                        {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                        {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                    ],
+                },
+            )
+        )
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'TXT',
+                    'values': [
+                        'v=spf1 include:a.com ~all',
+                        'v=spf1 include:b.com -all',
+                    ],
+                },
+            )
+        )
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has multiple SPF values', str(reasons[0]))
+
+    def test_subzone_no_mail_success(self):
+        # Use auto mode so apex auto-detection finds no apex signals and skips
+        zone = _make_zone()
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [{'preference': 0, 'exchange': '.'}],
+                },
+            )
+        )
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {'ttl': 300, 'type': 'TXT', 'values': ['V=SPF1 -ALL']},
+            )
+        )
+        v = MailZoneValidator('test', mode='auto')
+        # Null MX has a single value by design; redundancy check fires as expected
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'should have at least 2 values for redundancy', str(reasons[0])
+        )
+
+    def test_subzone_no_mail_failures(self):
+        # Use auto mode so apex auto-detection finds no apex signals and skips
+        v = MailZoneValidator('test', mode='auto')
+
+        # Missing strict SPF
+        zone = _make_zone()
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [{'preference': 0, 'exchange': '.'}],
+                },
+            )
+        )
+        reasons = v.validate(zone)
+        # redundancy + missing strict SPF
+        self.assertEqual(2, len(reasons))
+        self.assertIn(
+            'should have at least 2 values for redundancy', str(reasons[0])
+        )
+        self.assertIn('missing strict SPF TXT record', str(reasons[1]))
+
+        # Wrong SPF value
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'TXT',
+                    'values': ['v=spf1 include:a.com ~all'],
+                },
+            )
+        )
+        reasons = v.validate(zone)
+        self.assertEqual(2, len(reasons))
+        self.assertIn(
+            'should have at least 2 values for redundancy', str(reasons[0])
+        )
+        self.assertIn('should have a strict SPF TXT record', str(reasons[1]))
+
+    def test_explicit_mode_propagates_to_subzones(self):
+        # mode='mail': sub-zone with null MX still gets mail-mode SPF check.
+        # Provide a valid apex so only sub-zone errors surface.
+        def _valid_mail_apex(zone):
+            zone.add_record(
+                _add_record(
+                    zone,
+                    '',
+                    {
+                        'ttl': 300,
+                        'type': 'MX',
+                        'values': [
+                            {'preference': 10, 'exchange': 'mx1.unit.tests.'},
+                            {'preference': 20, 'exchange': 'mx2.unit.tests.'},
+                        ],
+                    },
+                )
+            )
+            zone.add_record(
+                _add_record(
+                    zone,
+                    '',
+                    {
+                        'ttl': 300,
+                        'type': 'TXT',
+                        'values': ['v=spf1 include:example.com -all'],
+                    },
+                )
+            )
+            zone.add_record(
+                _add_record(
+                    zone,
+                    '_dmarc',
+                    {
+                        'ttl': 300,
+                        'type': 'TXT',
+                        'values': ['v=DMARC1\\; p=reject\\;'],
+                    },
+                )
+            )
+
+        def _valid_no_mail_apex(zone):
+            zone.add_record(
+                _add_record(
+                    zone,
+                    '',
+                    {
+                        'ttl': 300,
+                        'type': 'MX',
+                        'values': [{'preference': 0, 'exchange': '.'}],
+                    },
+                )
+            )
+            zone.add_record(
+                _add_record(
+                    zone,
+                    '',
+                    {'ttl': 300, 'type': 'TXT', 'values': ['v=spf1 -all']},
+                )
+            )
+            zone.add_record(
+                _add_record(
+                    zone,
+                    '_dmarc',
+                    {
+                        'ttl': 300,
+                        'type': 'TXT',
+                        'values': ['v=DMARC1\\; p=reject\\;'],
+                    },
+                )
+            )
+
+        # mode='mail': sub-zone null MX → mail mode forces SPF check (no null-MX check)
+        zone = _make_zone()
+        _valid_mail_apex(zone)
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [{'preference': 0, 'exchange': '.'}],
+                },
+            )
+        )
+        v = MailZoneValidator('test', mode='mail')
+        reasons = v.validate(zone)
+        # redundancy fires on sub null MX; mail-mode SPF missing
+        self.assertEqual(2, len(reasons))
+        self.assertIn(
+            'should have at least 2 values for redundancy', str(reasons[0])
+        )
+        self.assertIn(
+            'handles mail but is missing an SPF TXT record', str(reasons[1])
+        )
+
+        # mode='no-mail': sub-zone real MX → null-MX structure check + strict SPF check
+        zone = _make_zone()
+        _valid_no_mail_apex(zone)
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [
+                        {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                        {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                    ],
+                },
+            )
+        )
+        v = MailZoneValidator('test', mode='no-mail')
+        reasons = v.validate(zone)
+        # apex null-MX redundancy + sub null-MX structure failure + sub missing strict SPF
+        self.assertEqual(3, len(reasons))
+        self.assertIn(
+            'should have at least 2 values for redundancy', str(reasons[0])
+        )
+        self.assertIn('should have a single Null MX record', str(reasons[1]))
+        self.assertIn('missing strict SPF TXT record', str(reasons[2]))
+
+        # auto mode: apex no-mail + sub mail coexist cleanly when both are properly configured
+        zone = _make_zone()
+        _valid_no_mail_apex(zone)
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [
+                        {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                        {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                    ],
+                },
+            )
+        )
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'TXT',
+                    'values': ['v=spf1 include:mail.example.com -all'],
+                },
+            )
+        )
+        v = MailZoneValidator('test', mode='auto')
+        # only the apex null-MX redundancy warning fires
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'should have at least 2 values for redundancy', str(reasons[0])
+        )
 
     def test_builtin_registration(self):
         ids = [v.id for v in Zone.validators.available_validators()]

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -393,6 +393,35 @@ class TestMailZoneValidator(TestCase):
         self.assertEqual(1, len(reasons))
         self.assertIn('terminate with "~all" or "-all"', str(reasons[0]))
 
+        # Non-SPF TXT (TXT exists but no v=spf1 entry)
+        zone = _make_zone()
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [
+                        {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                        {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                    ],
+                },
+            )
+        )
+        zone.add_record(
+            _add_record(
+                zone,
+                'sub',
+                {'ttl': 300, 'type': 'TXT', 'values': ['some-other-txt']},
+            )
+        )
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'handles mail but is missing an SPF TXT record', str(reasons[0])
+        )
+
         # Multiple SPF values
         zone = _make_zone()
         zone.add_record(

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -193,13 +193,8 @@ class TestMailZoneValidator(TestCase):
         zone.add_record(dmarc)
 
         v = MailZoneValidator('test', mode='no-mail')
-        # The Null MX has exactly 1 value by design, which always triggers the
-        # MX redundancy check; no-mail-specific validations all pass.
-        reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
+        # All validations pass
+        self.assertEqual([], v.validate(zone))
 
     def test_no_mail_mode_failures(self):
         zone = _make_zone()
@@ -267,7 +262,7 @@ class TestMailZoneValidator(TestCase):
         reasons = v.validate(zone)
         self.assertIn('should have at least 2 values', str(reasons[0]))
 
-        # Auto-detects 'no-mail' via Null MX; redundancy check fires first
+        # Auto-detects 'no-mail' via Null MX
         zone = _make_zone()
         mx = _add_record(
             zone,
@@ -280,10 +275,9 @@ class TestMailZoneValidator(TestCase):
         )
         zone.add_record(mx)
         reasons = v.validate(zone)
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
-        self.assertIn('missing strict SPF TXT record', str(reasons[1]))
+        self.assertEqual(2, len(reasons))
+        self.assertIn('missing strict SPF TXT record', str(reasons[0]))
+        self.assertIn('missing strict DMARC TXT record', str(reasons[1]))
 
         # Auto-detects 'no-mail' via strict SPF
         zone = _make_zone()
@@ -455,12 +449,8 @@ class TestMailZoneValidator(TestCase):
             )
         )
         v = MailZoneValidator('test', mode='auto')
-        # Null MX has a single value by design; redundancy check fires as expected
-        reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
+        # All validations pass
+        self.assertEqual([], v.validate(zone))
 
     def test_subzone_no_mail_failures(self):
         # Use auto mode so apex auto-detection finds no apex signals and skips
@@ -480,12 +470,9 @@ class TestMailZoneValidator(TestCase):
             )
         )
         reasons = v.validate(zone)
-        # redundancy + missing strict SPF
-        self.assertEqual(2, len(reasons))
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
-        self.assertIn('missing strict SPF TXT record', str(reasons[1]))
+        # missing strict SPF
+        self.assertEqual(1, len(reasons))
+        self.assertIn('missing strict SPF TXT record', str(reasons[0]))
 
         # Wrong SPF value
         zone.add_record(
@@ -500,11 +487,8 @@ class TestMailZoneValidator(TestCase):
             )
         )
         reasons = v.validate(zone)
-        self.assertEqual(2, len(reasons))
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
-        self.assertIn('should have a strict SPF TXT record', str(reasons[1]))
+        self.assertEqual(1, len(reasons))
+        self.assertIn('should have a strict SPF TXT record', str(reasons[0]))
 
     def test_explicit_mode_propagates_to_subzones(self):
         # mode='mail': sub-zone with null MX still gets mail-mode SPF check.
@@ -594,13 +578,10 @@ class TestMailZoneValidator(TestCase):
         )
         v = MailZoneValidator('test', mode='mail')
         reasons = v.validate(zone)
-        # redundancy fires on sub null MX; mail-mode SPF missing
-        self.assertEqual(2, len(reasons))
+        # mail-mode SPF missing (null MX is skipped by redundancy check)
+        self.assertEqual(1, len(reasons))
         self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
-        self.assertIn(
-            'handles mail but is missing an SPF TXT record', str(reasons[1])
+            'handles mail but is missing an SPF TXT record', str(reasons[0])
         )
 
         # mode='no-mail': sub-zone real MX → null-MX structure check + strict SPF check
@@ -622,13 +603,10 @@ class TestMailZoneValidator(TestCase):
         )
         v = MailZoneValidator('test', mode='no-mail')
         reasons = v.validate(zone)
-        # apex null-MX redundancy + sub null-MX structure failure + sub missing strict SPF
-        self.assertEqual(3, len(reasons))
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
-        self.assertIn('should have a single Null MX record', str(reasons[1]))
-        self.assertIn('missing strict SPF TXT record', str(reasons[2]))
+        # sub null-MX structure failure + sub missing strict SPF (apex null-MX redundancy is gone)
+        self.assertEqual(2, len(reasons))
+        self.assertIn('should have a single Null MX record', str(reasons[0]))
+        self.assertIn('missing strict SPF TXT record', str(reasons[1]))
 
         # auto mode: apex no-mail + sub mail coexist cleanly when both are properly configured
         zone = _make_zone()
@@ -659,12 +637,8 @@ class TestMailZoneValidator(TestCase):
             )
         )
         v = MailZoneValidator('test', mode='auto')
-        # only the apex null-MX redundancy warning fires
-        reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn(
-            'should have at least 2 values for redundancy', str(reasons[0])
-        )
+        # All validations pass (apex null-MX redundancy warning is gone)
+        self.assertEqual([], v.validate(zone))
 
     def test_builtin_registration(self):
         ids = [v.id for v in Zone.validators.available_validators()]

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -669,6 +669,39 @@ class TestMailZoneValidator(TestCase):
         # All validations pass (apex null-MX redundancy warning is gone)
         self.assertEqual([], v.validate(zone))
 
+    def test_null_mx_skips_redundancy_check(self):
+        # Explicitly verify that Null MX records skip the redundancy check.
+        # This is a regression test for the case where we want to ensure
+        # that the 2-value minimum requirement is bypassed for Null MX.
+        zone = _make_zone()
+        # Null MX
+        mx = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 0, 'exchange': '.'}],
+            },
+        )
+        zone.add_record(mx)
+        # Strict SPF
+        spf = _add_record(
+            zone, '', {'ttl': 300, 'type': 'TXT', 'values': ['v=spf1 -all']}
+        )
+        zone.add_record(spf)
+        # Strict DMARC
+        dmarc = _add_record(
+            zone,
+            '_dmarc',
+            {'ttl': 300, 'type': 'TXT', 'values': ['v=DMARC1; p=reject;']},
+        )
+        zone.add_record(dmarc)
+
+        v = MailZoneValidator('test', mode='no-mail')
+        # All validations pass, specifically no redundancy warning for the single MX value
+        self.assertEqual([], v.validate(zone))
+
     def test_builtin_registration(self):
         ids = [v.id for v in Zone.validators.available_validators()]
         self.assertIn('mail', ids)


### PR DESCRIPTION
## Summary

- `MailZoneValidator` now validates MX redundancy and SPF for each non-apex sub-domain that has MX records, in addition to the existing apex checks
- When the validator is configured with an explicit `mode='mail'` or `mode='no-mail'`, that mode propagates to sub-domains as well as the apex
- In `auto` mode, each sub-domain is independently detected: null MX → `no-mail`, otherwise → `mail`
- DMARC is intentionally not required at the sub-domain level since it inherits from the parent zone

## Details

For `mail` sub-domains: SPF TXT must be present and terminate with `~all` or `-all`.

For `no-mail` sub-domains: MX must be a single null MX (`0 .`) and SPF must be exactly `v=spf1 -all`.

Related: #1396, #1398