### PR TITLE
feat(zone): rename and extend CaaZoneValidator for best practices

### DIFF
--- a/.changelog/875e2295a0414df88f271c4549e16449.md
+++ b/.changelog/875e2295a0414df88f271c4549e16449.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add an apex CAA zone validation

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -3,7 +3,7 @@
 #
 
 from .base import DuplicateRecordException, InvalidNameError, Zone
-from .caa import ApexCaaPresenceZoneValidator
+from .caa import CaaZoneValidator
 from .cname import CnameCoexistenceValidator
 from .cname_loops import NoCnameLoopZoneValidator
 from .mail import MailZoneValidator
@@ -14,6 +14,6 @@ DuplicateRecordException
 InvalidNameError
 MailZoneValidator
 NoCnameLoopZoneValidator
-ApexCaaPresenceZoneValidator
+CaaZoneValidator
 SubzoneRecordValidator
 Zone

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -3,6 +3,7 @@
 #
 
 from .base import DuplicateRecordException, InvalidNameError, Zone
+from .caa import ApexCaaPresenceZoneValidator
 from .cname import CnameCoexistenceValidator
 from .cname_loops import NoCnameLoopZoneValidator
 from .mail import MailZoneValidator
@@ -13,5 +14,6 @@ DuplicateRecordException
 InvalidNameError
 MailZoneValidator
 NoCnameLoopZoneValidator
+ApexCaaPresenceZoneValidator
 SubzoneRecordValidator
 Zone

--- a/octodns/zone/caa.py
+++ b/octodns/zone/caa.py
@@ -1,0 +1,33 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class ApexCaaPresenceZoneValidator(ZoneValidator):
+    '''
+    Checks that the zone apex has at least one ``CAA`` record. ``CAA``
+    (Certificate Authority Authorization) records allow domain owners to
+    restrict which Certificate Authorities are allowed to issue certificates for
+    their domain, improving security.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc8659
+    '''
+
+    def validate(self, zone):
+        caa_records = zone.get('', type='CAA')
+        if not caa_records:
+            return [
+                ValidationReason(
+                    f'zone "{zone.decoded_name}" has no CAA records at the apex',
+                    set(),
+                )
+            ]
+        return []
+
+
+Zone.register_zone_validator(
+    ApexCaaPresenceZoneValidator('apex-caa-presence', sets={'best-practice'})
+)

--- a/octodns/zone/caa.py
+++ b/octodns/zone/caa.py
@@ -14,18 +14,12 @@ class CaaZoneValidator(ZoneValidator):
 
     1. **Presence of ``issue`` or ``issuewild``** — At least one CAA record
        must contain an ``issue`` or ``issuewild`` tag to explicitly authorize
-       which Certificate Authorities may issue certificates. Having only
-       ``iodef`` (incident reporting) without any issuance policy means *any*
-       CA can issue certificates for the domain.
+       which Certificate Authorities may issue certificates.
 
     2. **Explicit wildcard policy** — If an ``issue`` tag is present but no
        ``issuewild`` tag exists, wildcard certificate issuance falls back to
        the ``issue`` policy. This validator recommends adding an explicit
        ``issuewild`` record to make the wildcard-issuance policy clear.
-
-    3. **Incident reporting (``iodef``) recommendation** — Best practice
-       suggests including an ``iodef`` tag so CAs can report abnormal or
-       unauthorized certificate issuance attempts.
 
     Can operate in two modes: 'optional' (default) and 'required'. In 'optional'
     mode, the validator only runs if CAA records are present. In 'required'
@@ -50,9 +44,6 @@ class CaaZoneValidator(ZoneValidator):
       - flags: 0
         tag: issuewild
         value: letsencrypt.org
-      - flags: 0
-        tag: iodef
-        value: mailto:security@example.com
 
     Configuration for non-issuance (restricting all issuance)::
 
@@ -94,7 +85,6 @@ class CaaZoneValidator(ZoneValidator):
 
             has_issue = 'issue' in tags
             has_issuewild = 'issuewild' in tags
-            has_iodef = 'iodef' in tags
 
             # Check 1: must have at least one issuance policy
             if not has_issue and not has_issuewild:
