### PR TITLE
New provider: OpusDNS

### DIFF
--- a/.changelog/787467ce3ffc4a1c949a70aa34f23612.md
+++ b/.changelog/787467ce3ffc4a1c949a70aa34f23612.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+New provider: OpusDNS, and fix Bunny DNS provider URL

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,6 +143,9 @@ their own repositories and released as independent modules.
    * - `NS1`_
      - `octodns_ns1`_
      -
+   * - `OpusDNS`_
+     - `octodns_opusdns`_
+     -
    * - `OVHcloud DNS`_
      - `octodns_ovh`_
      -
@@ -194,7 +197,7 @@ their own repositories and released as independent modules.
 .. _BIND, AXFR, RFC-2136: https://www.isc.org/bind/
 .. _octodns_bind: https://github.com/octodns/octodns-bind/
 .. _Bunny DNS: https://bunny.net/dns/
-.. _octodns_bunny: https://github.com/Relkian/octodns-bunny
+.. _octodns_bunny: https://github.com/relkian/octodns-bunny
 .. _Cloudflare DNS: https://www.cloudflare.com/dns/
 .. _octodns_cloudflare: https://github.com/octodns/octodns-cloudflare/
 .. _ClouDNS: https://www.cloudns.net/
@@ -241,6 +244,8 @@ their own repositories and released as independent modules.
 .. _olofvndrhr/octodns-netbox-dns: https://github.com/olofvndrhr/octodns-netbox-dns
 .. _NS1: https://ns1.com/products/managed-dns
 .. _octodns_ns1: https://github.com/octodns/octodns-ns1/
+.. _OpusDNS: https://www.opusdns.com/dns
+.. _octodns_opusdns: https://github.com/relkian/octodns-opusdns
 .. _OVHcloud DNS: https://www.ovhcloud.com/en/domains/dns-subdomain/
 .. _octodns_ovh: https://github.com/octodns/octodns-ovh/
 .. _Pi-hole: https://pi-hole.net/


### PR DESCRIPTION
This PR adds [OpusDNS provider](https://github.com/relkian/octodns-opusdns) to the providers list.
It also fixes a typo in my existing [Bunny DNS provider](https://github.com/relkian/octodns-bunny) repository URL.