### PR TITLE
OwnershipProcessor: refuse to take over foreign-owned records by default

### DIFF
--- a/.changelog/1b6ad68b3a95427fa75cea2c124e62fb.md
+++ b/.changelog/1b6ad68b3a95427fa75cea2c124e62fb.md
@@ -1,4 +1,4 @@
 ---
 type: minor
 ---
-OwnershipProcessor: refuse to take over records whose existing ownership marker has a foreign value; add allow_takeover (default false) to restore prior behavior. Closes #1368
+OwnershipProcessor: refuse to take over records whose existing ownership marker has a foreign value; add allow_takeover (default false) to restore prior behavior.

--- a/.changelog/1b6ad68b3a95427fa75cea2c124e62fb.md
+++ b/.changelog/1b6ad68b3a95427fa75cea2c124e62fb.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+OwnershipProcessor: refuse to take over records whose existing ownership marker has a foreign value; add allow_takeover (default false) to restore prior behavior. Closes #1368

--- a/octodns/processor/ownership.py
+++ b/octodns/processor/ownership.py
@@ -88,32 +88,37 @@ class OwnershipProcessor(BaseProcessor):
             # If we don't have any change there's nothing to do
             return plan
 
-        # First find all the ownership info
+        # First find all the ownership info; we need to look at both the
+        # desired and existing states, many things will show up in both,
+        # but that's fine. While walking existing, also collect any foreign
+        # ownership markers so we can check them once `owned` is fully
+        # populated below (it depends on desired too).
         owned = defaultdict(dict)
-        # We need to look for ownership in both the desired and existing
-        # states, many things will show up in both, but that's fine.
-        for record in list(plan.existing.records) + list(plan.desired.records):
+        foreign = []
+        for record in plan.existing.records:
+            if self._is_ownership(record):
+                name, _type = self._decode_ownership_name(record)
+                owned[name][_type] = True
+            elif not self.allow_takeover and self._is_ownership_name(record):
+                foreign.append(record)
+        for record in plan.desired.records:
             if self._is_ownership(record):
                 name, _type = self._decode_ownership_name(record)
                 owned[name][_type] = True
 
-        if not self.allow_takeover:
-            # If an existing ownership record doesn't belong to us, but we're
-            # about to take ownership of the record it's marking, someone/
-            # something else believes they own it. Refuse to step on it
-            # rather than silently overwriting their marker.
-            for record in plan.existing.records:
-                if self._is_ownership_name(record) and not self._is_ownership(
-                    record
-                ):
-                    name, _type = self._decode_ownership_name(record)
-                    if _type in owned[name]:
-                        raise OwnershipException(
-                            f'{self.id}: refusing to take over '
-                            f'{record.fqdn} {_type}, owned by '
-                            f'{record.values}, not {self._txt_values}; set '
-                            'allow_takeover=true to override'
-                        )
+        # If an existing ownership record doesn't belong to us, but we're
+        # about to take ownership of the record it's marking, someone/
+        # something else believes they own it. Refuse to step on it rather
+        # than silently overwriting their marker.
+        for record in foreign:
+            name, _type = self._decode_ownership_name(record)
+            if _type in owned[name]:
+                raise OwnershipException(
+                    f'{self.id}: refusing to take over {record.fqdn} '
+                    f'{_type}, owned by {record.values}, not '
+                    f'{self._txt_values}; set allow_takeover=true to '
+                    'override'
+                )
 
         # Cases:
         # - Configured in source

--- a/octodns/processor/ownership.py
+++ b/octodns/processor/ownership.py
@@ -6,12 +6,18 @@ from collections import defaultdict
 
 from ..provider.plan import Plan
 from ..record import Record
-from .base import BaseProcessor
+from .base import BaseProcessor, ProcessorException
+
+
+class OwnershipException(ProcessorException):
+    pass
 
 
 # Mark anything octoDNS is managing that way it can know it's safe to modify or
 # delete. We'll take ownership of existing records that we're told to manage
-# and thus "own" them going forward.
+# and thus "own" them going forward. If a record we're told to manage already
+# has an ownership marker belonging to someone/something else, we'll refuse to
+# take it over and raise OwnershipException unless allow_takeover=True.
 class OwnershipProcessor(BaseProcessor):
     def __init__(
         self,
@@ -20,6 +26,7 @@ class OwnershipProcessor(BaseProcessor):
         txt_value='*octodns*',
         txt_ttl=60,
         should_replace=False,
+        allow_takeover=False,
         **kwargs,
     ):
         super().__init__(name, **kwargs)
@@ -28,6 +35,7 @@ class OwnershipProcessor(BaseProcessor):
         self.txt_ttl = txt_ttl
         self._txt_values = [txt_value]
         self.should_replace = should_replace
+        self.allow_takeover = allow_takeover
 
     def process_source_zone(self, desired, sources, lenient=False):
         for record in desired.records:
@@ -60,6 +68,21 @@ class OwnershipProcessor(BaseProcessor):
             and record.values == self._txt_values
         )
 
