### PR TITLE
Fix brittle DMARC handling in MailZoneValidator

### DIFF
--- a/.changelog/f4f8d8556b8a4d338eed65c34537e80e.md
+++ b/.changelog/f4f8d8556b8a4d338eed65c34537e80e.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix brittle DMARC handling in MailZoneValidator

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -140,13 +140,15 @@ class MailZoneValidator(ZoneValidator):
                     records,
                 )
             )
-        elif 'p' not in self._parse_dmarc_tags(dmarc_value):
-            reasons.append(
-                ValidationReason(
-                    f'DMARC record at _dmarc.{zone.decoded_name} is missing a policy (p=...)',
-                    [dmarc_txt],
+        else:
+            dmarc_tags = self._parse_dmarc_tags(dmarc_value)
+            if 'p' not in dmarc_tags:
+                reasons.append(
+                    ValidationReason(
+                        f'DMARC record at _dmarc.{zone.decoded_name} is missing a policy (p=...)',
+                        [dmarc_txt],
+                    )
                 )
-            )
 
         return reasons
 
@@ -209,13 +211,15 @@ class MailZoneValidator(ZoneValidator):
                     records,
                 )
             )
-        elif self._parse_dmarc_tags(dmarc_value).get('p') != 'reject':
-            reasons.append(
-                ValidationReason(
-                    f'zone "{zone.decoded_name}" disables mail and should have a DMARC TXT record with "v=DMARC1; p=reject;"',
-                    [dmarc_txt],
+        else:
+            dmarc_tags = self._parse_dmarc_tags(dmarc_value)
+            if dmarc_tags.get('p') != 'reject':
+                reasons.append(
+                    ValidationReason(
+                        f'zone "{zone.decoded_name}" disables mail and should have a DMARC TXT record with "v=DMARC1; p=reject;"',
+                        [dmarc_txt],
+                    )
                 )
-            )
 
         return reasons
 
@@ -333,6 +337,8 @@ class MailZoneValidator(ZoneValidator):
                 )
             dmarc_value = dmarc_value[0]
 
+        dmarc_tags = self._parse_dmarc_tags(dmarc_value)
+
         if mode == 'auto':
             # update mode to main/no-mail based on detection
             if apex_mx_record or apex_spf_value or dmarc_value:
@@ -350,9 +356,8 @@ class MailZoneValidator(ZoneValidator):
                     )
                     mode = 'no-mail'
                 elif (
-                    dmarc_value
-                    and self._parse_dmarc_tags(dmarc_value).get('v') == 'dmarc1'
-                    and self._parse_dmarc_tags(dmarc_value).get('p') == 'reject'
+                    dmarc_tags.get('v') == 'dmarc1'
+                    and dmarc_tags.get('p') == 'reject'
                 ):
                     self.log.debug(
                         'validate: zone=%s, dmarc_value indicates no-mail',

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -71,6 +71,21 @@ class MailZoneValidator(ZoneValidator):
             reason = ValidationReason(reason=multi_msg, records={txt_record})
         return values[0], reason
 
+    def _parse_dmarc_tags(self, dmarc_value):
+        if not dmarc_value:
+            return {}
+        tags = {}
+        for part in dmarc_value.split(';'):
+            part = part.strip()
+            if not part:
+                continue
+            if '=' in part:
+                tag, val = part.split('=', 1)
+                tags[tag.strip().lower()] = val.strip().lower()
+            else:
+                tags[part.strip().lower()] = ''
+        return tags
+
     def _validate_mail(
         self,
         zone,
@@ -125,7 +140,7 @@ class MailZoneValidator(ZoneValidator):
                     records,
                 )
             )
-        elif 'p=' not in dmarc_value:
+        elif 'p' not in self._parse_dmarc_tags(dmarc_value):
             reasons.append(
                 ValidationReason(
                     f'DMARC record at _dmarc.{zone.decoded_name} is missing a policy (p=...)',
@@ -194,7 +209,7 @@ class MailZoneValidator(ZoneValidator):
                     records,
                 )
             )
-        elif 'p=reject' not in dmarc_value:
+        elif self._parse_dmarc_tags(dmarc_value).get('p') != 'reject':
             reasons.append(
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail and should have a DMARC TXT record with "v=DMARC1; p=reject;"',
@@ -334,7 +349,11 @@ class MailZoneValidator(ZoneValidator):
                         zone.decoded_name,
                     )
                     mode = 'no-mail'
