### PR TITLE
Add --honor-lenient flag to octodns-validate

### DIFF
--- a/.changelog/ea0ae7c844ee4b5eab36caaa26a2ea2a.md
+++ b/.changelog/ea0ae7c844ee4b5eab36caaa26a2ea2a.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add suppress_lenient_warnings param to Zone.validate() and --honor-lenient flag to octodns-validate CLI

--- a/.changelog/ea0ae7c844ee4b5eab36caaa26a2ea2a.md
+++ b/.changelog/ea0ae7c844ee4b5eab36caaa26a2ea2a.md
@@ -1,4 +1,4 @@
 ---
 type: minor
 ---
-Add suppress_lenient_warnings param to Zone.validate() and --honor-lenient flag to octodns-validate CLI
+Add `--honor-lenient` flag to `octodns-validate`; suppress validation warnings for zones and records configured with `lenient: true`, exiting 0 when no non-lenient issues remain. Also fixes a bug where a zone with `lenient: true` in config could cause subsequent zones in the same run to incorrectly inherit lenient mode.

--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -31,13 +31,11 @@ def main():
     parser.add_argument(
         '--all',
         action='store_true',
-        default=False,
         help='Validate records in lenient mode, printing warnings so that all validation issues are shown',
     )
     parser.add_argument(
         '--honor-lenient',
         action='store_true',
-        default=False,
         help='Suppress warnings for zones and records configured with lenient: true, exiting 0 if no non-lenient issues remain',
     )
 

--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -43,6 +43,9 @@ def main():
 
     args = parser.parse_args(WARNING)
 
+    if args.all and args.honor_lenient:
+        parser.error('--all and --honor-lenient are mutually exclusive')
+
     flagging = FlaggingHandler()
     getLogger('Record').addHandler(flagging)
     getLogger('Zone').addHandler(flagging)

--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -46,6 +46,10 @@ def main():
     if args.all and args.honor_lenient:
         parser.error('--all and --honor-lenient are mutually exclusive')
 
+    # FlaggingHandler sets flag=True on any WARNING-level log record reaching
+    # the 'Record' or 'Zone' loggers. --honor-lenient works by suppressing
+    # lenient warnings before they reach here, so FlaggingHandler never fires
+    # for lenient issues, producing a natural exit 0.
     flagging = FlaggingHandler()
     getLogger('Record').addHandler(flagging)
     getLogger('Zone').addHandler(flagging)

--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -34,6 +34,12 @@ def main():
         default=False,
         help='Validate records in lenient mode, printing warnings so that all validation issues are shown',
     )
+    parser.add_argument(
+        '--honor-lenient',
+        action='store_true',
+        default=False,
+        help='Suppress warnings for zones and records configured with lenient: true, exiting 0 if no non-lenient issues remain',
+    )
 
     args = parser.parse_args(WARNING)
 
@@ -42,7 +48,9 @@ def main():
     getLogger('Zone').addHandler(flagging)
 
     manager = Manager(args.config_file)
-    manager.validate_configs(lenient=args.all)
+    manager.validate_configs(
+        lenient=args.all, suppress_lenient_warnings=args.honor_lenient
+    )
 
     if flagging.flag:
         exit(1)

--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument(
         '--all',
         action='store_true',
-        help='Validate records in lenient mode, printing warnings so that all validation issues are shown',
+        help='Continue validating even after errors, printing all validation issues instead of stopping at the first',
     )
     parser.add_argument(
         '--honor-lenient',
@@ -40,9 +40,6 @@ def main():
     )
 
     args = parser.parse_args(WARNING)
-
-    if args.all and args.honor_lenient:
-        parser.error('--all and --honor-lenient are mutually exclusive')
 
     # FlaggingHandler sets flag=True on any WARNING-level log record reaching
     # the 'Record' or 'Zone' loggers. --honor-lenient works by suppressing

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1318,7 +1318,9 @@ class Manager(object):
                 if 'alias' in self.config['zones'][source_zone]:
                     self.log.exception('Invalid alias zone')
                     raise ManagerException(
-                        f'Invalid alias zone {decoded_zone_name}: source zone {source_zone} is an alias zone'
+                        f'Invalid alias zone {decoded_zone_name}: '
+                        f'source zone {source_zone} is an '
+                        'alias zone'
                     )
 
                 # this is just here to satisfy coverage, see

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1296,7 +1296,9 @@ class Manager(object):
             target.apply(plan)
 
     def validate_configs(self, lenient=False, suppress_lenient_warnings=False):
-        # TODO: this code can probably be shared with stuff in sync
+        # TODO: this code can probably be shared with stuff in sync.
+        # Note: validate_configs carries suppress_lenient_warnings; the sync
+        # path's zone.validate() does not — reconcile this if/when merging.
 
         zones = self.config['zones']
         zones = self._preprocess_zones(zones)

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -4,6 +4,7 @@
 
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext as _nullcontext
 from fnmatch import filter as fnmatch_filter
 from hashlib import sha256
 from importlib import import_module
@@ -23,6 +24,7 @@ from .provider.base import BaseProvider
 from .provider.plan import Plan
 from .provider.yaml import SplitYamlProvider, YamlProvider
 from .record import Record
+from .record.base import suppress_lenient_record_warnings
 from .record.exception import RecordException
 from .record.validator import RecordValidator, ValueValidator
 from .secret.environ import EnvironSecrets
@@ -1348,15 +1350,26 @@ class Manager(object):
                     f'Zone {decoded_zone_name}, unknown source: ' + source
                 )
 
-            zone_lenient = lenient or config.get('lenient', False)
-            for source in sources:
-                if isinstance(source, YamlProvider):
-                    source.populate(zone, lenient=zone_lenient)
+            zone_config_lenient = config.get('lenient', False)
+            zone_lenient = lenient or zone_config_lenient
 