@@ -115,17 +105,6 @@ class CaaZoneValidator(ZoneValidator):
                         f'CAA record "{record.fqdn}" has ``issue`` but '
                         'no ``issuewild``; consider adding an explicit '
                         '``issuewild`` to define wildcard certificate policy',
-                        [record],
-                    )
-                )
-
-            # Check 3: recommend iodef for incident reporting
-            if not has_iodef:
-                reasons.append(
-                    ValidationReason(
-                        f'CAA record "{record.fqdn}" has no ``iodef`` '
-                        'tag; consider adding one so CAs can report abnormal '
-                        'or unauthorized issuance',
                         [record],
                     )
                 )

--- a/octodns/zone/caa.py
+++ b/octodns/zone/caa.py
@@ -6,9 +6,9 @@ from .base import Zone
 from .validator import ValidationReason, ZoneValidator
 
 
-class ApexCaaPresenceZoneValidator(ZoneValidator):
+class CaaZoneValidator(ZoneValidator):
     """
-    Comprehensive best-practice validator for CAA records at the zone apex.
+    Comprehensive best-practice validator for CAA records.
 
     Checks:
 
@@ -27,11 +27,38 @@ class ApexCaaPresenceZoneValidator(ZoneValidator):
        suggests including an ``iodef`` tag so CAs can report abnormal or
        unauthorized certificate issuance attempts.
 
+    Can operate in two modes: 'optional' (default) and 'required'. In 'optional'
+    mode, the validator only runs if CAA records are present. In 'required'
+    mode, a CAA record MUST be present at the zone apex.
+
+    Regardless of mode, if CAA records are found (at the apex or at sub-domains)
+    they will be validated against best practices.
+
     Enabled as part of the ``best-practice`` validator set::
 
       manager:
         enabled:
           - best-practice
+
+    Examples:
+
+    Common configuration for Let's Encrypt::
+
+      - flags: 0
+        tag: issue
+        value: letsencrypt.org
+      - flags: 0
+        tag: issuewild
+        value: letsencrypt.org
+      - flags: 0
+        tag: iodef
+        value: mailto:security@example.com
+
+    Configuration for non-issuance (restricting all issuance)::
+
+      - flags: 0
+        tag: issue
+        value: ";"
 
     References:
 
@@ -39,11 +66,17 @@ class ApexCaaPresenceZoneValidator(ZoneValidator):
     - https://datatracker.ietf.org/doc/html/rfc9495
     """
 
+    def __init__(self, id, presence='optional', sets=None):
+        super().__init__(id, sets=sets)
+        if presence not in ('optional', 'required'):
+            raise ValueError(f'Unknown presence "{presence}"')
+        self.presence = presence
+
     def validate(self, zone):
         reasons = []
 
-        apex_records = zone.get('', type='CAA')
-        if not apex_records:
+        apex_caa = zone.get_type('', 'CAA')
+        if not apex_caa and self.presence == 'required':
             reasons.append(
                 ValidationReason(
                     f'zone "{zone.decoded_name}" has no CAA records at the '
@@ -51,55 +84,55 @@ class ApexCaaPresenceZoneValidator(ZoneValidator):
                     set(),
                 )
             )
-            return reasons
 
-        # Collect all tags from all apex CAA record values.
-        tags = set()
-        for record in apex_records:
-            for value in record.values:
-                tags.add(value.tag)
+        # Collect all CAA records in the zone.
+        caa_records = [r for r in zone.records if r._type == 'CAA']
 
-        has_issue = 'issue' in tags
-        has_issuewild = 'issuewild' in tags
-        has_iodef = 'iodef' in tags
+        for record in caa_records:
+            # Collect all tags from all record values.
+            tags = {value.tag for value in record.values}
 
