### PR TITLE
Deprecate YamlProvider escaped_semicolons=True default

### DIFF
--- a/.changelog/04811c9509624644a09f08c1ea9e1305.md
+++ b/.changelog/04811c9509624644a09f08c1ea9e1305.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Deprecate default of YamlProvider escaped_semicolons=True

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -206,11 +206,18 @@ class YamlProvider(BaseProvider):
         split_catchall=True,
         shared_filename=False,
         disable_zonefile=False,
-        escaped_semicolons=True,
+        escaped_semicolons=None,
         ignore_missing_zones=False,
         *args,
         **kwargs,
     ):
+        if escaped_semicolons is None:
+            deprecated(
+                'YamlProvider: escaped_semicolons currently defaults to True, default value is DEPRECATED and will default to False in 2.0. Please explicitly set escaped_semicolons to True or False in your configuration to avoid behavior changes.',
+                stacklevel=2,
+            )
+            escaped_semicolons = True
+
         klass = self.__class__.__name__
         self.log = logging.getLogger(f'{klass}[{id}]')
         self.log.debug(

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -608,6 +608,56 @@ www:
                 ['missing value(s)', 'missing value(s)'], ctx.exception.reasons
             )
 
+    def test_escaped_semicolons_deprecation(self):
+        import warnings
+
+        # Case 1: escaped_semicolons is not provided, should raise DeprecationWarning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            provider = YamlProvider('test', 'tests/config')
+            self.assertTrue(provider.escaped_semicolons)
+
+        self.assertTrue(
+            any(
+                'escaped_semicolons currently defaults to True, default value is DEPRECATED'
+                in str(warning.message)
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+            )
+        )
+
+        # Case 2: escaped_semicolons=True is explicitly provided, should NOT raise DeprecationWarning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            provider = YamlProvider(
+                'test', 'tests/config', escaped_semicolons=True
+            )
+            self.assertTrue(provider.escaped_semicolons)
+
+        self.assertFalse(
+            any(
+                'escaped_semicolons' in str(warning.message)
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+            )
+        )
+
+        # Case 3: escaped_semicolons=False is explicitly provided, should NOT raise DeprecationWarning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            provider = YamlProvider(
+                'test', 'tests/config', escaped_semicolons=False
+            )
+            self.assertFalse(provider.escaped_semicolons)
+
+        self.assertFalse(
+            any(
+                'escaped_semicolons' in str(warning.message)
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+            )
+        )
+
 
 class TestSplitYamlProvider(TestCase):
     def test_list_all_yaml_files(self):


### PR DESCRIPTION
Deprecates the default value of `escaped_semicolons` in `YamlProvider` to prepare for changing the default to `False` in 2.0. 

/cc #1218 
/cc #1253