-            zone.validate(
-                lenient=zone_lenient,
-                suppress_lenient_warnings=suppress_lenient_warnings,
+            ctx = (
+                suppress_lenient_record_warnings(
+                    zone_config_lenient=zone_config_lenient
+                )
+                if suppress_lenient_warnings
+                else _nullcontext()
             )
+            with ctx:
+                for source in sources:
+                    if isinstance(source, YamlProvider):
+                        source.populate(zone, lenient=zone_lenient)
+
+                zone.validate(
+                    lenient=zone_lenient,
+                    suppress_lenient_warnings=suppress_lenient_warnings,
+                    zone_config_lenient=zone_config_lenient,
+                )
 
             # check that processors are in order if any are specified
             processors = config.get('processors') or []

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1351,7 +1351,7 @@ class Manager(object):
                 )
 
             zone_config_lenient = config.get('lenient', False)
-            zone_lenient = lenient or zone_config_lenient
+            effective_lenient = lenient or zone_config_lenient
 
             ctx = (
                 suppress_lenient_record_warnings(
@@ -1363,10 +1363,10 @@ class Manager(object):
             with ctx:
                 for source in sources:
                     if isinstance(source, YamlProvider):
-                        source.populate(zone, lenient=zone_lenient)
+                        source.populate(zone, lenient=effective_lenient)
 
                 zone.validate(
-                    lenient=zone_lenient,
+                    lenient=effective_lenient,
                     suppress_lenient_warnings=suppress_lenient_warnings,
                     zone_config_lenient=zone_config_lenient,
                 )

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1295,7 +1295,7 @@ class Manager(object):
                 plan = Plan(zone, zone, [], False)
             target.apply(plan)
 
-    def validate_configs(self, lenient=False):
+    def validate_configs(self, lenient=False, suppress_lenient_warnings=False):
         # TODO: this code can probably be shared with stuff in sync
 
         zones = self.config['zones']
@@ -1349,7 +1349,10 @@ class Manager(object):
                 if isinstance(source, YamlProvider):
                     source.populate(zone, lenient=zone_lenient)
 
-            zone.validate(lenient=zone_lenient)
+            zone.validate(
+                lenient=zone_lenient,
+                suppress_lenient_warnings=suppress_lenient_warnings,
+            )
 
             # check that processors are in order if any are specified
             processors = config.get('processors') or []

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -3,6 +3,8 @@
 #
 
 from collections import defaultdict
+from contextlib import contextmanager
+from contextvars import ContextVar
 from copy import deepcopy
 from logging import getLogger
 
@@ -129,6 +131,25 @@ class ValuesTypeValidator(RecordValidator):
         )
 
 
+_suppress_lenient_record_warnings: ContextVar[bool] = ContextVar(
+    '_suppress_lenient_record_warnings', default=False
+)
+_zone_config_lenient: ContextVar[bool] = ContextVar(
+    '_zone_config_lenient', default=False
+)
+
+
+@contextmanager
+def suppress_lenient_record_warnings(zone_config_lenient=False):
+    t1 = _suppress_lenient_record_warnings.set(True)
+    t2 = _zone_config_lenient.set(zone_config_lenient)
+    try:
+        yield
+    finally:
+        _suppress_lenient_record_warnings.reset(t1)
+        _zone_config_lenient.reset(t2)
+
+
 class Record(EqualityTupleMixin):
     log = getLogger('Record')
 
@@ -232,14 +253,26 @@ class Record(EqualityTupleMixin):
             raise Exception(msg)
         reasons.extend(_class.validate(name, fqdn, data))
         try:
-            lenient |= data['octodns']['lenient']
+            record_config_lenient = data['octodns']['lenient']
         except KeyError:
-            pass
+            record_config_lenient = False
+        lenient |= record_config_lenient
         if reasons:
             if lenient:
-                cls.log.warning(
-                    ValidationError.build_message(fqdn, reasons, context)
+                is_config_lenient = (
+                    record_config_lenient or _zone_config_lenient.get()
                 )
+                if (
+                    _suppress_lenient_record_warnings.get()
+                    and is_config_lenient
+                ):
+                    cls.log.debug(
+                        ValidationError.build_message(fqdn, reasons, context)
+                    )
+                else:
+                    cls.log.warning(
+                        ValidationError.build_message(fqdn, reasons, context)
+                    )
             else:
                 raise ValidationError(fqdn, reasons, context)
         return _class(zone, name, data, source=source, context=context)

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -274,7 +274,7 @@ class Zone(object):
     def available_zone_validators(cls):
         return cls.validators.available_validators()
 
-    def validate(self, lenient=False):
+    def validate(self, lenient=False, suppress_lenient_warnings=False):
         reasons = self.validators.process_zone(self)
         if not reasons:
             return
@@ -287,7 +287,7 @@ class Zone(object):
             else:
                 reasons_to_raise.append(reason)
 
-        if reasons_to_warn:
+        if reasons_to_warn and not suppress_lenient_warnings:
             self.log.warning(
                 ValidationError.build_message(
                     self.decoded_name, reasons_to_warn, context=self.context

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -293,6 +293,14 @@ class Zone(object):
                     self.decoded_name, reasons_to_warn, context=self.context
                 )
             )
+        elif reasons_to_warn and suppress_lenient_warnings:
+            self.log.debug(
+                'suppressed lenient warnings for %s: %s',
+                self.decoded_name,
+                ValidationError.build_message(
+                    self.decoded_name, reasons_to_warn, context=self.context
+                ),
+            )
 
         if reasons_to_raise:
             raise ValidationError(

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -274,19 +274,28 @@ class Zone(object):
     def available_zone_validators(cls):
         return cls.validators.available_validators()
 
-    def validate(self, lenient=False, suppress_lenient_warnings=False):
+    def validate(
+        self,
+        lenient=False,
+        suppress_lenient_warnings=False,
+        zone_config_lenient=False,
+    ):
         '''
         Validate zone records using all registered zone validators.
 
         :param lenient: When True, all validation reasons are treated as
             warnings (logged) rather than errors (raised). Equivalent to
-            passing ``lenient: true`` at the zone config level.
-        :param suppress_lenient_warnings: When True, validation reasons that
-            would normally be logged as warnings (because ``lenient`` is True
-            or the reason's records are individually lenient-tagged) are
-            silently suppressed instead. Non-lenient reasons still raise
-            ``ValidationError`` regardless of this flag. Set by
-            ``--honor-lenient`` in the octodns-validate CLI.
+            passing ``lenient: true`` at the zone config level. Set by the
+            ``--all`` CLI flag.
+        :param suppress_lenient_warnings: When True, warnings that are due to
+            lenient configuration (zone-level ``lenient: true`` or
+            per-record ``lenient: true``) are silently suppressed. Reasons
+            that become warnings only because of the global ``--all`` flag
+            are still logged and trigger exit 1. Set by ``--honor-lenient``.
+        :param zone_config_lenient: When True, this zone has ``lenient: true``
+            in its zone config. Used with ``suppress_lenient_warnings`` to
+            suppress all warnings for this zone (since every issue in it is
+            lenient by zone-level config).
         '''
         reasons = self.validators.process_zone(self)
         if not reasons:
@@ -294,25 +303,30 @@ class Zone(object):
 
         reasons_to_raise = []
         reasons_to_warn = []
+        reasons_to_suppress = []
         for reason in reasons:
-            if lenient or reason.lenient:
+            is_lenient_reason = zone_config_lenient or reason.lenient
+            if is_lenient_reason and suppress_lenient_warnings:
+                reasons_to_suppress.append(reason)
+            elif lenient or is_lenient_reason:
                 reasons_to_warn.append(reason)
             else:
                 reasons_to_raise.append(reason)
 
-        if reasons_to_warn and not suppress_lenient_warnings:
-            self.log.warning(
-                ValidationError.build_message(
-                    self.decoded_name, reasons_to_warn, context=self.context
-                )
-            )
-        elif reasons_to_warn and suppress_lenient_warnings:
+        if reasons_to_suppress:
             self.log.debug(
                 'suppressed lenient warnings for %s: %s',
                 self.decoded_name,
                 ValidationError.build_message(
-                    self.decoded_name, reasons_to_warn, context=self.context
+                    self.decoded_name, reasons_to_suppress, context=self.context
                 ),
+            )
+
+        if reasons_to_warn:
+            self.log.warning(
+                ValidationError.build_message(
+                    self.decoded_name, reasons_to_warn, context=self.context
+                )
             )
 
         if reasons_to_raise:

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -275,6 +275,19 @@ class Zone(object):
         return cls.validators.available_validators()
 
     def validate(self, lenient=False, suppress_lenient_warnings=False):
+        '''
+        Validate zone records using all registered zone validators.
+
+        :param lenient: When True, all validation reasons are treated as
+            warnings (logged) rather than errors (raised). Equivalent to
+            passing ``lenient: true`` at the zone config level.
+        :param suppress_lenient_warnings: When True, validation reasons that
+            would normally be logged as warnings (because ``lenient`` is True
+            or the reason's records are individually lenient-tagged) are
+            silently suppressed instead. Non-lenient reasons still raise
+            ``ValidationError`` regardless of this flag. Set by
+            ``--honor-lenient`` in the octodns-validate CLI.
+        '''
         reasons = self.validators.process_zone(self)
         if not reasons:
             return

--- a/tests/config/validate-lenient-then-strict.yaml
+++ b/tests/config/validate-lenient-then-strict.yaml
@@ -8,11 +8,7 @@ zones:
   empty.:
     sources:
     - in
-    targets:
-    - dump
     lenient: true
   unit.tests.:
     sources:
     - in
-    targets:
-    - dump

--- a/tests/config/validate-lenient-then-strict.yaml
+++ b/tests/config/validate-lenient-then-strict.yaml
@@ -1,0 +1,18 @@
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+    supports_root_ns: False
+    strict_supports: False
+zones:
+  empty.:
+    sources:
+    - in
+    targets:
+    - dump
+    lenient: true
+  unit.tests.:
+    sources:
+    - in
+    targets:
+    - dump

--- a/tests/test_octodns_cmds_validate.py
+++ b/tests/test_octodns_cmds_validate.py
@@ -36,7 +36,16 @@ class TestValidateMain(TestCase):
             # Should not raise — clean config, no validation errors
             main()
 
-    def test_all_and_honor_lenient_are_mutually_exclusive(self):
+    def test_all_and_honor_lenient_non_lenient_issue_exits_1(self):
+        from octodns.record.base import Record
+        from octodns.zone import Zone
+        from octodns.zone.validator import ValidationReason
+
+        non_lenient_record = Record.new(
+            Zone('unit.tests.', []),
+            'test',
+            {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'},
+        )
         with patch(
             'sys.argv',
             [
@@ -47,10 +56,47 @@ class TestValidateMain(TestCase):
                 '--honor-lenient',
             ],
         ):
-            with self.assertRaises(SystemExit) as ctx:
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[
+                    ValidationReason('non-lenient issue', [non_lenient_record])
+                ],
+            ):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+                self.assertEqual(1, ctx.exception.code)
+
+    def test_all_and_honor_lenient_only_lenient_issues_exits_0(self):
+        from octodns.record.base import Record
+        from octodns.zone import Zone
+        from octodns.zone.validator import ValidationReason
+
+        lenient_record = Record.new(
+            Zone('unit.tests.', []),
+            'test',
+            {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'},
+            lenient=True,
+        )
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-lenient-zone.yaml'),
+                '--all',
+                '--honor-lenient',
+            ],
+        ):
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[
+                    ValidationReason('lenient issue', [lenient_record])
+                ],
+            ):
+                # Only lenient issues — suppressed, flagging never fires → exit 0
                 main()
-            # argparse parser.error() exits with code 2
-            self.assertEqual(2, ctx.exception.code)
 
     def test_honor_lenient_exits_0_when_only_lenient_issues(self):
         # simple-lenient-zone.yaml has empty. with lenient:true
@@ -110,3 +156,35 @@ class TestValidateMain(TestCase):
                 # With --honor-lenient, lenient zone warnings are suppressed →
                 # FlaggingHandler never fires → no exit(1)
                 main()
+
+    def test_honor_lenient_non_lenient_issue_exits_1(self):
+        from octodns.record.base import Record
+        from octodns.zone import Zone
+        from octodns.zone.exception import ValidationError
+        from octodns.zone.validator import ValidationReason
+
+        non_lenient_record = Record.new(
+            Zone('unit.tests.', []),
+            'www',
+            {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'},
+        )
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-validate.yaml'),
+                '--honor-lenient',
+            ],
+        ):
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[
+                    ValidationReason('non-lenient issue', [non_lenient_record])
+                ],
+            ):
+                # Without --all, non-lenient issues raise ValidationError directly
+                # (not demoted to a warning, so FlaggingHandler is never involved)
+                with self.assertRaises(ValidationError):
+                    main()

