### PR TITLE
Fix broken f-string interpolation bugs

### DIFF
--- a/.changelog/676debe981654a72bb40eb58c6a619c9.md
+++ b/.changelog/676debe981654a72bb40eb58c6a619c9.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix broken f-string interpolation in alias zone error message and Geo repr

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1333,9 +1333,7 @@ class Manager(object):
                 if 'alias' in self.config['zones'][source_zone]:
                     self.log.exception('Invalid alias zone')
                     raise ManagerException(
-                        f'Invalid alias zone {decoded_zone_name}: '
-                        'source zone {source_zone} is an '
-                        'alias zone'
+                        f'Invalid alias zone {decoded_zone_name}: source zone {source_zone} is an alias zone'
                     )
 
                 # this is just here to satisfy coverage, see

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -126,10 +126,7 @@ class GeoValue(EqualityTupleMixin):
         )
 
     def __repr__(self):
-        return (
-            f"'Geo {self.continent_code} {self.country_code} "
-            "{self.subdivision_code} {self.values}'"
-        )
+        return f"'Geo {self.continent_code} {self.country_code} {self.subdivision_code} {self.values}'"
 
 
 class GeoValidator(RecordValidator):

--- a/tests/test_octodns_record_geo.py
+++ b/tests/test_octodns_record_geo.py
@@ -65,8 +65,10 @@ class TestRecordGeo(TestCase):
         # Geo provider does consider lack of geo diffs to be changes
         self.assertTrue(geo.changes(other, geo_target))
 
-        # __repr__ doesn't blow up
-        geo.__repr__()
+        # __repr__ includes all the fields
+        af = geo.geo['AF']
+        expected = f"'Geo {af.continent_code} {af.country_code} {af.subdivision_code} {af.values}'"
+        self.assertEqual(expected, af.__repr__())
 
 
 class TestRecordGeoCodes(TestCase):


### PR DESCRIPTION
## Summary
- Fixes an alias zone error message where an f-string was split across lines and the continuation lines lost their `f` prefix, so `{source_zone}` was emitted literally instead of being interpolated.
- Found and fixed the same bug pattern in `GeoValue.__repr__`, where `{subdivision_code}` and `{values}` were emitted literally instead of being interpolated.
- Strengthened `tests/test_octodns_record_geo.py` to assert on the actual `__repr__` content instead of just calling it, so this bug class is caught in the future.

/cc #1436 found the original problem

## Test plan
- [x] `./script/test` passes (781 passed)
- [x] `./script/coverage` at 100%
- [x] `./script/lint` and `./script/format` clean