### PR TITLE
Version 1.18.0 bump & changelog update

### DIFF
--- a/.changelog/0b46802c5067451c87d6260ef4f1bcab.md
+++ b/.changelog/0b46802c5067451c87d6260ef4f1bcab.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Migrate SubzoneRecordException checks to SubzoneRecordValidator

--- a/.changelog/0f98ccc556f64b64a955a24dec956822.md
+++ b/.changelog/0f98ccc556f64b64a955a24dec956822.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Extend MailZoneValidator to validate MX and SPF for sub-domains; explicit mode propagates, auto detects per-subdomain

--- a/.changelog/10b638a4be6848c5a8eef2a1d91f6de6.md
+++ b/.changelog/10b638a4be6848c5a8eef2a1d91f6de6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pass through docs around new validators config/reccomendations.

--- a/.changelog/24133387c13041949fa4cf79276736f3.md
+++ b/.changelog/24133387c13041949fa4cf79276736f3.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Implement additional DNS validators (SPF, CNAME, ALIAS, IPs)

--- a/.changelog/6186fcb1167c4d00bc095dc3ae5a1e6e.md
+++ b/.changelog/6186fcb1167c4d00bc095dc3ae5a1e6e.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add zone validators that ensure in-zone targets are resolvable

--- a/.changelog/787467ce3ffc4a1c949a70aa34f23612.md
+++ b/.changelog/787467ce3ffc4a1c949a70aa34f23612.md
@@ -1,4 +1,0 @@
----
-type: none
----
-New provider: OpusDNS, and fix Bunny DNS provider URL

--- a/.changelog/875e2295a0414df88f271c4549e16449.md
+++ b/.changelog/875e2295a0414df88f271c4549e16449.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add an apex CAA zone validation

--- a/.changelog/8e4da8e4367346fb8bdac252af524659.md
+++ b/.changelog/8e4da8e4367346fb8bdac252af524659.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Handle null values in TXT/SPF records gracefully, raising ValidationError instead of TypeError/AttributeError

--- a/.changelog/94b1b2ea173b4befbeabfce5a8b21483.md
+++ b/.changelog/94b1b2ea173b4befbeabfce5a8b21483.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add DNAME coexistence zone validator

--- a/.changelog/9c95d5342c5f45259755b9c3007ee654.md
+++ b/.changelog/9c95d5342c5f45259755b9c3007ee654.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add NoCnameLoopZoneValidator to detect circular CNAME/ALIAS chains

--- a/.changelog/ab361a853c184c80a2e57e495c79354c.md
+++ b/.changelog/ab361a853c184c80a2e57e495c79354c.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add ZoneValidator framework for cross-record zone-level validation, with manager.validators config, best-practice built-in/example (mail)

--- a/.changelog/b820442b551340f4a617f516e73263c3.md
+++ b/.changelog/b820442b551340f4a617f516e73263c3.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Migrate CNAME coexistence check to CnameCoexistenceValidator

--- a/.changelog/c4a88d417e7341f9ae7cfc6d0168479d.md
+++ b/.changelog/c4a88d417e7341f9ae7cfc6d0168479d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-New provider: Mikrotik

--- a/.changelog/d4fb7c2f994a4b469f1f295c963bc5c6.md
+++ b/.changelog/d4fb7c2f994a4b469f1f295c963bc5c6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add script/coverage-report helper to parse coverage.json

--- a/.changelog/dbdda8b610054e49b2597c6909d019e8.md
+++ b/.changelog/dbdda8b610054e49b2597c6909d019e8.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix RFC-based validators to run only in strict set and sync documentation

--- a/.changelog/ec5001be5b3a444aa1c3ee9c026c224e.md
+++ b/.changelog/ec5001be5b3a444aa1c3ee9c026c224e.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add ns-target-not-cname, mx-target-not-cname, and srv-target-not-cname zone validators

--- a/.changelog/f4f8d8556b8a4d338eed65c34537e80e.md
+++ b/.changelog/f4f8d8556b8a4d338eed65c34537e80e.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix brittle DMARC handling in MailZoneValidator