--- a/tests/test_octodns_cmds_validate.py
+++ b/tests/test_octodns_cmds_validate.py
@@ -1,0 +1,104 @@
+#
+#
+#
+
+from os.path import dirname, join
+from unittest import TestCase
+from unittest.mock import patch
+
+from octodns.cmds.validate import main
+
+config_dir = join(dirname(__file__), 'config')
+
+
+def get_config_filename(which):
+    return join(config_dir, which)
+
+
+class TestValidateMain(TestCase):
+    def test_no_flags_clean_config_exits_0(self):
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-validate.yaml'),
+            ],
+        ):
+            # Should not raise — clean config, no validation errors
+            main()
+
+    def test_all_and_honor_lenient_are_mutually_exclusive(self):
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-validate.yaml'),
+                '--all',
+                '--honor-lenient',
+            ],
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+            # argparse parser.error() exits with code 2
+            self.assertEqual(2, ctx.exception.code)
+
+    def test_honor_lenient_exits_0_when_only_lenient_issues(self):
+        # simple-lenient-zone.yaml has empty. with lenient:true
+        # With no real validation issues, this should exit cleanly
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-lenient-zone.yaml'),
+                '--honor-lenient',
+            ],
+        ):
+            # Should not raise or exit 1
+            main()
+
+    def test_all_flag_causes_exit_1_on_lenient_issues(self):
+        from octodns.zone import Zone
+        from octodns.zone.validator import ValidationReason
+
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-lenient-zone.yaml'),
+                '--all',
+            ],
+        ):
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[ValidationReason('zone is broken', [])],
+            ):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+                self.assertEqual(1, ctx.exception.code)
+
+    def test_honor_lenient_suppresses_lenient_warnings_exit_0(self):
+        from octodns.zone import Zone
+        from octodns.zone.validator import ValidationReason
+
+        with patch(
+            'sys.argv',
+            [
+                'octodns-validate',
+                '--config-file',
+                get_config_filename('simple-lenient-zone.yaml'),
+                '--honor-lenient',
+            ],
+        ):
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[ValidationReason('zone is broken', [])],
+            ):
+                # With --honor-lenient, lenient zone warnings are suppressed →
+                # FlaggingHandler never fires → no exit(1)
+                main()

