### PR TITLE
Version 1.19.0 bump & changelog update

### DIFF
--- a/.changelog/04811c9509624644a09f08c1ea9e1305.md
+++ b/.changelog/04811c9509624644a09f08c1ea9e1305.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Deprecate default of YamlProvider escaped_semicolons=True

--- a/.changelog/0c65bd7cfbd04f68b7643808706f21be.md
+++ b/.changelog/0c65bd7cfbd04f68b7643808706f21be.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add a validators section to the docs

--- a/.changelog/0d6fadeaaeb14209a24c4bc2bb33f0e9.md
+++ b/.changelog/0d6fadeaaeb14209a24c4bc2bb33f0e9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix #1427: restore sub-zone record check in Zone.add_record so leniently-added ownership records are not rejected at validate time

--- a/.changelog/1b21d60db3fe49469a9d79ec332a85c8.md
+++ b/.changelog/1b21d60db3fe49469a9d79ec332a85c8.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Support tilde (~) expansion in !include directives

--- a/.changelog/ace5e7f864cd4c0e93ab1b289dcc31af.md
+++ b/.changelog/ace5e7f864cd4c0e93ab1b289dcc31af.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add a first pass at a workflow focused AGENTS.md

--- a/.changelog/c753149caf5843e59adf60341b7453ba.md
+++ b/.changelog/c753149caf5843e59adf60341b7453ba.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix MailZoneValidator auto-detection: DMARC p=reject is a best-practice enforcement policy, not a no-mail signal — zones with real MX records and p=reject DMARC were incorrectly flagged. Auto-detection now uses MX as the primary signal (Null MX → no-mail, real MX → mail) with SPF as fallback; DMARC policy is never used for mode detection. Closes #1422.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.19.0 - 2026-06-07
+
+Minor:
+* Deprecate default of YamlProvider escaped_semicolons=True - [#1419](https://github.com/octodns/octodns/pull/1419)
+* Support tilde (~) expansion in !include directives - [#1420](https://github.com/octodns/octodns/pull/1420)
+
+Patch:
+* Fix MailZoneValidator auto-detection: DMARC p=reject is a best-practice enforcement policy, not a no-mail signal — zones with real MX records and p=reject DMARC were incorrectly flagged. Auto-detection now uses MX as the primary signal (Null MX → no-mail, real MX → mail) with SPF as fallback; DMARC policy is never used for mode detection. Closes #1422. - [#1425](https://github.com/octodns/octodns/pull/1425)
+* Fix #1427: restore sub-zone record check in Zone.add_record so leniently-added ownership records are not rejected at validate time - [#1428](https://github.com/octodns/octodns/pull/1428)
+
 ## 1.18.0 - 2026-05-24
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.18.0'
+__version__ = __VERSION__ = '1.19.0'


### PR DESCRIPTION
## 1.19.0 - 2026-06-07

Minor:
* Deprecate default of YamlProvider escaped_semicolons=True - [#1419](https://github.com/octodns/octodns/pull/1419)
* Support tilde (~) expansion in !include directives - [#1420](https://github.com/octodns/octodns/pull/1420)

Patch:
* Fix MailZoneValidator auto-detection: DMARC p=reject is a best-practice enforcement policy, not a no-mail signal — zones with real MX records and p=reject DMARC were incorrectly flagged. Auto-detection now uses MX as the primary signal (Null MX → no-mail, real MX → mail) with SPF as fallback; DMARC policy is never used for mode detection. Closes #1422. - [#1425](https://github.com/octodns/octodns/pull/1425)
* Fix #1427: restore sub-zone record check in Zone.add_record so leniently-added ownership records are not rejected at validate time - [#1428](https://github.com/octodns/octodns/pull/1428)

