### PR TITLE
MailZoneValidator: min_mx + single_mx_regexes exemptions for single-MX providers

### DIFF
--- a/.changelog/5f27cf6201944e4d8f4bac2f372c88b6.md
+++ b/.changelog/5f27cf6201944e4d8f4bac2f372c88b6.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+MailZoneValidator: add min_mx parameter (default 2) and single_mx_regexes for exempting known single-MX providers (SendGrid, Amazon SES, Postmark) from the redundancy check

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -3,6 +3,8 @@
 #
 
 from logging import getLogger
+from re import compile as re_compile
+from re import error as re_error
 
 from .base import Zone
 from .validator import ValidationReason, ZoneValidator
@@ -30,7 +32,11 @@ class MailZoneValidator(ZoneValidator):
 
     'mail' mode enforces:
 
-    - Multiple MX records for redundancy (at apex and throughout the zone).
+    - At least ``min_mx`` MX records for redundancy (default 2) at the apex
+      and throughout the zone. MX records with a single value whose exchange
+      matches a known single-MX provider (see ``DEFAULT_SINGLE_MX_REGEXES``)
+      or a user-supplied ``single_mx_regexes`` pattern are exempt from this
+      check.
     - Presence of an SPF record at the apex.
     - SPF record terminates with ~all or -all.
     - Presence of a DMARC record at _dmarc.