--- a/tests/test_octodns_cmds_validate.py
+++ b/tests/test_octodns_cmds_validate.py
@@ -2,11 +2,12 @@
 #
 #
 
+from logging import getLogger
 from os.path import dirname, join
 from unittest import TestCase
 from unittest.mock import patch
 
-from octodns.cmds.validate import main
+from octodns.cmds.validate import FlaggingHandler, main
 
 config_dir = join(dirname(__file__), 'config')
 
@@ -16,6 +17,13 @@ def get_config_filename(which):
 
 
 class TestValidateMain(TestCase):
+    def tearDown(self):
+        for logger_name in ('Zone', 'Record'):
+            log = getLogger(logger_name)
+            log.handlers = [
+                h for h in log.handlers if not isinstance(h, FlaggingHandler)
+            ]
+
     def test_no_flags_clean_config_exits_0(self):
         with patch(
             'sys.argv',

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -695,19 +695,83 @@ class TestManager(TestCase):
                     any('zone is broken' in msg for msg in logs.output)
                 )
 
-                # lenient=True, suppress_lenient_warnings=True: no warning, no exception
-                with self.assertNoLogs('Zone', level='WARNING'):
+                # lenient=True (--all), suppress_lenient_warnings=True (--honor-lenient):
+                # non-lenient zone, no per-record lenient → warning is NOT suppressed
+                # (--honor-lenient only suppresses warnings due to lenient config, not due to --all)
+                with self.assertLogs('Zone', level='WARNING') as logs:
                     Manager(
                         get_config_filename('simple-validate.yaml')
                     ).validate_configs(
                         lenient=True, suppress_lenient_warnings=True
                     )
