### PR TITLE
Implement additional DNS validators for octoDNS

### DIFF
--- a/.changelog/24133387c13041949fa4cf79276736f3.md
+++ b/.changelog/24133387c13041949fa4cf79276736f3.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Implement additional DNS validators (SPF, CNAME, ALIAS, IPs)

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -6,7 +6,11 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .target import _check_target_format, _check_target_trailing_dot
+from .target import (
+    _check_target_format,
+    _check_target_not_ip,
+    _check_target_trailing_dot,
+)
 from .validator import ValueValidator
 
 
@@ -108,10 +112,27 @@ class MxValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
+class MxValueNotIpValidator(ValueValidator):
+    '''
+    Checks that the MX ``exchange`` field is not an IP address.
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            exchange = value.get('exchange') or value.get('value')
+            if exchange:
+                reasons += _check_target_not_ip(exchange, _type, 'exchange')
+        return reasons
+
+
 class MxValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         MxValueValidator('mx-value', sets={'legacy'}),
         MxValueRfcValidator('mx-value-rfc', sets={'strict'}),
+        MxValueNotIpValidator(
+            'mx-value-not-ip', sets={'strict', 'best-practice'}
+        ),
         MxValueBestPracticeValidator(
             'mx-value-best-practice', sets={'best-practice'}
         ),

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -2,22 +2,31 @@
 #
 #
 
-from ..deprecation import deprecated
 from .base import Record
 from .chunked import _ChunkedValue, _ChunkedValuesMixin
+from .validator import RecordValidator
+
+
+class SpfRecordTypeValidator(RecordValidator):
+    '''
+    Validates that the deprecated SPF record type is not used.
+    '''
+
+    def validate(self, record_cls, name, fqdn, data):
+        return [
+            'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0'
+        ]
 
 
 class SpfRecord(_ChunkedValuesMixin, Record):
     REFERENCES = ('https://datatracker.ietf.org/doc/html/rfc7208',)
     _type = 'SPF'
     _value_type = _ChunkedValue
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        deprecated(
-            'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0',
-            stacklevel=99,
+    VALIDATORS = [
+        SpfRecordTypeValidator(
+            'spf-record-type', sets={'strict', 'best-practice'}
         )
+    ]
 
 
 Record.register_type(SpfRecord)

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -8,7 +8,11 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .target import _check_target_format, _check_target_trailing_dot
+from .target import (
+    _check_target_format,
+    _check_target_not_ip,
+    _check_target_trailing_dot,
+)
 from .validator import RecordValidator, ValueValidator
 
 
@@ -186,10 +190,27 @@ class SrvValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
+class SrvValueNotIpValidator(ValueValidator):
+    '''
+    Checks that the SRV ``target`` field is not an IP address.
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        for value in data:
+            target = value.get('target')
+            if target:
+                reasons += _check_target_not_ip(target, _type, 'target')
+        return reasons
+
+
 class SrvValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         SrvValueValidator('srv-value', sets={'legacy'}),
         SrvValueRfcValidator('srv-value-rfc', sets={'strict'}),
+        SrvValueNotIpValidator(
+            'srv-value-not-ip', sets={'strict', 'best-practice'}
+        ),
         SrvValueBestPracticeValidator(
             'srv-value-best-practice', sets={'best-practice'}
         ),

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -2,6 +2,8 @@
 #
 #
 
+import ipaddress
+
 from fqdn import FQDN
 
 from ..idna import idna_encode
@@ -18,6 +20,21 @@ def _check_target_format(target, _type, key='value'):
     target = idna_encode(target)
     if not FQDN(str(target), allow_underscores=True).is_valid:
         return [f'{_type} {key} "{target}" is not a valid FQDN']
+    return []
+
+
+def _check_target_not_ip(target, _type, key='value'):
+    if not target or target == '.':
+        return []
+    if '{' in target and '}' in target:
+        return []
+
+    t = target.rstrip('.')
+    try:
+        ipaddress.ip_address(t)
+        return [f'{_type} {key} "{target}" is an IP address']
+    except ValueError:
+        pass
     return []
 
 