-                elif dmarc_value and dmarc_value == 'v=dmarc1; p=reject;':
+                elif (
+                    dmarc_value
+                    and self._parse_dmarc_tags(dmarc_value).get('v') == 'dmarc1'
+                    and self._parse_dmarc_tags(dmarc_value).get('p') == 'reject'
+                ):
                     self.log.debug(
                         'validate: zone=%s, dmarc_value indicates no-mail',
                         zone.decoded_name,

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -328,6 +328,92 @@ class TestMailZoneValidator(TestCase):
         zone = _make_zone()
         self.assertEqual([], v.validate(zone))
 
+    def test_dmarc_brittle_fixes(self):
+        # 1. Auto-detects no-mail via various DMARC formats (no spaces, extra spaces, additional tags)
+        formats = [
+            'v=DMARC1\\;p=reject\\;rua=mailto:dmarc@unit.tests',
+            'v=DMARC1\\; p=reject\\; rua=mailto:dmarc@unit.tests',
+            'v=DMARC1\\; p = reject\\;',
+            'v=DMARC1\\;p = reject',
+        ]
+        v_auto = MailZoneValidator('test', mode='auto')
+        for fmt in formats:
+            zone = _make_zone()
+            dmarc = _add_record(
+                zone, '_dmarc', {'ttl': 300, 'type': 'TXT', 'values': [fmt]}
+            )
+            zone.add_record(dmarc)
+            reasons = v_auto.validate(zone)
+            # Should detect no-mail mode, so it complains about missing strict SPF and missing Null MX
+            self.assertEqual(2, len(reasons))
+            self.assertIn('missing a Null MX record', str(reasons[0]))
+            self.assertIn('missing strict SPF TXT record', str(reasons[1]))
+
+        # 2. Validation of policy presence in mail mode with different spaces / tags
+        v_mail = MailZoneValidator('test', mode='mail')
+        for fmt in formats:
+            zone = _make_zone()
+            mx = _add_record(
+                zone,
+                '',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [
+                        {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                        {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+                    ],
+                },
+            )
+            zone.add_record(mx)
+            spf = _add_record(
+                zone, '', {'ttl': 300, 'type': 'TXT', 'values': ['v=spf1 -all']}
+            )
+            zone.add_record(spf)
+            dmarc = _add_record(
+                zone, '_dmarc', {'ttl': 300, 'type': 'TXT', 'values': [fmt]}
+            )
+            zone.add_record(dmarc)
+            reasons = v_mail.validate(zone)
+            # Should pass successfully without saying policy is missing
+            self.assertEqual([], reasons)
+
+        # 3. Validation in no-mail mode with different spaces / tags
+        v_nomail = MailZoneValidator('test', mode='no-mail')
+        for fmt in formats:
+            zone = _make_zone()
+            mx = _add_record(
+                zone,
+                '',
+                {
+                    'ttl': 300,
+                    'type': 'MX',
+                    'values': [{'preference': 0, 'exchange': '.'}],
+                },
+            )
+            zone.add_record(mx)
+            spf = _add_record(
+                zone, '', {'ttl': 300, 'type': 'TXT', 'values': ['v=spf1 -all']}
+            )
+            zone.add_record(spf)
+            dmarc = _add_record(
+                zone, '_dmarc', {'ttl': 300, 'type': 'TXT', 'values': [fmt]}
+            )
+            zone.add_record(dmarc)
+            reasons = v_nomail.validate(zone)
+            # Should pass successfully
+            self.assertEqual([], reasons)
+
+        # 4. Helper method direct tests for 100% branch/statement coverage
+        self.assertEqual({}, v_auto._parse_dmarc_tags(None))
+        self.assertEqual({}, v_auto._parse_dmarc_tags(''))
+        self.assertEqual(
+            {'v': 'dmarc1', 'p': 'reject', 'extra_tag_without_equals': ''},
+            v_auto._parse_dmarc_tags(
+                'v=dmarc1; p=reject; extra_tag_without_equals'
+            ),
+        )
+
     def test_subzone_mail_success(self):
         # Use auto mode so apex auto-detection finds no apex signals and skips;
         # sub-domain with MX+SPF validates clean.


### PR DESCRIPTION
Fixes the brittle DMARC handling in MailZoneValidator by parsing DMARC values into tag-value pairs instead of using exact substring/exact-matching checks. This allows the validator to correctly identify no-mail mode and check DMARC policies even when records use atypical tag spacing or additional tags.

/cc https://github.com/octodns/octodns/pull/1396