+    def _is_ownership_name(self, record):
+        # Matches the ownership naming convention regardless of value, i.e.
+        # this may be an ownership record belonging to someone/something else.
+        return record._type == 'TXT' and record.name.startswith(self.txt_name)
+
+    def _decode_ownership_name(self, record):
+        pieces = record.name.split('.', 2)
+        if len(pieces) > 2:
+            _, _type, name = pieces
+            name = name.replace('_wildcard', '*')
+        else:
+            _type = pieces[1]
+            name = ''
+        return name, _type.upper()
+
     def process_plan(self, plan, sources, target, lenient=False):
         if not plan:
             # If we don't have any change there's nothing to do
@@ -71,14 +94,26 @@ class OwnershipProcessor(BaseProcessor):
         # states, many things will show up in both, but that's fine.
         for record in list(plan.existing.records) + list(plan.desired.records):
             if self._is_ownership(record):
-                pieces = record.name.split('.', 2)
-                if len(pieces) > 2:
-                    _, _type, name = pieces
-                    name = name.replace('_wildcard', '*')
-                else:
-                    _type = pieces[1]
-                    name = ''
-                owned[name][_type.upper()] = True
+                name, _type = self._decode_ownership_name(record)
+                owned[name][_type] = True
+
+        if not self.allow_takeover:
+            # If an existing ownership record doesn't belong to us, but we're
+            # about to take ownership of the record it's marking, someone/
+            # something else believes they own it. Refuse to step on it
+            # rather than silently overwriting their marker.
+            for record in plan.existing.records:
+                if self._is_ownership_name(record) and not self._is_ownership(
+                    record
+                ):
+                    name, _type = self._decode_ownership_name(record)
+                    if _type in owned[name]:
+                        raise OwnershipException(
+                            f'{self.id}: refusing to take over '
+                            f'{record.fqdn} {_type}, owned by '
+                            f'{record.values}, not {self._txt_values}; set '
+                            'allow_takeover=true to override'
+                        )
 
         # Cases:
         # - Configured in source

--- a/tests/test_octodns_processor_ownership.py
+++ b/tests/test_octodns_processor_ownership.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from helpers import PlannableProvider
 
-from octodns.processor.ownership import OwnershipProcessor
+from octodns.processor.ownership import OwnershipException, OwnershipProcessor
 from octodns.provider.plan import Plan
 from octodns.record import Delete, Record
 from octodns.zone import DuplicateRecordException, Zone
@@ -177,3 +177,48 @@ class TestOwnershipProcessor(TestCase):
         self.assertEqual(
             ['_owner.a.a', 'a'], sorted([r.name for r in got.records])
         )
+
+    def test_allow_takeover(self):
+        ownership = OwnershipProcessor('ownership')
+        # disallowed by default
+        self.assertFalse(ownership.allow_takeover)
+
+        provider = PlannableProvider('helper')
+
+        # `the-a` is managed by us (and thus has its ownership marker in
+        # plan.desired), but a foreign ownership record for it already
+        # exists in plan.existing
+        ownership_added = ownership.process_source_zone(zone.copy(), None)
+        plan = provider.plan(ownership_added)
+
+        the_a = records['the-a']
+        plan.existing.add_record(the_a)
+        foreign_ownership = Record.new(
+            zone,
+            f'{ownership.txt_name}.a.the-a',
+            {'ttl': 30, 'type': 'TXT', 'value': 'someone-else'},
+        )
+        plan.existing.add_record(foreign_ownership)
+
+        with self.assertRaises(OwnershipException) as ctx:
+            ownership.process_plan(plan, None, None)
+        self.assertIn('the-a', str(ctx.exception))
+        self.assertIn('someone-else', str(ctx.exception))
+
+        # opting in restores the old, silent takeover behavior
+        ownership.allow_takeover = True
+        got = ownership.process_plan(plan, None, None)
+        self.assertTrue(got)
+
+        # a foreign ownership record for something we don't manage is left
+        # alone and does not raise, regardless of allow_takeover
+        ownership.allow_takeover = False
+        plan = provider.plan(ownership_added)
+        foreign_unmanaged = Record.new(
+            zone,
+            f'{ownership.txt_name}.a.extra-a',
+            {'ttl': 30, 'type': 'TXT', 'value': 'someone-else'},
+        )
+        plan.existing.add_record(foreign_unmanaged)
+        got = ownership.process_plan(plan, None, None)
+        self.assertTrue(got)


### PR DESCRIPTION
## Summary
* `OwnershipProcessor` previously silently overwrote an existing `_owner` TXT marker even when its value belonged to someone/something else, effectively taking over a record octoDNS didn't actually own.
* Adds `allow_takeover` (default `false`). When disallowed, `process_plan` now raises `OwnershipException` if it finds a foreign-valued ownership marker on a record octoDNS is about to claim, naming the record and the foreign value. Setting `allow_takeover: true` restores the old silent-takeover behavior.
* Unmanaged records with foreign ownership markers are left untouched either way, matching current behavior.

Closes #1368

## Test plan
- [x] `./script/test tests/test_octodns_processor_ownership.py` — new `test_allow_takeover` covers default-raises, `allow_takeover=True` opt-out, and unmanaged-record sanity case
- [x] `./script/test` — full suite (779 tests) passes
- [x] `./script/lint` — clean
- [x] `./script/coverage` — 100% maintained