@@ -56,6 +73,28 @@ class TargetsValueValidator(ValueValidator):
         for value in data:
             reasons += _check_target_format(value, _type)
 
+        return reasons
+
+
+class TargetValueNotIpValidator(ValueValidator):
+    '''
+    Checks that a single-value target is not an IP address.
+    '''
+
+    def validate(self, value_cls, data, _type):
+        return _check_target_not_ip(data, _type)
+
+
+class TargetsValueNotIpValidator(ValueValidator):
+    '''
+    Checks that each target in a multi-value record is not an IP address.
+    '''
+
+    def validate(self, value_cls, data, _type):
+        reasons = []
+        if data:
+            for value in data:
+                reasons += _check_target_not_ip(value, _type)
         return reasons
 
 
@@ -98,6 +137,9 @@ class TargetsValueBestPracticeValidator(ValueValidator):
 class _TargetValue(str):
     VALIDATORS = [
         TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'}),
+        TargetValueNotIpValidator(
+            'target-value-not-ip', sets={'strict', 'best-practice'}
+        ),
         TargetValueBestPracticeValidator(
             'target-value-best-practice', sets={'best-practice'}
         ),
@@ -136,6 +178,9 @@ class _TargetValue(str):
 class _TargetsValue(str):
     VALIDATORS = [
         TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'}),
+        TargetsValueNotIpValidator(
+            'targets-value-not-ip', sets={'strict', 'best-practice'}
+        ),
         TargetsValueBestPracticeValidator(
             'targets-value-best-practice', sets={'best-practice'}
         ),

--- a/octodns/zone/cname.py
+++ b/octodns/zone/cname.py
@@ -9,7 +9,7 @@ from .validator import ValidationReason, ZoneValidator
 class CnameCoexistenceValidator(ZoneValidator):
     '''
     Verify that CNAME records do not coexist with other records at the same
-    node.
+    node, and ALIAS records do not coexist with A or AAAA records.
     '''
 
     def validate(self, zone):
@@ -19,10 +19,18 @@ class CnameCoexistenceValidator(ZoneValidator):
                 types = [r._type for r in node]
                 if 'CNAME' in types:
                     # All records at this node have the same FQDN
-                    record = next(iter(node))
+                    record = next(r for r in node if r._type == 'CNAME')
                     reasons.append(
                         ValidationReason(
                             f'Invalid state, CNAME at {record.fqdn} cannot coexist with other records',
+                            node,
+                        )
+                    )
+                elif 'ALIAS' in types and ('A' in types or 'AAAA' in types):
+                    record = next(r for r in node if r._type == 'ALIAS')
+                    reasons.append(
+                        ValidationReason(
+                            f'Invalid state, ALIAS at {record.fqdn} cannot coexist with A or AAAA records',
                             node,
                         )
                     )
@@ -103,6 +111,48 @@ class CnameTargetResolvableInZoneZoneValidator(ZoneValidator):
         return reasons
 
 
+class RootCnameZoneValidator(ZoneValidator):
+    '''
+    Checks that a CNAME record is not present at the zone apex (root).
+    RFC 1912 forbids CNAME records at the root.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        cname = zone.get_type('', 'CNAME')
+        if cname:
+            reasons.append(
+                ValidationReason(
+                    f'CNAME record at zone apex "{cname.decoded_fqdn}" is not allowed',
+                    [cname],
+                )
+            )
+        return reasons
+
+
+class CnameTargetNotCnameZoneValidator(ZoneValidator):
+    '''
+    Checks that CNAME records do not point to other CNAME records within the same zone.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        for record in zone.records:
+            if record._type == 'CNAME':
+                target = str(record.value)
+                if zone.owns('CNAME', target):
+                    hostname = zone.hostname_from_fqdn(target)
+                    cnames = zone.get(hostname, type='CNAME')
+                    if cnames:
+                        reasons.append(
+                            ValidationReason(
+                                f'CNAME record "{record.decoded_fqdn}" points to target "{target}" which is also a CNAME',
+                                [record],
+                            )
+                        )
+        return reasons
+
+
 Zone.register_zone_validator(
     CnameCoexistenceValidator('cname-coexistence', sets={'legacy', 'strict'})
 )
@@ -114,5 +164,15 @@ Zone.register_zone_validator(
 Zone.register_zone_validator(
     CnameTargetResolvableInZoneZoneValidator(
         'cname-target-resolvable-in-zone', sets={'best-practice'}
+    )
+)
+
+Zone.register_zone_validator(
+    RootCnameZoneValidator('root-cname', sets={'strict'})
+)
+
+Zone.register_zone_validator(
+    CnameTargetNotCnameZoneValidator(
+        'cname-target-not-cname', sets={'best-practice'}
     )
 )

--- a/tests/test_octodns_record_mx.py
+++ b/tests/test_octodns_record_mx.py
@@ -13,6 +13,7 @@ from octodns.record.mx import (
     MxRecord,
     MxValue,
     MxValueBestPracticeValidator,
+    MxValueNotIpValidator,
     MxValueRfcValidator,
 )
 from octodns.record.rr import RrParseError
@@ -526,3 +527,22 @@ class TestMxValue(TestCase):
             )
         finally:
             Record.disable_validator('mx-value-rfc', types=['MX'])
+
+    def test_not_ip_validator(self):
+        validate = MxValueNotIpValidator('test').validate
+
+        self.assertEqual(
+            [],
+            validate(
+                MxValue,
+                [{'preference': 10, 'exchange': 'mx.unit.tests.'}],
+                'MX',
+            ),
+        )
+        self.assertEqual(
+            ['MX exchange "1.2.3.4." is an IP address'],
+            validate(
+                MxValue, [{'preference': 10, 'exchange': '1.2.3.4.'}], 'MX'
+            ),
+        )
+        self.assertEqual([], validate(MxValue, [{'preference': 10}], 'MX'))

--- a/tests/test_octodns_record_spf.py
+++ b/tests/test_octodns_record_spf.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.spf import SpfRecord
+from octodns.record.spf import SpfRecord, SpfRecordTypeValidator
 from octodns.zone import Zone
 
 
@@ -68,4 +68,13 @@ class TestRecordSpf(TestCase):
         self.assertEqual(
             ['unescaped ; in "this has some; semi-colons\\; in it"'],
             ctx.exception.reasons,
+        )
+
+    def test_spf_validator(self):
+        v = SpfRecordTypeValidator('test')
+        self.assertEqual(
+            [
+                'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0'
+            ],
+            v.validate(SpfRecord, 'name', 'fqdn', {}),
         )

--- a/tests/test_octodns_record_srv.py
+++ b/tests/test_octodns_record_srv.py
@@ -15,6 +15,7 @@ from octodns.record.srv import (
     SrvRecord,
     SrvValue,
     SrvValueBestPracticeValidator,
+    SrvValueNotIpValidator,
     SrvValueRfcValidator,
 )
 from octodns.zone import Zone
@@ -852,4 +853,44 @@ class TestSrvValue(TestCase):
         self.assertEqual(
             ['SRV target "unit.tests..example.com." is not a valid FQDN'],
             ctx.exception.reasons,
+        )
+
+    def test_not_ip_validator(self):
+        validate = SrvValueNotIpValidator('test').validate
+
+        self.assertEqual(
+            [],
+            validate(
+                SrvValue,
+                [
+                    {
+                        'priority': 10,
+                        'weight': 20,
+                        'port': 30,
+                        'target': 'srv.unit.tests.',
+                    }
+                ],
+                'SRV',
+            ),
+        )
+        self.assertEqual(
+            ['SRV target "1.2.3.4." is an IP address'],
+            validate(
+                SrvValue,
+                [
+                    {
+                        'priority': 10,
+                        'weight': 20,
+                        'port': 30,
+                        'target': '1.2.3.4.',
+                    }
+                ],
+                'SRV',
+            ),
+        )
+        self.assertEqual(
+            [],
+            validate(
+                SrvValue, [{'priority': 10, 'weight': 20, 'port': 30}], 'SRV'
+            ),
         )

--- a/tests/test_octodns_record_target.py
+++ b/tests/test_octodns_record_target.py
@@ -7,7 +7,9 @@ from unittest import TestCase
 from octodns.record.alias import AliasRecord
 from octodns.record.target import (
     TargetsValueBestPracticeValidator,
+    TargetsValueNotIpValidator,
     TargetValueBestPracticeValidator,
+    TargetValueNotIpValidator,
     _TargetsValue,
     _TargetValue,
 )
@@ -119,4 +121,63 @@ class TestTargetBestPracticeValidators(TestCase):
         self.assertEqual(
             ['NS value "ns2.foo.com" missing trailing .'],
             validate(_TargetsValue, ['ns1.foo.com.', 'ns2.foo.com'], 'NS'),
+        )
+
+
+class TestTargetNotIpValidators(TestCase):
+
+    def test_target_value_not_ip_validator(self):
+        validate = TargetValueNotIpValidator('target-value-not-ip').validate
+
+        # valid
+        self.assertEqual([], validate(_TargetValue, 'foo.bar.com.', 'CNAME'))
+
+        # missing/empty value — no error
+        self.assertEqual([], validate(_TargetValue, None, 'CNAME'))
+        self.assertEqual([], validate(_TargetValue, '', 'CNAME'))
+
+        # null target for permitted types — exempt
+        self.assertEqual([], validate(_TargetValue, '.', 'SRV'))
+
+        # template variable — exempt until after substitution
+        self.assertEqual(
+            [], validate(_TargetValue, '{zone_name}example.com', 'CNAME')
+        )
+
+        # ipv4
+        self.assertEqual(
+            ['CNAME value "192.168.1.1" is an IP address'],
+            validate(_TargetValue, '192.168.1.1', 'CNAME'),
+        )
+
+        # ipv4 with trailing dot
+        self.assertEqual(
+            ['CNAME value "192.168.1.1." is an IP address'],
+            validate(_TargetValue, '192.168.1.1.', 'CNAME'),
+        )
+
+        # ipv6
+        self.assertEqual(
+            ['CNAME value "2001:db8::1" is an IP address'],
+            validate(_TargetValue, '2001:db8::1', 'CNAME'),
+        )
+
+    def test_targets_value_not_ip_validator(self):
+        validate = TargetsValueNotIpValidator('targets-value-not-ip').validate
+
+        # valid
+        self.assertEqual(
+            [], validate(_TargetsValue, ['ns1.foo.com.', 'ns2.foo.com.'], 'NS')
+        )
+
+        # empty list — no errors
+        self.assertEqual([], validate(_TargetsValue, [], 'NS'))
+
+        # template variable — exempt
+        self.assertEqual([], validate(_TargetsValue, ['{zone_name}ns1'], 'NS'))
+
+        # multiple values, one bad
+        self.assertEqual(
+            ['NS value "192.168.1.1" is an IP address'],
+            validate(_TargetsValue, ['ns1.foo.com.', '192.168.1.1'], 'NS'),
         )

--- a/tests/test_octodns_zone_validators_cname.py
+++ b/tests/test_octodns_zone_validators_cname.py
@@ -8,8 +8,10 @@ from octodns.record import Record
 from octodns.zone import Zone
 from octodns.zone.cname import (
     CnameCoexistenceValidator,
+    CnameTargetNotCnameZoneValidator,
     CnameTargetResolvableInZoneZoneValidator,
     NoCnameLoopZoneValidator,
+    RootCnameZoneValidator,
 )
 
 
@@ -157,6 +159,110 @@ class TestCnameCoexistenceValidator(TestCase):
         reasons = v.validate(zone)
         self.assertEqual(1, len(reasons))
         self.assertTrue(reasons[0].lenient)
+
+    def test_alias_coexistence(self):
+        v = CnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        # ALIAS and TXT (should pass)
+        alias1 = _add_record(
+            zone, '', {'type': 'ALIAS', 'value': 'target.unit.tests.'}
+        )
+        txt1 = _add_record(zone, '', {'type': 'TXT', 'value': 'some txt'})
+        zone.add_record(alias1)
+        zone.add_record(txt1)
+        self.assertEqual([], v.validate(zone))
+
+        # ALIAS and A (should fail)
+        a2 = _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4'})
+        alias2 = _add_record(
+            zone, 'www', {'type': 'ALIAS', 'value': 'target.unit.tests.'}
+        )
+        zone.add_record(a2)
+        zone.add_record(alias2)
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'ALIAS at www.unit.tests. cannot coexist with A or AAAA records',
+            str(reasons[0]),
+        )
+
+        # ALIAS and AAAA (should fail)
+        zone2 = _make_zone()
+        aaaa3 = _add_record(zone2, '', {'type': 'AAAA', 'value': '::1'})
+        alias3 = _add_record(
+            zone2, '', {'type': 'ALIAS', 'value': 'target.unit.tests.'}
+        )
+        zone2.add_record(aaaa3)
+        zone2.add_record(alias3)
+        reasons2 = v.validate(zone2)
+        self.assertEqual(1, len(reasons2))
+        self.assertIn(
+            'ALIAS at unit.tests. cannot coexist with A or AAAA records',
+            str(reasons2[0]),
+        )
+
+
+class TestRootCnameZoneValidator(TestCase):
+    def test_root_cname(self):
+        v = RootCnameZoneValidator('test')
+        zone = _make_zone()
+
+        # No records
+        self.assertEqual([], v.validate(zone))
+
+        # CNAME not at root
+        cname1 = _add_record(
+            zone, 'www', {'type': 'CNAME', 'value': 'target.unit.tests.'}
+        )
+        zone.add_record(cname1)
+        self.assertEqual([], v.validate(zone))
+
+        # CNAME at root
+        cname2 = _add_record(
+            zone, '', {'type': 'CNAME', 'value': 'target.unit.tests.'}
+        )
+        zone.add_record(cname2)
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'CNAME record at zone apex "unit.tests." is not allowed',
+            str(reasons[0]),
+        )
+
+
+class TestCnameTargetNotCnameZoneValidator(TestCase):
+    def test_cname_target_not_cname(self):
+        v = CnameTargetNotCnameZoneValidator('test')
+        zone = _make_zone()
+
+        # Target is A record
+        cname1 = _add_record(
+            zone, 'www', {'type': 'CNAME', 'value': 'target.unit.tests.'}
+        )
+        a1 = _add_record(zone, 'target', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(cname1)
+        zone.add_record(a1)
+        self.assertEqual([], v.validate(zone))
+
+        # Target is out of zone
+        cname2 = _add_record(
+            zone, 'api', {'type': 'CNAME', 'value': 'out.of.zone.'}
+        )
+        zone.add_record(cname2)
+        self.assertEqual([], v.validate(zone))
+
+        # Target is CNAME
+        cname3 = _add_record(
+            zone, 'alias', {'type': 'CNAME', 'value': 'www.unit.tests.'}
+        )
+        zone.add_record(cname3)
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'CNAME record "alias.unit.tests." points to target "www.unit.tests." which is also a CNAME',
+            str(reasons[0]),
+        )
 
 
 class TestCnameTargetResolvableInZoneZoneValidator(TestCase):


### PR DESCRIPTION
This PR introduces several new validators to enforce DNS best practices across octoDNS:

- **SpfRecordTypeValidator**: Raises validation error when SPF record type is used to enforce transition to TXT.
- **RootCnameZoneValidator**: Rejects CNAME records at the zone apex.
- **CnameTargetNotCnameZoneValidator**: Discourages internal CNAME chaining.
- **ALIAS Coexistence**: Ensures ALIAS records do not coexist with A or AAAA records.
- **TargetNotIpValidator**: Enforces that target fields for CNAME, MX, NS, SRV, ALIAS, PTR, and DNAME records are hostnames rather than direct IP addresses.
- **Tests**: Comprehensive tests added for all new validator logic.

/cc #1396