@@ -48,12 +54,41 @@ class MailZoneValidator(ZoneValidator):
     parent zone per RFC 7489 §6.6.3.
     '''
 
-    def __init__(self, id, mode='auto', sets=None):
+    # MX exchanges of providers known to (correctly) operate with a single MX
+    # record. A record with exactly one value whose exchange matches one of
+    # these patterns is exempt from the ``min_mx`` redundancy check. Patterns
+    # are matched via re.search against the exchange including its trailing dot.
+    #
+    # PRs welcome: if you run across another reputable provider that only hands
+    # out a single MX, please add it here.
+    DEFAULT_SINGLE_MX_REGEXES = (
+        r'^mx\.sendgrid\.net\.$',  # SendGrid
+        r'^inbound-smtp\..+\.amazonaws\.com\.$',  # Amazon SES (region-specific)
+        r'^inbound\.postmarkapp\.com\.$',  # Postmark
+    )
+
+    def __init__(
+        self, id, mode='auto', min_mx=2, single_mx_regexes=None, sets=None
+    ):
         super().__init__(id, sets=sets)
         self.log = getLogger(f'MailZoneValidator[{id}]')
         if mode not in ('auto', 'mail', 'no-mail'):
             raise ValueError(f'Unknown mode "{mode}"')
         self.mode = mode
+        self.min_mx = min_mx
+        self._single_mx_res = []
+        for r in (*self.DEFAULT_SINGLE_MX_REGEXES, *(single_mx_regexes or [])):
+            try:
+                self._single_mx_res.append(re_compile(r))
+            except re_error as e:
+                raise ValueError(
+                    f'Invalid single_mx_regexes pattern "{r}": {e}'
+                )
+
+    def _is_single_mx_provider(self, mx_record):
+        # called only when mx_record has exactly one value
+        exchange = str(mx_record.values[0].exchange)
+        return any(r.search(exchange) for r in self._single_mx_res)
 
     def _is_null_mx(self, mx_record):
         return (
@@ -308,10 +343,16 @@ class MailZoneValidator(ZoneValidator):
             if self._is_null_mx(record):
                 continue
 
-            if len(record.values) < 2:
+            if len(record.values) < self.min_mx:
+                # only a lone MX can belong to an exempt single-MX provider;
+                # skip the regex matching when it couldn't help
+                if len(record.values) == 1 and self._is_single_mx_provider(
+                    record
+                ):
+                    continue
                 reasons.append(
                     ValidationReason(
-                        f'MX record "{record.fqdn}" should have at least 2 values for redundancy, found {len(record.values)}',
+                        f'MX record "{record.fqdn}" should have at least {self.min_mx} values for redundancy, found {len(record.values)}',
                         [record],
                     )
                 )

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -62,9 +62,11 @@ class MailZoneValidator(ZoneValidator):
     # PRs welcome: if you run across another reputable provider that only hands
     # out a single MX, please add it here.
     DEFAULT_SINGLE_MX_REGEXES = (
-        r'^mx\.sendgrid\.net\.$',  # SendGrid
-        r'^inbound-smtp\..+\.amazonaws\.com\.$',  # Amazon SES (region-specific)
         r'^inbound\.postmarkapp\.com\.$',  # Postmark
+        r'^(feedback|inbound)-smtp\..+\.amazonaws\.com\.$',  # Amazon AWS (region-specific)
+        r'^mx\.hubapi\.com\.$',  # HubSpot
+        r'^mx\.sendgrid\.net\.$',  # SendGrid
+        r'^smtp\.google\.com\.$',  # Google
     )
 
     def __init__(

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -62,11 +62,12 @@ class MailZoneValidator(ZoneValidator):
     # PRs welcome: if you run across another reputable provider that only hands
     # out a single MX, please add it here.
     DEFAULT_SINGLE_MX_REGEXES = (
+        r'^(feedback|inbound)-smtp\..+\.amazon(aws|ses)\.com\.$',  # Amazon AWS (region-specific)
         r'^inbound\.postmarkapp\.com\.$',  # Postmark
-        r'^(feedback|inbound)-smtp\..+\.amazonaws\.com\.$',  # Amazon AWS (region-specific)
         r'^mx\.hubapi\.com\.$',  # HubSpot
         r'^mx\.sendgrid\.net\.$',  # SendGrid
         r'^smtp\.google\.com\.$',  # Google
+        r'^smtp\.siftrock\.com.',  # Marketo
     )
 
     def __init__(

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -79,7 +79,10 @@ class MailZoneValidator(ZoneValidator):
         self.mode = mode
         self.min_mx = min_mx
         self._single_mx_res = []
-        for r in (*self.DEFAULT_SINGLE_MX_REGEXES, *(single_mx_regexes or [])):
+        # use set to get a unique list of regexes
+        for r in set(
+            (*self.DEFAULT_SINGLE_MX_REGEXES, *(single_mx_regexes or []))
+        ):
             try:
                 self._single_mx_res.append(re_compile(r))
             except re_error as e:

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -27,12 +27,28 @@ class TestMailZoneValidator(TestCase):
     def test_mail_validator_init(self):
         v = MailZoneValidator('test')
         self.assertEqual('auto', v.mode)
+        self.assertEqual(2, v.min_mx)
+        # default regexes are compiled and stored
+        self.assertEqual(
+            len(MailZoneValidator.DEFAULT_SINGLE_MX_REGEXES),
+            len(v._single_mx_res),
+        )
 
         v = MailZoneValidator('test', mode='mail')
         self.assertEqual('mail', v.mode)
 
         v = MailZoneValidator('test', mode='no-mail')
         self.assertEqual('no-mail', v.mode)
+
+        v = MailZoneValidator('test', min_mx=1)
+        self.assertEqual(1, v.min_mx)
+
+        # user regexes are appended to the defaults
+        v = MailZoneValidator('test', single_mx_regexes=[r'\.example\.com\.$'])
+        self.assertEqual(
+            len(MailZoneValidator.DEFAULT_SINGLE_MX_REGEXES) + 1,
+            len(v._single_mx_res),
+        )
 
         with self.assertRaises(ValueError):
             MailZoneValidator('test', mode='bad')
@@ -931,6 +947,122 @@ class TestMailZoneValidator(TestCase):
             )
         )
         self.assertEqual([], v.validate(zone))
+
+    def _make_valid_mail_zone(self, mx_values):
+        '''Helper: build a zone that passes all mail checks except potentially
+        redundancy, using the given mx_values list.'''
+        zone = _make_zone()
+        zone.add_record(
+            _add_record(zone, '', {'type': 'MX', 'values': mx_values})
+        )
+        zone.add_record(
+            _add_record(
+                zone,
+                '',
+                {'type': 'TXT', 'values': ['v=spf1 include:example.com -all']},
+            )
+        )
+        zone.add_record(
+            _add_record(
+                zone,
+                '_dmarc',
+                {'type': 'TXT', 'values': ['v=DMARC1\\; p=reject\\;']},
+            )
+        )
+        return zone
+
+    def test_single_mx_provider_sendgrid_exempt(self):
+        # A single-value apex MX pointing at SendGrid should not trigger the
+        # redundancy check.
+        zone = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'mx.sendgrid.net.'}]
+        )
+        v = MailZoneValidator('test', mode='mail')
+        self.assertEqual([], v.validate(zone))
+
+    def test_single_mx_provider_aws_ses_exempt(self):
+        # Amazon SES uses region-specific inbound-smtp hostnames; all should be
+        # exempt.
+        for region_host in (
+            'inbound-smtp.us-east-1.amazonaws.com.',
+            'inbound-smtp.us-west-2.amazonaws.com.',
+            'inbound-smtp.eu-west-1.amazonaws.com.',
+        ):
+            zone = self._make_valid_mail_zone(
+                [{'preference': 10, 'exchange': region_host}]
+            )
+            v = MailZoneValidator('test', mode='mail')
+            self.assertEqual(
+                [], v.validate(zone), f'{region_host} should be exempt'
+            )
+
+        # A single amazonaws.com host that is NOT an SES inbound endpoint
+        # must still be flagged.
+        zone = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'smtp.us-east-1.amazonaws.com.'}]
+        )
+        v = MailZoneValidator('test', mode='mail')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('should have at least 2 values', str(reasons[0]))
+
+    def test_single_mx_provider_postmark_exempt(self):
+        zone = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'inbound.postmarkapp.com.'}]
+        )
+        v = MailZoneValidator('test', mode='mail')
+        self.assertEqual([], v.validate(zone))
+
+    def test_min_mx_one_disables_redundancy_check(self):
+        # min_mx=1 means a single non-exempt MX is fine.
+        zone = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'mail1.unit.tests.'}]
+        )
+        v = MailZoneValidator('test', mode='mail', min_mx=1)
+        self.assertEqual([], v.validate(zone))
+
+    def test_min_mx_three_requires_three_values(self):
+        # min_mx=3: a two-value MX is now insufficient.
+        zone = self._make_valid_mail_zone(
+            [
+                {'preference': 10, 'exchange': 'mail1.unit.tests.'},
+                {'preference': 20, 'exchange': 'mail2.unit.tests.'},
+            ]
+        )
+        v = MailZoneValidator('test', mode='mail', min_mx=3)
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('should have at least 3 values', str(reasons[0]))
+
+    def test_single_mx_regexes_custom_extends_defaults(self):
+        # A user-supplied regex exempts a provider not in the built-in list,
+        # while the built-in defaults still apply.
+        zone = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'mx.customprovider.example.com.'}]
+        )
+        # Without the custom regex, it is flagged.
+        v = MailZoneValidator('test', mode='mail')
+        reasons = v.validate(zone)
+        self.assertEqual(1, len(reasons))
+        self.assertIn('should have at least 2 values', str(reasons[0]))
+
+        # With the custom regex, it is exempt.
+        v = MailZoneValidator(
+            'test',
+            mode='mail',
+            single_mx_regexes=[r'\.customprovider\.example\.com\.$'],
+        )
+        self.assertEqual([], v.validate(zone))
+
+        # Built-in SendGrid exemption still works alongside custom regexes.
+        zone2 = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'mx.sendgrid.net.'}]
+        )
+        self.assertEqual([], v.validate(zone2))
+
+    def test_single_mx_regexes_invalid_pattern_raises(self):
+        with self.assertRaisesRegex(ValueError, r'\('):
+            MailZoneValidator('test', single_mx_regexes=['('])
 
     def test_builtin_registration(self):
         ids = [v.id for v in Zone.validators.available_validators()]


### PR DESCRIPTION
## Summary

Closes #1423.

- Adds `min_mx=2` parameter to `MailZoneValidator` — the minimum number of MX values required for the redundancy check. Setting `min_mx=1` effectively disables it.
- Adds `DEFAULT_SINGLE_MX_REGEXES` class constant: a tuple of regexes (matched via `re.search` against the exchange, including its trailing dot) for providers known to legitimately operate with a single MX record. Seeded with **SendGrid** (`mx.sendgrid.net.`), **Amazon SES** (`inbound-smtp.<region>.amazonaws.com.`), and **Postmark** (`inbound.postmarkapp.com.`). Carries a PR-invite comment for community additions.
- Adds `single_mx_regexes=None` parameter to append user-supplied regexes to the built-in list without replacing it.
- The exemption check runs only when `len(record.values) == 1` to avoid regex overhead for records that already have enough values.
- Invalid regex patterns in `single_mx_regexes` raise `ValueError` at construction time with the offending pattern in the message.

## Configuration example

```yaml
validators:
  mail:
    class: octodns.zone.mail.MailZoneValidator
    # lower the threshold (or set to 1 to disable the redundancy check)
    min_mx: 1
    # add your own single-MX provider exemptions
    single_mx_regexes:
      - '^mx\.myprovider\.com\.$'
```

## Test plan

- [x] `test_mail_validator_init` — verifies defaults and new param storage
- [x] `test_single_mx_provider_sendgrid_exempt` — SendGrid is exempt
- [x] `test_single_mx_provider_aws_ses_exempt` — SES regional hosts exempt; non-SES amazonaws.com still flagged
- [x] `test_single_mx_provider_postmark_exempt` — Postmark is exempt
- [x] `test_min_mx_one_disables_redundancy_check` — `min_mx=1` passes a single non-exempt MX
- [x] `test_min_mx_three_requires_three_values` — `min_mx=3` flags a 2-value MX with correct message
- [x] `test_single_mx_regexes_custom_extends_defaults` — custom regex exempts new provider; built-in defaults still apply
- [x] `test_single_mx_regexes_invalid_pattern_raises` — bad regex raises `ValueError` with pattern in message
- [x] 778/778 tests pass, 100% branch coverage

/cc Fixes #1423