+                self.assertTrue(
+                    any('zone is broken' in msg for msg in logs.output)
+                )
 
                 # zone config has lenient:true, no lenient= arg: suppress_lenient_warnings=True silences it
                 with self.assertNoLogs('Zone', level='WARNING'):
                     Manager(
                         get_config_filename('simple-lenient-zone.yaml')
                     ).validate_configs(suppress_lenient_warnings=True)
+
+    def test_validate_configs_suppress_lenient_record_warnings(self):
+        # Record-level warnings from populate must respect the same suppression
+        # rules as zone-level warnings: suppress only when lenient by config.
+        from octodns.record.base import (
+            Record,
+            _suppress_lenient_record_warnings,
+            _zone_config_lenient,
+        )
+
+        with zone_validators_snapshot():
+            real_new = Record.new.__func__
+
+            @classmethod
+            def instrumented_new(
+                cls, zone, name, data, source=None, lenient=False
+            ):
+                record = real_new(
+                    cls, zone, name, data, source=source, lenient=lenient
+                )
+                if lenient:
+                    # mirror what Record.new does for a best-practice violation:
+                    # suppress only when both contextvar flags say to
+                    record_config_lenient = (data.get('octodns') or {}).get(
+                        'lenient', False
+                    )
+                    is_config_lenient = (
+                        record_config_lenient or _zone_config_lenient.get()
+                    )
+                    if (
+                        _suppress_lenient_record_warnings.get()
+                        and is_config_lenient
+                    ):
+                        cls.log.debug('suppressed record warning for %s', name)
+                    else:
+                        cls.log.warning('record warning for %s', name)
+                return record
+
+            with patch.object(Record, 'new', instrumented_new):
+                # lenient zone + suppress=True → no Record WARNING
+                with self.assertNoLogs('Record', level='WARNING'):
+                    Manager(
+                        get_config_filename('simple-lenient-zone.yaml')
+                    ).validate_configs(suppress_lenient_warnings=True)
+
+                # lenient=True (--all) + suppress=True on a non-lenient zone:
+                # warning comes from --all, not from config → must NOT be suppressed
+                with patch.object(
+                    Zone.validators, 'process_zone', return_value=[]
+                ):
+                    with self.assertLogs('Record', level='WARNING') as logs:
+                        Manager(
+                            get_config_filename('simple-validate.yaml')
+                        ).validate_configs(
+                            lenient=True, suppress_lenient_warnings=True
+                        )
+                    self.assertTrue(
+                        any('record warning' in msg for msg in logs.output)
+                    )
 
     def test_validate_configs_lenient_not_inherited_across_zones(self):
         # Regression test for the loop bug: validate_configs() was reassigning

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -703,6 +703,12 @@ class TestManager(TestCase):
                         lenient=True, suppress_lenient_warnings=True
                     )
 
+                # zone config has lenient:true, no lenient= arg: suppress_lenient_warnings=True silences it
+                with self.assertNoLogs('Zone', level='WARNING'):
+                    Manager(
+                        get_config_filename('simple-lenient-zone.yaml')
+                    ).validate_configs(suppress_lenient_warnings=True)
+
     def test_validate_configs_lenient_not_inherited_across_zones(self):
         # Regression test for the loop bug: validate_configs() was reassigning
         # the `lenient` function parameter from zone config on each iteration,

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -730,10 +730,18 @@ class TestManager(TestCase):
                 'process_zone',
                 return_value=[ValidationReason('zone is broken', [])],
             ):
-                with self.assertRaises(ValidationError):
-                    Manager(
-                        get_config_filename('validate-lenient-then-strict.yaml')
-                    ).validate_configs()
+                # empty. should warn (lenient), unit.tests. should raise (strict)
+                with self.assertLogs('Zone', level='WARNING') as logs:
+                    with self.assertRaises(ValidationError):
+                        Manager(
+                            get_config_filename(
+                                'validate-lenient-then-strict.yaml'
+                            )
+                        ).validate_configs()
+                self.assertTrue(
+                    any('empty.' in msg for msg in logs.output),
+                    'expected a warning for the lenient empty. zone',
+                )
 
     def test_source_only_as_a_target(self):
         with self.assertRaises(ManagerException) as ctx:

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -709,21 +709,24 @@ class TestManager(TestCase):
         # so a zone with lenient:true in config would cause subsequent zones
         # to inherit lenient=True.
         # After the fix, each zone uses a local zone_lenient variable instead.
+        #
+        # validate-lenient-then-strict.yaml has two zones:
+        #   empty.      — lenient: true
+        #   unit.tests. — no lenient config
+        # With the bug, processing empty. first would set lenient=True for the
+        # rest of the loop, so unit.tests. would only warn instead of raising.
         with zone_validators_snapshot():
             from octodns.zone.validator import ValidationReason
 
-            # A non-lenient reason — should raise, not warn
+            # A non-lenient reason — should raise on the strict zone
             with patch.object(
                 Zone.validators,
                 'process_zone',
                 return_value=[ValidationReason('zone is broken', [])],
             ):
-                # simple-validate.yaml has unit.tests. with no lenient config.
-                # Before the fix, if any prior zone was lenient, this would only warn.
-                # After the fix, it must raise.
                 with self.assertRaises(ValidationError):
                     Manager(
-                        get_config_filename('simple-validate.yaml')
+                        get_config_filename('validate-lenient-then-strict.yaml')
                     ).validate_configs()
 
     def test_source_only_as_a_target(self):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -677,6 +677,55 @@ class TestManager(TestCase):
                     any('zone is broken' in msg for msg in logs.output)
                 )
 
