### PR TITLE
Add support for using alias zones with wildcards

### DIFF
--- a/.changelog/dc53f775a1d4447f82d73bf747eefdc2.md
+++ b/.changelog/dc53f775a1d4447f82d73bf747eefdc2.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add support for using alias zones with wildcards

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -863,9 +863,26 @@ class Manager(object):
                 continue
 
             # it's dynamic, get a list of zone names from the configured sources
+            dynamic_sources = config.get('sources')
+            if not dynamic_sources:
+                # no sources for this dynamic zone, check if it's an alias
+                alias = config.get('alias')
+                if alias:
+                    # it is an alias, we'll use the sources from the aliased
+                    # zone
+                    try:
+                        dynamic_sources = zones[alias]['sources']
+                    except KeyError:
+                        # this will be caught and handled later in sync, for
+                        # now we'll just move on
+                        pass
+
             found_sources = sources or self._get_sources(
-                name, config, eligible_sources
+                name, {'sources': dynamic_sources}, eligible_sources
             )
+            if not found_sources:
+                continue
+
             self.log.info(
                 '_preprocess_zones: dynamic zone=%s, sources=%s',
                 name,

--- a/tests/config/dynamic-alias-missing-sources.yaml
+++ b/tests/config/dynamic-alias-missing-sources.yaml
@@ -1,0 +1,13 @@
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+zones:
+  target.zone.:
+    # no sources
+    targets:
+      - in
+  "*":
+    alias: target.zone.
+    targets:
+      - in

--- a/tests/config/dynamic-alias.yaml
+++ b/tests/config/dynamic-alias.yaml
@@ -1,0 +1,21 @@
+manager:
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+  dump:
+    class: octodns.provider.yaml.YamlProvider
+    directory: env/YAML_TMP_DIR
+
+zones:
+  subzone.unit.tests.:
+    sources:
+    - in
+    targets:
+    - dump
+
+  '*':
+    alias: subzone.unit.tests.
+    regex: '^unit.tests\.$'
+    targets:
+    - dump

--- a/tests/config/dynamic-eligible-sources-filtering.yaml
+++ b/tests/config/dynamic-eligible-sources-filtering.yaml
@@ -1,0 +1,13 @@
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+  other:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+zones:
+  "*":
+    sources:
+      - in
+    targets:
+      - other

--- a/tests/config/dynamic-no-sources-no-alias.yaml
+++ b/tests/config/dynamic-no-sources-no-alias.yaml
@@ -1,0 +1,9 @@
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+zones:
+  "*":
+    # no sources, no alias
+    targets:
+      - in

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -1889,6 +1889,45 @@ class TestManager(TestCase):
             manager.sync()
         self.assertIn('does not support `list_zones`', str(ctx.exception))
 
+    def test_dynamic_config_alias(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+
+            manager = Manager(get_config_filename('dynamic-alias.yaml'))
+
+            # subzone.unit.tests. has 3 records.
+            # *.alias should find subzone.unit.tests. and create an alias for
+            # it, which should also have 3 records.
+            # Total 6 changes.
+            self.assertEqual(6, manager.sync(dry_run=False))
+
+    def test_dynamic_config_alias_missing_sources(self):
+        manager = Manager(
+            get_config_filename('dynamic-alias-missing-sources.yaml')
+        )
+        # This will raise ManagerException because sources will be None
+        # eventually, hitting the pass in except KeyError and the continue
+        # if not found_sources
+        with self.assertRaises(ManagerException) as ctx:
+            manager.sync()
+        self.assertIn('is missing sources', str(ctx.exception))
+
+    def test_dynamic_config_no_sources_no_alias(self):
+        manager = Manager(
+            get_config_filename('dynamic-no-sources-no-alias.yaml')
+        )
+        with self.assertRaises(ManagerException) as ctx:
+            manager.sync()
+        self.assertIn('is missing sources', str(ctx.exception))
+
+    def test_dynamic_config_eligible_sources_filtering(self):
+        manager = Manager(
+            get_config_filename('dynamic-eligible-sources-filtering.yaml')
+        )
+        # 'other' is not in the dynamic zone's sources, so _get_sources
+        # returns None, hitting the continue
+        manager.sync(eligible_sources=['other'])
+
     def test_build_kwargs(self):
         manager = Manager(get_config_filename('simple.yaml'))
 


### PR DESCRIPTION
This PR adds support for the `alias` directive in dynamic zone configurations (e.g., `*`).

Currently, dynamic zones require `sources` to discover which zones to configure via `list_zones()`. When using an `alias`, `sources` is typically omitted. This change allows dynamic zones to fall back to the `sources` of the aliased zone for discovery.

Additionally, it fixes a potential crash when `eligible_sources` filters out all sources for a dynamic zone.

Includes tests and ensures 100% coverage.