### PR TITLE
Version 1.20.0 bump & changelog update

### DIFF
--- a/.changelog/1945a2c6a67148ceba8544f8bbe71c3e.md
+++ b/.changelog/1945a2c6a67148ceba8544f8bbe71c3e.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix formatted txt in docs

--- a/.changelog/1b6ad68b3a95427fa75cea2c124e62fb.md
+++ b/.changelog/1b6ad68b3a95427fa75cea2c124e62fb.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-OwnershipProcessor: refuse to take over records whose existing ownership marker has a foreign value; add allow_takeover (default false) to restore prior behavior.

--- a/.changelog/5f27cf6201944e4d8f4bac2f372c88b6.md
+++ b/.changelog/5f27cf6201944e4d8f4bac2f372c88b6.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-MailZoneValidator: add min_mx parameter (default 2) and single_mx_regexes for exempting known single-MX providers (SendGrid, Amazon SES, Postmark) from the redundancy check

--- a/.changelog/7ef8908d580e485cbdd93b60c8a9d0c4.md
+++ b/.changelog/7ef8908d580e485cbdd93b60c8a9d0c4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/acb49cc69b7a431c9c4d8452d0ca8525.md
+++ b/.changelog/acb49cc69b7a431c9c4d8452d0ca8525.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add INWX and octodns_inwx provider to docs

--- a/.changelog/cb416f0d01a14a53938c1e3caf5e607a.md
+++ b/.changelog/cb416f0d01a14a53938c1e3caf5e607a.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Allow a config validator to override a built-in validator by reusing its id, making it easy to tweak built-in validator parameters (e.g. forcing the mail zone validator into no-mail mode)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.20.0 - 2026-06-21
+
+Minor:
+* Allow a config validator to override a built-in validator by reusing its id, making it easy to tweak built-in validator parameters (e.g. forcing the mail zone validator into no-mail mode) - [#1434](https://github.com/octodns/octodns/pull/1434)
+* OwnershipProcessor: refuse to take over records whose existing ownership marker has a foreign value; add allow_takeover (default false) to restore prior behavior. - [#1432](https://github.com/octodns/octodns/pull/1432)
+* MailZoneValidator: add min_mx parameter (default 2) and single_mx_regexes for exempting known single-MX providers (SendGrid, Amazon SES, Postmark) from the redundancy check - [#1430](https://github.com/octodns/octodns/pull/1430)
+
 ## 1.19.0 - 2026-06-07
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.19.0'
+__version__ = __VERSION__ = '1.20.0'


### PR DESCRIPTION
## 1.20.0 - 2026-06-21

Minor:
* Allow a config validator to override a built-in validator by reusing its id, making it easy to tweak built-in validator parameters (e.g. forcing the mail zone validator into no-mail mode) - [#1434](https://github.com/octodns/octodns/pull/1434)
* OwnershipProcessor: refuse to take over records whose existing ownership marker has a foreign value; add allow_takeover (default false) to restore prior behavior. - [#1432](https://github.com/octodns/octodns/pull/1432)
* MailZoneValidator: add min_mx parameter (default 2) and single_mx_regexes for exempting known single-MX providers (SendGrid, Amazon SES, Postmark) from the redundancy check - [#1430](https://github.com/octodns/octodns/pull/1430)

