### PR TITLE
Add consistent-ttl-at-name zone validator

### DIFF
--- a/.changelog/5ab7a2a80439432ea6228c760e3e7990.md
+++ b/.changelog/5ab7a2a80439432ea6228c760e3e7990.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add consistent-ttl-at-name zone validator

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -7,7 +7,9 @@ from .cname import CnameCoexistenceValidator
 from .cname_loops import NoCnameLoopZoneValidator
 from .mail import MailZoneValidator
 from .subzone import SubzoneRecordValidator
+from .ttl import ConsistentTtlAtNameZoneValidator
 
+ConsistentTtlAtNameZoneValidator
 CnameCoexistenceValidator
 DuplicateRecordException
 InvalidNameError

--- a/octodns/zone/ttl.py
+++ b/octodns/zone/ttl.py
@@ -1,0 +1,32 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class ConsistentTtlAtNameZoneValidator(ZoneValidator):
+    '''
+    Verify that all records at the same name (node) share the same TTL.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for node in zone._records.values():
+            if len(node) > 1:
+                ttls = {r.ttl for r in node}
+                if len(ttls) > 1:
+                    record = next(iter(node))
+                    reasons.append(
+                        ValidationReason(
+                            f'Invalid state, multiple TTLs at {record.fqdn}',
+                            node,
+                        )
+                    )
+        return reasons
+
+
+Zone.register_zone_validator(
+    ConsistentTtlAtNameZoneValidator('consistent-ttl-at-name', sets={'strict'})
+)

--- a/tests/test_octodns_zone_validators_ttl.py
+++ b/tests/test_octodns_zone_validators_ttl.py
@@ -1,0 +1,49 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.ttl import ConsistentTtlAtNameZoneValidator
+
+
+def _make_zone(name='unit.tests.'):
+    return Zone(name, [])
+
+
+def _add_record(zone, name, data, lenient=True):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    record = Record.new(zone, name, data, lenient=lenient)
+    zone.add_record(record)
+    return record
+
+
+class TestConsistentTtlAtNameZoneValidator(TestCase):
+    def test_valid_same_ttl(self):
+        zone = _make_zone()
+        _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4', 'ttl': 300})
+        _add_record(zone, 'www', {'type': 'AAAA', 'value': '::1', 'ttl': 300})
+
+        v = ConsistentTtlAtNameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))
+
+    def test_invalid_different_ttls(self):
+        zone = _make_zone()
+        _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4', 'ttl': 300})
+        _add_record(zone, 'www', {'type': 'AAAA', 'value': '::1', 'ttl': 600})
+
+        v = ConsistentTtlAtNameZoneValidator('test')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('multiple TTLs', str(reasons[0]))
+        self.assertEqual(2, len(reasons[0].records))
+
+    def test_single_record(self):
+        zone = _make_zone()
+        _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4', 'ttl': 300})
+
+        v = ConsistentTtlAtNameZoneValidator('test')
+        self.assertEqual([], v.validate(zone))


### PR DESCRIPTION
Ports the consistent-ttl-at-name validator from PR #1397 into the current ZoneValidator system. When multiple records exist at the same name (node) they must share the same TTL. The validator is registered with the 'strict' set.

- octodns/zone/ttl.py: new ConsistentTtlAtNameZoneValidator
- octodns/zone/__init__.py: export the new validator
- tests/test_octodns_zone_validators_ttl.py: dedicated test coverage

/cc https://github.com/octodns/octodns/pull/1396