--- a/.changelog/fe66fcda80994d009673045a97a030e6.md
+++ b/.changelog/fe66fcda80994d009673045a97a030e6.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Implement GlueForInZoneNsZoneValidator and MultiValueApexNsZoneValidator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.18.0 - 2026-05-24
+
+Minor:
+
+* Add ZoneValidator framework for cross-record zone-level validation - [#1396](https://github.com/octodns/octodns/pull/1396)
+  * New checks disabled by default, see docs for opt-in, will be default on in 2.x
+  * Migrate SubzoneRecordException checks to SubzoneRecordValidator - [#1398](https://github.com/octodns/octodns/pull/1398)
+  * MailZoneValidator: MX records, DMARC and SPF TXT values for both mail and no-mail cases per sub-domain - [#1403](https://github.com/octodns/octodns/pull/1403), [#1417](https://github.com/octodns/octodns/pull/1417)
+  * Add zone validators that ensure in-zone targets are resolvable - [#1407](https://github.com/octodns/octodns/pull/1407)
+  * Add NoCnameLoopZoneValidator to detect circular CNAME/ALIAS chains - [#1401](https://github.com/octodns/octodns/pull/1401)
+  * Migrate CNAME coexistence check to CnameCoexistenceValidator - [#1398](https://github.com/octodns/octodns/pull/1398)
+  * Add DNAME coexistence zone validator - [#1415](https://github.com/octodns/octodns/pull/1415)
+  * Add ns-target-not-cname, mx-target-not-cname, and srv-target-not-cname zone validators - [#1409](https://github.com/octodns/octodns/pull/1409)
+  * Add an apex CAA zone validation - [#1405](https://github.com/octodns/octodns/pull/1405)
+  * Implement GlueForInZoneNsZoneValidator and MultiValueApexNsZoneValidator - [#1399](https://github.com/octodns/octodns/pull/1399)
+* Implement additional DNS validators (SPF, CNAME, ALIAS, IPs) - [#1413](https://github.com/octodns/octodns/pull/1413)
+
+Patch:
+
+* Fix RFC-based validators to run only in strict set and sync documentation - [#1414](https://github.com/octodns/octodns/pull/1414)
+* Handle null values in TXT/SPF records gracefully, raising ValidationError instead of TypeError/AttributeError - [#1402](https://github.com/octodns/octodns/pull/1402)
 ## 1.17.0 - 2026-05-06 - Now with more validation
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.17.0'
+__version__ = __VERSION__ = '1.18.0'


### PR DESCRIPTION
## 1.18.0 - 2026-05-24

Minor:

* Add ZoneValidator framework for cross-record zone-level validation - [#1396](https://github.com/octodns/octodns/pull/1396)
  * New checks disabled by default, see docs for opt-in, will be default on in 2.x
  * Migrate SubzoneRecordException checks to SubzoneRecordValidator - [#1398](https://github.com/octodns/octodns/pull/1398)
  * MailZoneValidator: MX records, DMARC and SPF TXT values for both mail and no-mail cases per sub-domain - [#1403](https://github.com/octodns/octodns/pull/1403), [#1417](https://github.com/octodns/octodns/pull/1417)
  * Add zone validators that ensure in-zone targets are resolvable - [#1407](https://github.com/octodns/octodns/pull/1407)
  * Add NoCnameLoopZoneValidator to detect circular CNAME/ALIAS chains - [#1401](https://github.com/octodns/octodns/pull/1401)
  * Migrate CNAME coexistence check to CnameCoexistenceValidator - [#1398](https://github.com/octodns/octodns/pull/1398)
  * Add DNAME coexistence zone validator - [#1415](https://github.com/octodns/octodns/pull/1415)
  * Add ns-target-not-cname, mx-target-not-cname, and srv-target-not-cname zone validators - [#1409](https://github.com/octodns/octodns/pull/1409)
  * Add an apex CAA zone validation - [#1405](https://github.com/octodns/octodns/pull/1405)
  * Implement GlueForInZoneNsZoneValidator and MultiValueApexNsZoneValidator - [#1399](https://github.com/octodns/octodns/pull/1399)
* Implement additional DNS validators (SPF, CNAME, ALIAS, IPs) - [#1413](https://github.com/octodns/octodns/pull/1413)

Patch:

* Fix RFC-based validators to run only in strict set and sync documentation - [#1414](https://github.com/octodns/octodns/pull/1414)
* Handle null values in TXT/SPF records gracefully, raising ValidationError instead of TypeError/AttributeError - [#1402](https://github.com/octodns/octodns/pull/1402)