+    def test_validate_configs_suppress_lenient_warnings(self):
+        with zone_validators_snapshot():
+            from octodns.zone.validator import ValidationReason
+
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[ValidationReason('zone is broken', [])],
+            ):
+                # lenient=True, no suppress: warning is logged
+                with self.assertLogs('Zone', level='WARNING') as logs:
+                    Manager(
+                        get_config_filename('simple-validate.yaml')
+                    ).validate_configs(lenient=True)
+                self.assertTrue(
+                    any('zone is broken' in msg for msg in logs.output)
+                )
+
+                # lenient=True, suppress_lenient_warnings=True: no warning, no exception
+                with self.assertNoLogs('Zone', level='WARNING'):
+                    Manager(
+                        get_config_filename('simple-validate.yaml')
+                    ).validate_configs(
+                        lenient=True, suppress_lenient_warnings=True
+                    )
+
+    def test_validate_configs_lenient_not_inherited_across_zones(self):
+        # Regression test for the loop bug: validate_configs() was reassigning
+        # the `lenient` function parameter from zone config on each iteration,
+        # so a zone with lenient:true in config would cause subsequent zones
+        # to inherit lenient=True.
+        # After the fix, each zone uses a local zone_lenient variable instead.
+        with zone_validators_snapshot():
+            from octodns.zone.validator import ValidationReason
+
+            # A non-lenient reason — should raise, not warn
+            with patch.object(
+                Zone.validators,
+                'process_zone',
+                return_value=[ValidationReason('zone is broken', [])],
+            ):
+                # simple-validate.yaml has unit.tests. with no lenient config.
+                # Before the fix, if any prior zone was lenient, this would only warn.
+                # After the fix, it must raise.
+                with self.assertRaises(ValidationError):
+                    Manager(
+                        get_config_filename('simple-validate.yaml')
+                    ).validate_configs()
+
     def test_source_only_as_a_target(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('provider-problems.yaml')).sync(

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -715,63 +715,44 @@ class TestManager(TestCase):
                     ).validate_configs(suppress_lenient_warnings=True)
 
     def test_validate_configs_suppress_lenient_record_warnings(self):
-        # Record-level warnings from populate must respect the same suppression
-        # rules as zone-level warnings: suppress only when lenient by config.
-        from octodns.record.base import (
-            Record,
-            _suppress_lenient_record_warnings,
-            _zone_config_lenient,
-        )
+        # validate_configs() must activate the suppress context for lenient
+        # zones so that Record.new() best-practice warnings are silenced for
+        # lenient-by-config records/zones, but NOT for warnings that only
+        # exist because --all was passed.
+        import octodns.manager as manager_module
+        from octodns.record.base import suppress_lenient_record_warnings
 
         with zone_validators_snapshot():
-            real_new = Record.new.__func__
+            calls = []
+            real_ctx = suppress_lenient_record_warnings
 
