### PR TITLE
Support tilde (~) expansion in !include directives

### DIFF
--- a/.changelog/1b21d60db3fe49469a9d79ec332a85c8.md
+++ b/.changelog/1b21d60db3fe49469a9d79ec332a85c8.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Support tilde (~) expansion in !include directives

--- a/octodns/yaml.py
+++ b/octodns/yaml.py
@@ -2,7 +2,7 @@
 #
 #
 
-from os.path import dirname, join
+from os.path import dirname, expanduser, isabs, join
 
 from natsort import natsort_keygen
 from yaml import SafeDumper, SafeLoader, compose, dump, load
@@ -22,7 +22,12 @@ class ContextLoader(SafeLoader):
         mark = self.get_mark()
         directory = dirname(mark.name)
 
-        filename = join(directory, self.construct_scalar(node))
+        path = self.construct_scalar(node)
+        path = expanduser(path)
+        if isabs(path):
+            filename = path
+        else:
+            filename = join(directory, path)
 
         with open(filename, 'r') as fh:
             return load(fh, self.__class__)
@@ -31,7 +36,12 @@ class ContextLoader(SafeLoader):
         mark = self.get_mark()
         directory = dirname(mark.name)
 
-        filename = join(directory, self.construct_scalar(node))
+        path = self.construct_scalar(node)
+        path = expanduser(path)
+        if isabs(path):
+            filename = path
+        else:
+            filename = join(directory, path)
 
         with open(filename, 'r') as fh:
             yield compose(fh, self.__class__).value

--- a/tests/test_octodns_yaml.py
+++ b/tests/test_octodns_yaml.py
@@ -2,8 +2,10 @@
 #
 #
 
+import os
 from io import StringIO
 from unittest import TestCase
+from unittest.mock import patch
 
 from yaml.constructor import ConstructorError
 
@@ -156,3 +158,33 @@ class TestYaml(TestCase):
             'Invalid order_mode, "bad2", options are "natural", "simple"',
             str(ctx.exception),
         )
+
+    @patch('octodns.yaml.expanduser')
+    def test_include_tilde(self, expanduser_mock):
+        expanduser_mock.side_effect = lambda path: (
+            os.path.abspath('tests/config/include/dict.yaml')
+            if path == '~/dict.yaml'
+            else (
+                os.path.abspath('tests/config/include/main.yaml')
+                if path == '~/main.yaml'
+                else path
+            )
+        )
+
+        data = safe_load('!include ~/main.yaml')
+        self.assertEqual('main', data['name'])
+        expanduser_mock.assert_any_call('~/main.yaml')
+
+        # Test flatten_include with tilde in a merge
+        yaml_content = '''---
+parent:
+  k: overwritten
+  <<: !include ~/dict.yaml
+  child: added
+  z: overwrote
+'''
+        data = safe_load(yaml_content, enforce_order=False)
+        self.assertEqual('v', data['parent']['k'])
+        self.assertEqual('added', data['parent']['child'])
+        self.assertEqual('overwrote', data['parent']['z'])
+        expanduser_mock.assert_any_call('~/dict.yaml')


### PR DESCRIPTION
Supports expanding the tilde (`~`) character to the user's home directory in `!include` directives within YAML configurations.

/cc #1382 Support tilde (~) expansion in !include directives