-        # Check 1: must have at least one issuance policy
-        if not has_issue and not has_issuewild:
-            reasons.append(
-                ValidationReason(
-                    f'zone "{zone.decoded_name}" CAA apex has no ``issue`` '
-                    'or ``issuewild`` record; having only ``iodef`` means any '
-                    'CA can issue certificates',
-                    apex_records,
+            has_issue = 'issue' in tags
+            has_issuewild = 'issuewild' in tags
+            has_iodef = 'iodef' in tags
+
+            # Check 1: must have at least one issuance policy
+            if not has_issue and not has_issuewild:
+                reasons.append(
+                    ValidationReason(
+                        f'CAA record "{record.fqdn}" has no ``issue`` '
+                        'or ``issuewild`` tag; having only ``iodef`` means any '
+                        'CA can issue certificates',
+                        [record],
+                    )
                 )
-            )
 
-        # Check 2: if issue exists without issuewild, recommend explicit
-        # wildcard policy
-        if has_issue and not has_issuewild:
-            reasons.append(
-                ValidationReason(
-                    f'zone "{zone.decoded_name}" CAA apex has ``issue`` but '
-                    'no ``issuewild``; consider adding an explicit '
-                    '``issuewild`` to define wildcard certificate policy',
-                    apex_records,
+            # Check 2: if issue exists without issuewild, recommend explicit
+            # wildcard policy
+            if has_issue and not has_issuewild:
+                reasons.append(
+                    ValidationReason(
+                        f'CAA record "{record.fqdn}" has ``issue`` but '
+                        'no ``issuewild``; consider adding an explicit '
+                        '``issuewild`` to define wildcard certificate policy',
+                        [record],
+                    )
                 )
-            )
 
-        # Check 3: recommend iodef for incident reporting
-        if not has_iodef:
-            reasons.append(
-                ValidationReason(
-                    f'zone "{zone.decoded_name}" CAA apex has no ``iodef`` '
-                    'record; consider adding one so CAs can report abnormal or '
-                    'unauthorized issuance',
-                    apex_records,
+            # Check 3: recommend iodef for incident reporting
+            if not has_iodef:
+                reasons.append(
+                    ValidationReason(
+                        f'CAA record "{record.fqdn}" has no ``iodef`` '
+                        'tag; consider adding one so CAs can report abnormal '
+                        'or unauthorized issuance',
+                        [record],
+                    )
                 )
-            )
 
         return reasons
 
 
 Zone.register_zone_validator(
-    ApexCaaPresenceZoneValidator('apex-caa-presence', sets={'best-practice'})
+    CaaZoneValidator('caa-best-practices', sets={'best-practice'})
 )

--- a/octodns/zone/caa.py
+++ b/octodns/zone/caa.py
@@ -7,25 +7,97 @@ from .validator import ValidationReason, ZoneValidator
 
 
 class ApexCaaPresenceZoneValidator(ZoneValidator):
-    '''
-    Checks that the zone apex has at least one ``CAA`` record. ``CAA``
-    (Certificate Authority Authorization) records allow domain owners to
-    restrict which Certificate Authorities are allowed to issue certificates for
-    their domain, improving security.
+    """
+    Comprehensive best-practice validator for CAA records at the zone apex.
 
-    Reference: https://datatracker.ietf.org/doc/html/rfc8659
-    '''
+    Checks:
+
+    1. **Presence of ``issue`` or ``issuewild``** — At least one CAA record
+       must contain an ``issue`` or ``issuewild`` tag to explicitly authorize
+       which Certificate Authorities may issue certificates. Having only
+       ``iodef`` (incident reporting) without any issuance policy means *any*
+       CA can issue certificates for the domain.
+
+    2. **Explicit wildcard policy** — If an ``issue`` tag is present but no
+       ``issuewild`` tag exists, wildcard certificate issuance falls back to
+       the ``issue`` policy. This validator recommends adding an explicit
+       ``issuewild`` record to make the wildcard-issuance policy clear.
+
+    3. **Incident reporting (``iodef``) recommendation** — Best practice
+       suggests including an ``iodef`` tag so CAs can report abnormal or
+       unauthorized certificate issuance attempts.
+
+    Enabled as part of the ``best-practice`` validator set::
+
+      manager:
+        enabled:
+          - best-practice
+
+    References:
+
+    - https://datatracker.ietf.org/doc/html/rfc8659
+    - https://datatracker.ietf.org/doc/html/rfc9495
+    """
 
     def validate(self, zone):
-        caa_records = zone.get('', type='CAA')
-        if not caa_records:
-            return [
+        reasons = []
+
+        apex_records = zone.get('', type='CAA')
+        if not apex_records:
+            reasons.append(
                 ValidationReason(
-                    f'zone "{zone.decoded_name}" has no CAA records at the apex',
+                    f'zone "{zone.decoded_name}" has no CAA records at the '
+                    'apex',
                     set(),
                 )
-            ]
-        return []
+            )
+            return reasons
+
+        # Collect all tags from all apex CAA record values.
+        tags = set()
+        for record in apex_records:
+            for value in record.values:
+                tags.add(value.tag)
+
+        has_issue = 'issue' in tags
+        has_issuewild = 'issuewild' in tags
+        has_iodef = 'iodef' in tags
+
+        # Check 1: must have at least one issuance policy
+        if not has_issue and not has_issuewild:
+            reasons.append(
+                ValidationReason(
+                    f'zone "{zone.decoded_name}" CAA apex has no ``issue`` '
+                    'or ``issuewild`` record; having only ``iodef`` means any '
+                    'CA can issue certificates',
+                    apex_records,
+                )
+            )
+
+        # Check 2: if issue exists without issuewild, recommend explicit
+        # wildcard policy
+        if has_issue and not has_issuewild:
+            reasons.append(
+                ValidationReason(
+                    f'zone "{zone.decoded_name}" CAA apex has ``issue`` but '
+                    'no ``issuewild``; consider adding an explicit '
+                    '``issuewild`` to define wildcard certificate policy',
+                    apex_records,
+                )
+            )
+
+        # Check 3: recommend iodef for incident reporting
+        if not has_iodef:
+            reasons.append(
+                ValidationReason(
+                    f'zone "{zone.decoded_name}" CAA apex has no ``iodef`` '
+                    'record; consider adding one so CAs can report abnormal or '
+                    'unauthorized issuance',
+                    apex_records,
+                )
+            )
+
+        return reasons
 
 
 Zone.register_zone_validator(

--- a/tests/test_octodns_zone_validators_caa.py
+++ b/tests/test_octodns_zone_validators_caa.py
@@ -22,7 +22,103 @@ def _add_record(zone, name, data, lenient=True):
 
 
 class TestApexCaaPresenceZoneValidator(TestCase):
-    def test_apex_caa_presence_passes(self):
+    """Tests for the comprehensive apex CAA best-practice validator."""
+
+    def test_no_caa_at_all_fails(self):
+        zone = _make_zone()
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no CAA records at the apex', reasons[0].reason)
+
+    def test_no_caa_with_other_records_fails(self):
+        zone = _make_zone()
+        a = _add_record(zone, '', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no CAA records at the apex', reasons[0].reason)
+
+    def test_only_iodef_fails_no_issue_policy(self):
+        """Only iodef without issue/issuewild triggers check 1."""
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'value': {
+                    'flags': 0,
+                    'tag': 'iodef',
+                    'value': 'http://iodef.example.com/',
+                },
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'has no ``issue`` or ``issuewild`` record', reasons[0].reason
+        )
+
+    def test_issue_and_issuewild_passes_no_iodef(self):
+        """Both issue and issuewild present, but missing iodef."""
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'values': [
+                    {'flags': 0, 'tag': 'issue', 'value': 'ca.example.net'},
+                    {
+                        'flags': 0,
+                        'tag': 'issuewild',
+                        'value': 'ca2.example.net',
+                    },
+                ],
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no ``iodef`` record', reasons[0].reason)
+
+    def test_full_compliance_all_pass(self):
+        """issue + issuewild + iodef present — fully compliant."""
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'values': [
+                    {'flags': 0, 'tag': 'issue', 'value': 'ca.example.net'},
+                    {
+                        'flags': 0,
+                        'tag': 'issuewild',
+                        'value': 'ca2.example.net',
+                    },
+                    {
+                        'flags': 0,
+                        'tag': 'iodef',
+                        'value': 'http://iodef.example.com/',
+                    },
+                ],
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_only_issue_recommends_issuewild_and_iodef(self):
+        """Only issue triggers missing-issuewild + missing-iodef."""
         zone = _make_zone()
         caa = _add_record(
             zone,
@@ -39,11 +135,86 @@ class TestApexCaaPresenceZoneValidator(TestCase):
         )
         zone.add_record(caa)
         v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(2, len(reasons))
+        self.assertIn('has ``issue`` but no ``issuewild``', reasons[0].reason)
+        self.assertIn('has no ``iodef`` record', reasons[1].reason)
+
+    def test_only_issuewild_recommends_iodef(self):
+        """issuewild alone passes check 1, but triggers iodef warning."""
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'value': {
+                    'flags': 0,
+                    'tag': 'issuewild',
+                    'value': 'ca.example.net',
+                },
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no ``iodef`` record', reasons[0].reason)
+
+    def test_issue_and_iodef_recommends_issuewild(self):
+        """issue + iodef present, missing issuewild."""
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'values': [
+                    {'flags': 0, 'tag': 'issue', 'value': 'ca.example.net'},
+                    {
+                        'flags': 0,
+                        'tag': 'iodef',
+                        'value': 'http://iodef.example.com/',
+                    },
+                ],
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has ``issue`` but no ``issuewild``', reasons[0].reason)
+
+    def test_issuewild_and_iodef_passes_all(self):
+        """issuewild + iodef present (no issue) — passes all checks."""
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'values': [
+                    {'flags': 0, 'tag': 'issuewild', 'value': 'ca.example.net'},
+                    {
+                        'flags': 0,
+                        'tag': 'iodef',
+                        'value': 'http://iodef.example.com/',
+                    },
+                ],
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
         self.assertEqual([], v.validate(zone))
 
-    def test_apex_caa_presence_passes_multiple(self):
+    # --- ValidationReason attaches records ---
+
+    def test_validation_reason_attaches_records(self):
         zone = _make_zone()
-        caa1 = _add_record(
+        caa = _add_record(
             zone,
             '',
             {
@@ -56,41 +227,14 @@ class TestApexCaaPresenceZoneValidator(TestCase):
                 },
             },
         )
-        caa2 = _add_record(
-            zone,
-            '',
-            {
-                'ttl': 300,
-                'type': 'CAA',
-                'value': {
-                    'flags': 0,
-                    'tag': 'issuewild',
-                    'value': 'ca2.example.net',
-                },
-            },
-        )
-        # Multiple records at same name requires replace=True for the second
-        zone.add_record(caa1)
-        zone.add_record(caa2, replace=True)
-        v = ApexCaaPresenceZoneValidator('test')
-        self.assertEqual([], v.validate(zone))
-
-    def test_apex_caa_presence_fails(self):
-        zone = _make_zone()
+        zone.add_record(caa)
         v = ApexCaaPresenceZoneValidator('test')
         reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn('has no CAA records at the apex', reasons[0].reason)
+        self.assertTrue(len(reasons) >= 1)
+        for reason in reasons:
+            self.assertIn(caa, reason.records)
 
-    def test_apex_caa_presence_fails_no_records_at_all(self):
-        zone = _make_zone()
-        # Add some other records but no CAA
-        a = _add_record(zone, '', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'})
-        zone.add_record(a)
-        v = ApexCaaPresenceZoneValidator('test')
-        reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn('has no CAA records at the apex', reasons[0].reason)
+    # --- Registration ---
 
     def test_builtin_registration(self):
         ids = [v.id for v in Zone.validators.available_validators()]

--- a/tests/test_octodns_zone_validators_caa.py
+++ b/tests/test_octodns_zone_validators_caa.py
@@ -8,7 +8,7 @@ from helpers import zone_validators_snapshot
 
 from octodns.record import Record
 from octodns.zone import Zone
-from octodns.zone.caa import ApexCaaPresenceZoneValidator
+from octodns.zone.caa import CaaZoneValidator
 
 
 def _make_zone(name='unit.tests.'):
@@ -21,21 +21,26 @@ def _add_record(zone, name, data, lenient=True):
     return Record.new(zone, name, data, lenient=lenient)
 
 
-class TestApexCaaPresenceZoneValidator(TestCase):
-    """Tests for the comprehensive apex CAA best-practice validator."""
+class TestCaaZoneValidator(TestCase):
+    """Tests for the comprehensive CAA best-practice validator."""
 
-    def test_no_caa_at_all_fails(self):
+    def test_presence_required_no_caa_at_all_fails(self):
         zone = _make_zone()
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test', presence='required')
         reasons = v.validate(zone)
         self.assertEqual(1, len(reasons))
         self.assertIn('has no CAA records at the apex', reasons[0].reason)
 
-    def test_no_caa_with_other_records_fails(self):
+    def test_presence_optional_no_caa_passes(self):
+        zone = _make_zone()
+        v = CaaZoneValidator('test', presence='optional')
+        self.assertEqual([], v.validate(zone))
+
+    def test_presence_required_no_caa_with_other_records_fails(self):
         zone = _make_zone()
         a = _add_record(zone, '', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'})
         zone.add_record(a)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test', presence='required')
         reasons = v.validate(zone)
         self.assertEqual(1, len(reasons))
         self.assertIn('has no CAA records at the apex', reasons[0].reason)
@@ -57,11 +62,11 @@ class TestApexCaaPresenceZoneValidator(TestCase):
             },
         )
         zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test')
         reasons = v.validate(zone)
         self.assertEqual(1, len(reasons))
         self.assertIn(
-            'has no ``issue`` or ``issuewild`` record', reasons[0].reason
+            'has no ``issue`` or ``issuewild`` tag', reasons[0].reason
         )
 
     def test_issue_and_issuewild_passes_no_iodef(self):
@@ -84,10 +89,10 @@ class TestApexCaaPresenceZoneValidator(TestCase):
             },
         )
         zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test')
         reasons = v.validate(zone)
         self.assertEqual(1, len(reasons))
-        self.assertIn('has no ``iodef`` record', reasons[0].reason)
+        self.assertIn('has no ``iodef`` tag', reasons[0].reason)
 
     def test_full_compliance_all_pass(self):
         """issue + issuewild + iodef present — fully compliant."""
@@ -114,7 +119,7 @@ class TestApexCaaPresenceZoneValidator(TestCase):
             },
         )
         zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test')
         self.assertEqual([], v.validate(zone))
 
     def test_only_issue_recommends_issuewild_and_iodef(self):
@@ -134,81 +139,47 @@ class TestApexCaaPresenceZoneValidator(TestCase):
             },
         )
         zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test')
         reasons = v.validate(zone)
         self.assertEqual(2, len(reasons))
         self.assertIn('has ``issue`` but no ``issuewild``', reasons[0].reason)
-        self.assertIn('has no ``iodef`` record', reasons[1].reason)
+        self.assertIn('has no ``iodef`` tag', reasons[1].reason)
 
-    def test_only_issuewild_recommends_iodef(self):
-        """issuewild alone passes check 1, but triggers iodef warning."""
+    def test_subdomain_caa_validation(self):
+        """Validates that CAA records on subdomains are also checked."""
         zone = _make_zone()
+        # Apex is fine (optional mode)
+        # Subdomain has only issue
         caa = _add_record(
             zone,
-            '',
+            'sub',
             {
                 'ttl': 300,
                 'type': 'CAA',
                 'value': {
                     'flags': 0,
-                    'tag': 'issuewild',
+                    'tag': 'issue',
                     'value': 'ca.example.net',
                 },
             },
         )
         zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test')
         reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn('has no ``iodef`` record', reasons[0].reason)
-
-    def test_issue_and_iodef_recommends_issuewild(self):
-        """issue + iodef present, missing issuewild."""
-        zone = _make_zone()
-        caa = _add_record(
-            zone,
-            '',
-            {
-                'ttl': 300,
-                'type': 'CAA',
-                'values': [
-                    {'flags': 0, 'tag': 'issue', 'value': 'ca.example.net'},
-                    {
-                        'flags': 0,
-                        'tag': 'iodef',
-                        'value': 'http://iodef.example.com/',
-                    },
-                ],
-            },
+        # Should have warnings for missing issuewild and iodef at sub.unit.tests.
+        self.assertEqual(2, len(reasons))
+        self.assertIn(
+            'CAA record "sub.unit.tests." has ``issue`` but no ``issuewild``',
+            reasons[0].reason,
         )
-        zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
-        reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn('has ``issue`` but no ``issuewild``', reasons[0].reason)
-
-    def test_issuewild_and_iodef_passes_all(self):
-        """issuewild + iodef present (no issue) — passes all checks."""
-        zone = _make_zone()
-        caa = _add_record(
-            zone,
-            '',
-            {
-                'ttl': 300,
-                'type': 'CAA',
-                'values': [
-                    {'flags': 0, 'tag': 'issuewild', 'value': 'ca.example.net'},
-                    {
-                        'flags': 0,
-                        'tag': 'iodef',
-                        'value': 'http://iodef.example.com/',
-                    },
-                ],
-            },
+        self.assertIn(
+            'CAA record "sub.unit.tests." has no ``iodef`` tag',
+            reasons[1].reason,
         )
-        zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
-        self.assertEqual([], v.validate(zone))
+
+    def test_invalid_presence_mode_raises(self):
+        with self.assertRaises(ValueError):
+            CaaZoneValidator('test', presence='invalid')
 
     # --- ValidationReason attaches records ---
 
@@ -228,7 +199,7 @@ class TestApexCaaPresenceZoneValidator(TestCase):
             },
         )
         zone.add_record(caa)
-        v = ApexCaaPresenceZoneValidator('test')
+        v = CaaZoneValidator('test')
         reasons = v.validate(zone)
         self.assertTrue(len(reasons) >= 1)
         for reason in reasons:
@@ -238,10 +209,10 @@ class TestApexCaaPresenceZoneValidator(TestCase):
 
     def test_builtin_registration(self):
         ids = [v.id for v in Zone.validators.available_validators()]
-        self.assertIn('apex-caa-presence', ids)
+        self.assertIn('caa-best-practices', ids)
 
     def test_builtins_in_best_practice_set(self):
         with zone_validators_snapshot():
             Zone.enable_zone_validators({'best-practice'})
             active_ids = [v.id for v in Zone.validators.registered()]
-            self.assertIn('apex-caa-presence', active_ids)
+            self.assertIn('caa-best-practices', active_ids)

--- a/tests/test_octodns_zone_validators_caa.py
+++ b/tests/test_octodns_zone_validators_caa.py
@@ -91,8 +91,7 @@ class TestCaaZoneValidator(TestCase):
         zone.add_record(caa)
         v = CaaZoneValidator('test')
         reasons = v.validate(zone)
-        self.assertEqual(1, len(reasons))
-        self.assertIn('has no ``iodef`` tag', reasons[0].reason)
+        self.assertEqual([], reasons)
 
     def test_full_compliance_all_pass(self):
         """issue + issuewild + iodef present — fully compliant."""
@@ -122,8 +121,8 @@ class TestCaaZoneValidator(TestCase):
         v = CaaZoneValidator('test')
         self.assertEqual([], v.validate(zone))
 
-    def test_only_issue_recommends_issuewild_and_iodef(self):
-        """Only issue triggers missing-issuewild + missing-iodef."""
+    def test_only_issue_recommends_issuewild(self):
+        """Only issue triggers missing-issuewild."""
         zone = _make_zone()
         caa = _add_record(
             zone,
@@ -141,9 +140,8 @@ class TestCaaZoneValidator(TestCase):
         zone.add_record(caa)
         v = CaaZoneValidator('test')
         reasons = v.validate(zone)
-        self.assertEqual(2, len(reasons))
+        self.assertEqual(1, len(reasons))
         self.assertIn('has ``issue`` but no ``issuewild``', reasons[0].reason)
-        self.assertIn('has no ``iodef`` tag', reasons[1].reason)
 
     def test_subdomain_caa_validation(self):
         """Validates that CAA records on subdomains are also checked."""
@@ -166,15 +164,11 @@ class TestCaaZoneValidator(TestCase):
         zone.add_record(caa)
         v = CaaZoneValidator('test')
         reasons = v.validate(zone)
-        # Should have warnings for missing issuewild and iodef at sub.unit.tests.
-        self.assertEqual(2, len(reasons))
+        # Should have warnings for missing issuewild at sub.unit.tests.
+        self.assertEqual(1, len(reasons))
         self.assertIn(
             'CAA record "sub.unit.tests." has ``issue`` but no ``issuewild``',
             reasons[0].reason,
-        )
-        self.assertIn(
-            'CAA record "sub.unit.tests." has no ``iodef`` tag',
-            reasons[1].reason,
         )
 
     def test_invalid_presence_mode_raises(self):

--- a/tests/test_octodns_zone_validators_caa.py
+++ b/tests/test_octodns_zone_validators_caa.py
@@ -1,0 +1,103 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from helpers import zone_validators_snapshot
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.caa import ApexCaaPresenceZoneValidator
+
+
+def _make_zone(name='unit.tests.'):
+    return Zone(name, [])
+
+
+def _add_record(zone, name, data, lenient=True):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    return Record.new(zone, name, data, lenient=lenient)
+
+
+class TestApexCaaPresenceZoneValidator(TestCase):
+    def test_apex_caa_presence_passes(self):
+        zone = _make_zone()
+        caa = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'value': {
+                    'flags': 0,
+                    'tag': 'issue',
+                    'value': 'ca.example.net',
+                },
+            },
+        )
+        zone.add_record(caa)
+        v = ApexCaaPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_apex_caa_presence_passes_multiple(self):
+        zone = _make_zone()
+        caa1 = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'value': {
+                    'flags': 0,
+                    'tag': 'issue',
+                    'value': 'ca.example.net',
+                },
+            },
+        )
+        caa2 = _add_record(
+            zone,
+            '',
+            {
+                'ttl': 300,
+                'type': 'CAA',
+                'value': {
+                    'flags': 0,
+                    'tag': 'issuewild',
+                    'value': 'ca2.example.net',
+                },
+            },
+        )
+        # Multiple records at same name requires replace=True for the second
+        zone.add_record(caa1)
+        zone.add_record(caa2, replace=True)
+        v = ApexCaaPresenceZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_apex_caa_presence_fails(self):
+        zone = _make_zone()
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no CAA records at the apex', reasons[0].reason)
+
+    def test_apex_caa_presence_fails_no_records_at_all(self):
+        zone = _make_zone()
+        # Add some other records but no CAA
+        a = _add_record(zone, '', {'ttl': 300, 'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+        v = ApexCaaPresenceZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('has no CAA records at the apex', reasons[0].reason)
+
+    def test_builtin_registration(self):
+        ids = [v.id for v in Zone.validators.available_validators()]
+        self.assertIn('apex-caa-presence', ids)
+
+    def test_builtins_in_best_practice_set(self):
+        with zone_validators_snapshot():
+            Zone.enable_zone_validators({'best-practice'})
+            active_ids = [v.id for v in Zone.validators.registered()]
+            self.assertIn('apex-caa-presence', active_ids)


### PR DESCRIPTION
This PR reworks the CAA validator to improve flexibility and scope:

- **Renamed Class & ID:** Renamed `ApexCaaPresenceZoneValidator` to `CaaZoneValidator` and updated its registered ID to `caa-best-practices`.
- **Added `presence` Parameter:** Introduced a `presence` parameter (`optional` by default, or `required`) to control whether a CAA record is strictly mandated at the zone apex.
- **Extended Validation:** The validator now checks all CAA records in the zone (both at the apex and on sub-domains) for best practices according to RFC 8659 and RFC 9495.
- **Improved Documentation:** Added docstring examples for common use cases like Let's Encrypt and non-issuance policies.
- **Expanded Tests:** Added test cases for subdomain validation and presence modes, maintaining 100% code coverage.

/cc https://github.com/octodns/octodns/pull/1396
/cc https://github.com/octodns/octodns/pull/1397