-            @classmethod
-            def instrumented_new(
-                cls, zone, name, data, source=None, lenient=False
+            def tracking_ctx(zone_config_lenient=False):
+                calls.append(zone_config_lenient)
+                return real_ctx(zone_config_lenient=zone_config_lenient)
+
+            with patch.object(
+                manager_module, 'suppress_lenient_record_warnings', tracking_ctx
             ):
-                record = real_new(
-                    cls, zone, name, data, source=source, lenient=lenient
-                )
-                if lenient:
-                    # mirror what Record.new does for a best-practice violation:
-                    # suppress only when both contextvar flags say to
-                    record_config_lenient = (data.get('octodns') or {}).get(
-                        'lenient', False
-                    )
-                    is_config_lenient = (
-                        record_config_lenient or _zone_config_lenient.get()
-                    )
-                    if (
-                        _suppress_lenient_record_warnings.get()
-                        and is_config_lenient
-                    ):
-                        cls.log.debug('suppressed record warning for %s', name)
-                    else:
-                        cls.log.warning('record warning for %s', name)
-                return record
+                # lenient zone: context manager must be activated with
+                # zone_config_lenient=True
+                Manager(
+                    get_config_filename('simple-lenient-zone.yaml')
+                ).validate_configs(suppress_lenient_warnings=True)
+                self.assertEqual([True], calls)
 
-            with patch.object(Record, 'new', instrumented_new):
-                # lenient zone + suppress=True → no Record WARNING
-                with self.assertNoLogs('Record', level='WARNING'):
-                    Manager(
-                        get_config_filename('simple-lenient-zone.yaml')
-                    ).validate_configs(suppress_lenient_warnings=True)
+                calls.clear()
 
-                # lenient=True (--all) + suppress=True on a non-lenient zone:
-                # warning comes from --all, not from config → must NOT be suppressed
+                # non-lenient zone with --all: context manager must NOT be
+                # activated (suppress_lenient_warnings=False)
                 with patch.object(
                     Zone.validators, 'process_zone', return_value=[]
                 ):
-                    with self.assertLogs('Record', level='WARNING') as logs:
-                        Manager(
-                            get_config_filename('simple-validate.yaml')
-                        ).validate_configs(
-                            lenient=True, suppress_lenient_warnings=True
-                        )
-                    self.assertTrue(
-                        any('record warning' in msg for msg in logs.output)
+                    Manager(
+                        get_config_filename('simple-validate.yaml')
+                    ).validate_configs(
+                        lenient=True, suppress_lenient_warnings=False
                     )
+                self.assertEqual([], calls)
 
     def test_validate_configs_lenient_not_inherited_across_zones(self):
         # Regression test for the loop bug: validate_configs() was reassigning

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -743,6 +743,58 @@ class TestRecordValidation(TestCase):
             lenient=True,
         )
 
+    def test_suppress_lenient_record_warnings_context_manager(self):
+        from octodns.record.base import suppress_lenient_record_warnings
+
+        # lenient-by-config record (octodns.lenient=True): warning suppressed
+        with self.assertNoLogs('Record', level='WARNING'):
+            with suppress_lenient_record_warnings(zone_config_lenient=False):
+                Record.new(
+                    self.zone,
+                    'www',
+                    {
+                        'octodns': {'lenient': True},
+                        'type': 'A',
+                        'ttl': -1,
+                        'value': '1.2.3.4',
+                    },
+                )
+
+        # lenient-by-zone-config (zone_config_lenient=True): warning suppressed
+        with self.assertNoLogs('Record', level='WARNING'):
+            with suppress_lenient_record_warnings(zone_config_lenient=True):
+                Record.new(
+                    self.zone,
+                    'www',
+                    {'type': 'A', 'ttl': -1, 'value': '1.2.3.4'},
+                    lenient=True,
+                )
+
+        # lenient-by-all-flag only (zone_config_lenient=False, no octodns.lenient):
+        # NOT suppressed — the warning must reach FlaggingHandler
+        with self.assertLogs('Record', level='WARNING') as logs:
+            with suppress_lenient_record_warnings(zone_config_lenient=False):
+                Record.new(
+                    self.zone,
+                    'www',
+                    {'type': 'A', 'ttl': -1, 'value': '1.2.3.4'},
+                    lenient=True,
+                )
+        self.assertTrue(any('invalid ttl' in msg for msg in logs.output))
+
+        # outside context manager: lenient warning always fires
+        with self.assertLogs('Record', level='WARNING'):
+            Record.new(
+                self.zone,
+                'www',
+                {
+                    'octodns': {'lenient': True},
+                    'type': 'A',
+                    'ttl': -1,
+                    'value': '1.2.3.4',
+                },
+            )
+
     def test_values_and_value(self):
         # value w/one
         r = Record.new(

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -777,6 +777,35 @@ class TestZone(TestCase):
         with self.assertRaises(ValidationError):
             zone2.validate(suppress_lenient_warnings=True)
 
+    def test_validate_suppress_emits_debug(self):
+        zone = Zone('unit.tests.', [])
+        a = Record.new(
+            zone,
+            'www',
+            {
+                'ttl': 60,
+                'type': 'A',
+                'value': '9.9.9.9',
+                'octodns': {'lenient': True},
+            },
+        )
+        cname = Record.new(
+            zone,
+            'www',
+            {
+                'ttl': 60,
+                'type': 'CNAME',
+                'value': 'foo.bar.com.',
+                'octodns': {'lenient': True},
+            },
+        )
+        zone.add_record(a)
+        zone.add_record(cname)
+
+        with self.assertLogs('Zone', level='DEBUG') as logs:
+            zone.validate(suppress_lenient_warnings=True)
+        self.assertTrue(any('suppressed' in msg.lower() for msg in logs.output))
+
     def test_validator_registration_methods(self):
         # Test class methods that delegate to Zone.validators
         # These are currently missing coverage in octodns/zone/__init__.py

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -3,6 +3,7 @@
 #
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from helpers import SimpleProvider
 
@@ -805,6 +806,45 @@ class TestZone(TestCase):
         with self.assertLogs('Zone', level='DEBUG') as logs:
             zone.validate(suppress_lenient_warnings=True)
         self.assertTrue(any('suppressed' in msg.lower() for msg in logs.output))
+
+    def test_validate_zone_config_lenient_suppresses_empty_record_reasons(self):
+        # zone_config_lenient=True suppresses warnings even for ValidationReasons
+        # that have no records (empty record set), which reason.lenient cannot
+        # handle since it requires all records to be individually lenient-tagged.
+        from octodns.zone.validator import ValidationReason
+
+        zone = Zone('unit.tests.', [])
+        with patch.object(
+            Zone.validators,
+            'process_zone',
+            return_value=[ValidationReason('zone-wide issue', [])],
+        ):
+            # Without zone_config_lenient: lenient=False means it raises
+            with self.assertRaises(ValidationError):
+                zone.validate()
+
+            # lenient=True alone (--all): warns but not suppressed
+            with self.assertLogs('Zone', level='WARNING') as logs:
+                zone.validate(lenient=True)
+            self.assertTrue(
+                any('zone-wide issue' in msg for msg in logs.output)
+            )
+
+            # lenient=True + suppress + zone_config_lenient=True: suppressed
+            with self.assertNoLogs('Zone', level='WARNING'):
+                zone.validate(
+                    lenient=True,
+                    suppress_lenient_warnings=True,
+                    zone_config_lenient=True,
+                )
+
+            # lenient=True + suppress but zone_config_lenient=False: NOT suppressed
+            # (--all makes it a warning, but --honor-lenient shouldn't suppress it)
+            with self.assertLogs('Zone', level='WARNING') as logs:
+                zone.validate(lenient=True, suppress_lenient_warnings=True)
+            self.assertTrue(
+                any('zone-wide issue' in msg for msg in logs.output)
+            )
 
     def test_validator_registration_methods(self):
         # Test class methods that delegate to Zone.validators

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -758,9 +758,7 @@ class TestZone(TestCase):
         # raised, but a warning is logged)
         with self.assertLogs('Zone', level='WARNING') as logs:
             zone.validate()
-        self.assertTrue(
-            any('CNAME' in msg or 'A' in msg for msg in logs.output)
-        )
+        self.assertTrue(any('unit.tests.' in msg for msg in logs.output))
 
         # With suppress_lenient_warnings=True, no warning is emitted
         with self.assertNoLogs('Zone', level='WARNING'):

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -729,6 +729,56 @@ class TestZone(TestCase):
         cname.octodns['lenient'] = True
         zone.validate()
 
+    def test_validate_suppress_lenient_warnings(self):
+        zone = Zone('unit.tests.', [])
+        a = Record.new(
+            zone,
+            'www',
+            {
+                'ttl': 60,
+                'type': 'A',
+                'value': '9.9.9.9',
+                'octodns': {'lenient': True},
+            },
+        )
+        cname = Record.new(
+            zone,
+            'www',
+            {
+                'ttl': 60,
+                'type': 'CNAME',
+                'value': 'foo.bar.com.',
+                'octodns': {'lenient': True},
+            },
+        )
+        zone.add_record(a)
+        zone.add_record(cname)
+
+        # Without suppress, warns (both records are lenient so no exception
+        # raised, but a warning is logged)
+        with self.assertLogs('Zone', level='WARNING') as logs:
+            zone.validate()
+        self.assertTrue(
+            any('CNAME' in msg or 'A' in msg for msg in logs.output)
+        )
+
+        # With suppress_lenient_warnings=True, no warning is emitted
+        with self.assertNoLogs('Zone', level='WARNING'):
+            zone.validate(suppress_lenient_warnings=True)
+
+        # Non-lenient issues still raise even when suppress_lenient_warnings=True
+        zone2 = Zone('unit.tests.', [])
+        a_strict = Record.new(
+            zone2, 'www', {'ttl': 60, 'type': 'A', 'value': '9.9.9.9'}
+        )
+        cname_strict = Record.new(
+            zone2, 'www', {'ttl': 60, 'type': 'CNAME', 'value': 'foo.bar.com.'}
+        )
+        zone2.add_record(a_strict)
+        zone2.add_record(cname_strict)
+        with self.assertRaises(ValidationError):
+            zone2.validate(suppress_lenient_warnings=True)
+
     def test_validator_registration_methods(self):
         # Test class methods that delegate to Zone.validators
         # These are currently missing coverage in octodns/zone/__init__.py


### PR DESCRIPTION
Closes #1431

## Summary

- Add `--honor-lenient` flag to `octodns-validate` that suppresses validation warnings for zones and records with `lenient: true` configured, exiting 0 when no non-lenient issues remain
- Make `--all` and `--honor-lenient` composable: `--all` keeps going on errors; `--honor-lenient` suppresses lenient-configured warnings; both together show all non-lenient issues and suppress lenient ones
- Thread `zone_config_lenient` separately from the `--all` lenient flag through `Zone.validate()` so `suppress_lenient_warnings` only silences reasons that are lenient by config, not by `--all`
- Introduce `_suppress_lenient_record_warnings` / `_zone_config_lenient` ContextVars in `record/base.py` so that record-level best-practice validator warnings emitted during `populate()` are also suppressed for lenient-configured records/zones — previously these bypassed `Zone.validate()` entirely and always triggered exit 1
- Fix pre-existing bug in `validate_configs()` where the `lenient` loop variable was overwritten per-zone, causing lenient to bleed across zones

## Behavior

| Flags | Lenient-configured issues | Non-lenient issues | Exit |
|---|---|---|---|
| _(none)_ | warns, exits 1 | raises exception | 1 |
| `--all` | warns, exits 1 | warns, exits 1 | 1 |
| `--honor-lenient` | silent | raises exception | 0 or 1 |
| `--all --honor-lenient` | silent | warns, exits 1 | 0 or 1 |

## Test plan

- [x] `test_validate_suppress_lenient_warnings` — `Zone.validate()` emits no warning when `suppress_lenient_warnings=True`; non-lenient issues still raise
- [x] `test_validate_suppress_emits_debug` — `Zone.validate()` emits DEBUG log when suppressing (audit trail)
- [x] `test_validate_zone_config_lenient_suppresses_empty_record_reasons` — `zone_config_lenient=True` suppresses zone-wide reasons that have no records (which `reason.lenient` can't handle); `lenient=True` (--all) alone without `zone_config_lenient` does NOT suppress
- [x] `test_validate_configs_suppress_lenient_warnings` — `validate_configs()` suppresses zone-level warnings end-to-end; confirms `--all` + `--honor-lenient` on non-lenient zone still warns
- [x] `test_validate_configs_suppress_lenient_record_warnings` — verifies `validate_configs()` activates `suppress_lenient_record_warnings` with the correct `zone_config_lenient` argument for lenient zones, and does not activate it when `suppress_lenient_warnings=False`
- [x] `test_validate_configs_lenient_not_inherited_across_zones` — regression: lenient zone warns, strict zone raises; loop variable bug fixed
- [x] `test_suppress_lenient_record_warnings_context_manager` — unit test for the ContextVar mechanism with real `Record.new()` calls: lenient-by-record-config suppressed, lenient-by-zone-config suppressed, lenient-by-`--all`-only NOT suppressed
- [x] CLI tests: clean exit, `--honor-lenient` exits 0 on lenient-only issues, `--honor-lenient` raises on non-lenient issues, `--all` exits 1 on lenient issues, `--all` + `--honor-lenient` exits 0 when only lenient issues, `--all` + `--honor-lenient` exits 1 when non-lenient issues present
- [x] 795 tests pass, 100% coverage maintained on all measured files

## Code review follow-ups applied

- Renamed `zone_lenient` → `effective_lenient` in `validate_configs()` to distinguish the resolved `--all`-or-config combination from `zone_config_lenient` (config-only) at a glance
- Replaced `test_validate_configs_suppress_lenient_record_warnings` stub implementation: removed private ContextVar imports and `instrumented_new` that re-implemented suppression logic; new test patches `suppress_lenient_record_warnings` in `octodns.manager` and asserts correct call arguments, testing the integration boundary rather than internal mechanics