### PR TITLE
Add DNAME coexistence zone validator

### DIFF
--- a/.changelog/94b1b2ea173b4befbeabfce5a8b21483.md
+++ b/.changelog/94b1b2ea173b4befbeabfce5a8b21483.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add DNAME coexistence zone validator

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -319,6 +319,10 @@ Validators active in ``strict`` only (stricter replacements):
 +----------------------------+-------------------------------------------------------+
 | ``no-cname-loop``          | CNAME chains within the zone must not loop            |
 +----------------------------+-------------------------------------------------------+
+| ``dname-coexistence``      | DNAME must not coexist with CNAME at any node, or     |
+|                            | with NS at a non-apex node. Also warns about occluded |
+|                            | subordinate records.                                  |
++----------------------------+-------------------------------------------------------+
 | ``mx-target-not-cname``    | MX target must not be a CNAME                         |
 +----------------------------+-------------------------------------------------------+
 | ``ns-target-not-cname``    | NS target must not be a CNAME                         |

--- a/octodns/zone/__init__.py
+++ b/octodns/zone/__init__.py
@@ -7,6 +7,7 @@ from .cname import (
     CnameTargetResolvableInZoneZoneValidator,
     NoCnameLoopZoneValidator,
 )
+from .dname import DnameCoexistenceValidator
 from .mail import MailZoneValidator, MxTargetResolvableInZoneZoneValidator
 from .ns import (
     GlueForInZoneNsZoneValidator,
@@ -22,6 +23,7 @@ from .subzone import SubzoneRecordValidator
 CaaZoneValidator
 CnameCoexistenceValidator
 CnameTargetResolvableInZoneZoneValidator
+DnameCoexistenceValidator
 DuplicateRecordException
 GlueForInZoneNsZoneValidator
 InvalidNameError

--- a/octodns/zone/dname.py
+++ b/octodns/zone/dname.py
@@ -1,0 +1,62 @@
+#
+#
+#
+
+from .base import Zone
+from .validator import ValidationReason, ZoneValidator
+
+
+class DnameCoexistenceValidator(ZoneValidator):
+    '''
+    Verify that DNAME records do not coexist with CNAME records at any node,
+    or with NS records at a non-apex node. Warn about records occluded by DNAME
+    records.
+    '''
+
+    def validate(self, zone):
+        reasons = []
+        dnames = []
+
+        for node in zone._records.values():
+            types = [r._type for r in node]
+            if 'DNAME' in types:
+                dname_record = next(r for r in node if r._type == 'DNAME')
+                dnames.append(dname_record)
+
+                if 'CNAME' in types:
+                    reasons.append(
+                        ValidationReason(
+                            f'Invalid state, DNAME at {dname_record.fqdn} cannot coexist with CNAME',
+                            node,
+                        )
+                    )
+
+                if 'NS' in types and dname_record.name != '':
+                    reasons.append(
+                        ValidationReason(
+                            f'Invalid state, DNAME at {dname_record.fqdn} cannot coexist with NS at a non-apex node',
+                            node,
+                        )
+                    )
+
+        for dname in dnames:
+            parent = dname.name
+            for record in zone.records:
+                name = record.name
+                is_child = (
+                    name != '' if parent == '' else name.endswith(f'.{parent}')
+                )
+                if is_child:
+                    reasons.append(
+                        ValidationReason(
+                            f'Record "{record.decoded_fqdn}" is occluded by DNAME "{dname.decoded_fqdn}"',
+                            [record],
+                        )
+                    )
+
+        return reasons
+
+
+Zone.register_zone_validator(
+    DnameCoexistenceValidator('dname-coexistence', sets={'strict'})
+)

--- a/tests/test_octodns_zone_validators_dname.py
+++ b/tests/test_octodns_zone_validators_dname.py
@@ -1,0 +1,171 @@
+#
+#
+#
+
+from unittest import TestCase
+
+from octodns.record import Record
+from octodns.zone import Zone
+from octodns.zone.dname import DnameCoexistenceValidator
+
+
+def _make_zone(name='unit.tests.'):
+    return Zone(name, [])
+
+
+def _add_record(zone, name, data, lenient=True):
+    if 'ttl' not in data:
+        data['ttl'] = 300
+    return Record.new(zone, name, data, lenient=lenient)
+
+
+class TestDnameCoexistenceValidator(TestCase):
+    def test_passes_empty_or_no_dname(self):
+        v = DnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        # Empty zone
+        self.assertEqual([], v.validate(zone))
+
+        # Single A record
+        a = _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(a)
+        self.assertEqual([], v.validate(zone))
+
+    def test_passes_dname_alone_or_with_other_allowed(self):
+        v = DnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        # DNAME at non-apex with A record (allowed coexistence)
+        dname = _add_record(
+            zone, 'sub', {'type': 'DNAME', 'value': 'target.other.'}
+        )
+        a = _add_record(zone, 'sub', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(dname)
+        zone.add_record(a)
+
+        self.assertEqual([], v.validate(zone))
+
+    def test_fails_dname_cname_coexistence(self):
+        v = DnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        dname = _add_record(
+            zone, 'sub', {'type': 'DNAME', 'value': 'target.other.'}
+        )
+        cname = _add_record(
+            zone, 'sub', {'type': 'CNAME', 'value': 'target.another.'}
+        )
+        zone.add_record(dname)
+        zone.add_record(cname)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('cannot coexist with CNAME', str(reasons[0]))
+        self.assertEqual({dname, cname}, reasons[0].records)
+
+    def test_dname_ns_coexistence(self):
+        v = DnameCoexistenceValidator('test')
+
+        # DNAME + NS at apex is allowed
+        zone_apex = _make_zone()
+        dname_apex = _add_record(
+            zone_apex, '', {'type': 'DNAME', 'value': 'target.other.'}
+        )
+        ns_apex = _add_record(
+            zone_apex,
+            '',
+            {'type': 'NS', 'values': ['ns1.other.', 'ns2.other.']},
+        )
+        zone_apex.add_record(dname_apex)
+        zone_apex.add_record(ns_apex)
+        self.assertEqual([], v.validate(zone_apex))
+
+        # DNAME + NS at non-apex is NOT allowed
+        zone_sub = _make_zone()
+        dname_sub = _add_record(
+            zone_sub, 'sub', {'type': 'DNAME', 'value': 'target.other.'}
+        )
+        ns_sub = _add_record(
+            zone_sub,
+            'sub',
+            {'type': 'NS', 'values': ['ns1.other.', 'ns2.other.']},
+        )
+        zone_sub.add_record(dname_sub)
+        zone_sub.add_record(ns_sub)
+
+        reasons = v.validate(zone_sub)
+        self.assertEqual(1, len(reasons))
+        self.assertIn(
+            'cannot coexist with NS at a non-apex node', str(reasons[0])
+        )
+        self.assertEqual({dname_sub, ns_sub}, reasons[0].records)
+
+    def test_fails_occlusion(self):
+        v = DnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        dname = _add_record(
+            zone, 'sub', {'type': 'DNAME', 'value': 'target.other.'}
+        )
+        # Record at subordinate name 'child.sub' (occluded)
+        a_child = _add_record(
+            zone, 'child.sub', {'type': 'A', 'value': '1.2.3.4'}
+        )
+        # Record at unrelated name 'childsub' (not occluded)
+        a_unrelated = _add_record(
+            zone, 'childsub', {'type': 'A', 'value': '5.6.7.8'}
+        )
+        # Record at same owner name 'sub' (not occluded)
+        a_same = _add_record(zone, 'sub', {'type': 'A', 'value': '9.10.11.12'})
+
+        zone.add_record(dname)
+        zone.add_record(a_child)
+        zone.add_record(a_unrelated)
+        zone.add_record(a_same)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('is occluded by DNAME', str(reasons[0]))
+        self.assertEqual({a_child}, reasons[0].records)
+
+    def test_fails_occlusion_at_apex(self):
+        v = DnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        # DNAME at apex occludes everything else in the zone
+        dname = _add_record(
+            zone, '', {'type': 'DNAME', 'value': 'target.other.'}
+        )
+        a_child = _add_record(zone, 'www', {'type': 'A', 'value': '1.2.3.4'})
+        zone.add_record(dname)
+        zone.add_record(a_child)
+
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('is occluded by DNAME', str(reasons[0]))
+        self.assertEqual({a_child}, reasons[0].records)
+
+    def test_multiple_dnames(self):
+        v = DnameCoexistenceValidator('test')
+        zone = _make_zone()
+
+        d1 = _add_record(
+            zone, 'sub1', {'type': 'DNAME', 'value': 'target1.other.'}
+        )
+        d2 = _add_record(
+            zone, 'sub2', {'type': 'DNAME', 'value': 'target2.other.'}
+        )
+
+        a1 = _add_record(zone, 'child.sub1', {'type': 'A', 'value': '1.2.3.4'})
+        a2 = _add_record(zone, 'child.sub2', {'type': 'A', 'value': '5.6.7.8'})
+
+        zone.add_record(d1)
+        zone.add_record(d2)
+        zone.add_record(a1)
+        zone.add_record(a2)
+
+        reasons = v.validate(zone)
+        self.assertEqual(2, len(reasons))
+        occluded_records = {r for reason in reasons for r in reason.records}
+        self.assertEqual({a1, a2}, occluded_records)


### PR DESCRIPTION
Implements the DNAME suggestion from validator-improvements.md to add the dname-coexistence validator to the strict set.

/cc https://github.com/octodns/octodns/pull/1396