### PR TITLE
Collapse remaining multi-line string concatenations

### DIFF
--- a/.changelog/b01976da4f474745b5c71935640d719a.md
+++ b/.changelog/b01976da4f474745b5c71935640d719a.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Collapse remaining multi-line string concatenations to avoid f-string interpolation bugs

--- a/octodns/cmds/args.py
+++ b/octodns/cmds/args.py
@@ -83,10 +83,7 @@ class ArgumentParser(_Base):
         logger.addHandler(handler)
 
         if args.log_syslog:
-            fmt = (
-                'octodns[%(process)-5s:%(thread)d]: %(name)s '
-                '%(levelname)-5s %(message)s'
-            )
+            fmt = 'octodns[%(process)-5s:%(thread)d]: %(name)s %(levelname)-5s %(message)s'
             handler = SysLogHandler(
                 address=args.syslog_device, facility=args.syslog_facility
             )

--- a/octodns/cmds/dump.py
+++ b/octodns/cmds/dump.py
@@ -18,14 +18,12 @@ def main():
     parser.add_argument(
         '--output-dir',
         required=True,
-        help='The directory into which the results will be '
-        'written (Note: will overwrite existing files)',
+        help='The directory into which the results will be written (Note: will overwrite existing files)',
     )
     parser.add_argument(
         '--output-provider',
         required=False,
-        help='The configured provider to use when dumping '
-        'records. Must support copy() and directory',
+        help='The configured provider to use when dumping records. Must support copy() and directory',
     )
     parser.add_argument(
         '--lenient',

--- a/octodns/cmds/sync.py
+++ b/octodns/cmds/sync.py
@@ -25,8 +25,7 @@ def main():
         '--force',
         action='store_true',
         default=False,
-        help='Acknowledge that significant changes are being '
-        'made and do them',
+        help='Acknowledge that significant changes are being made and do them',
     )
     parser.add_argument(
         '--checksum',
@@ -45,9 +44,7 @@ def main():
         '--source',
         default=[],
         action='append',
-        help='Limit sync to zones with the specified '
-        'source(s) (all sources will be synchronized for the '
-        'selected zones)',
+        help='Limit sync to zones with the specified source(s) (all sources will be synchronized for the selected zones)',
     )
     parser.add_argument(
         '--target',

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -382,8 +382,7 @@ class Manager(object):
         enabled = validators_config.get('enabled', ('legacy',))
         if isinstance(enabled, str):
             raise ManagerException(
-                'manager.validators.enabled must be a list of set names, not a string; '
-                f'use [{enabled!r}] to enable a single set'
+                f'manager.validators.enabled must be a list of set names, not a string; use [{enabled!r}] to enable a single set'
             )
         self.log.info('_configure_validators: enabling sets %s', list(enabled))
         Record.enable_validators(enabled)
@@ -396,14 +395,11 @@ class Manager(object):
         has_old = 'validators' in validators_config
         if has_new and has_old:
             raise ManagerException(
-                'manager.validators.record.validators and '
-                'manager.validators.validators cannot both be set; '
-                'remove manager.validators.validators (deprecated)'
+                'manager.validators.record.validators and manager.validators.validators cannot both be set; remove manager.validators.validators (deprecated)'
             )
         if has_old:
             deprecated(
-                'manager.validators.validators is deprecated, use '
-                'manager.validators.record.validators instead. Will be removed in 2.0',
+                'manager.validators.validators is deprecated, use manager.validators.record.validators instead. Will be removed in 2.0',
                 stacklevel=4,
             )
         add_config = record_config.get(
@@ -441,8 +437,7 @@ class Manager(object):
             )
         if has_old_dis:
             deprecated(
-                'manager.validators.disable_validators is deprecated, use '
-                'manager.validators.record.disable_validators instead. Will be removed in 2.0',
+                'manager.validators.disable_validators is deprecated, use manager.validators.record.disable_validators instead. Will be removed in 2.0',
                 stacklevel=4,
             )
         disable_config = record_config.get(
@@ -460,8 +455,7 @@ class Manager(object):
                     raise ManagerException(str(e)) from e
                 if removed == 0:
                     self.log.warning(
-                        '_configure_validators: no validator with id "%s" '
-                        'registered for "%s"',
+                        '_configure_validators: no validator with id "%s" registered for "%s"',
                         validator_id,
                         record_type,
                     )
@@ -1080,9 +1074,7 @@ class Manager(object):
                 desired_config = desired[zone_source]
             except KeyError:
                 raise ManagerException(
-                    f'Zone {idna_decode(zone_name)} cannot be synced '
-                    f'without zone {zone_source} sinced '
-                    'it is aliased'
+                    f'Zone {idna_decode(zone_name)} cannot be synced without zone {zone_source} sinced it is aliased'
                 )
             futures.append(
                 self._executor.submit(
@@ -1201,8 +1193,7 @@ class Manager(object):
         Dump zone data from the specified source
         '''
         self.log.info(
-            'dump: zone=%s, output_dir=%s, output_provider=%s, '
-            'lenient=%s, split=%s, sources=%s',
+            'dump: zone=%s, output_dir=%s, output_provider=%s, lenient=%s, split=%s, sources=%s',
             zone,
             output_dir,
             output_provider,
@@ -1228,10 +1219,7 @@ class Manager(object):
             # that we can tell it where the user has requested the dumped files
             # to reside.
             if not hasattr(target, 'directory'):
-                msg = (
-                    f'output_provider={output_provider}, does not support '
-                    'directory property'
-                )
+                msg = f'output_provider={output_provider}, does not support directory property'
                 raise ManagerException(msg)
             if target.directory != output_dir:
                 # If the requested target doesn't match what's configured in
@@ -1240,10 +1228,7 @@ class Manager(object):
                 # unchanged and potentially be used as a source, e.g. copying
                 # from one yaml to another
                 if not hasattr(target, 'copy'):
-                    msg = (
-                        f'output_provider={output_provider}, does not '
-                        'support copy method'
-                    )
+                    msg = f'output_provider={output_provider}, does not support copy method'
                     raise ManagerException(msg)
                 target = target.copy()
                 self.log.info(
@@ -1325,9 +1310,7 @@ class Manager(object):
                 if source_zone not in self.config['zones']:
                     self.log.exception('Invalid alias zone')
                     raise ManagerException(
-                        f'Invalid alias zone {decoded_zone_name}: '
-                        f'source zone {source_zone} does '
-                        'not exist'
+                        f'Invalid alias zone {decoded_zone_name}: source zone {source_zone} does not exist'
                     )
 
                 if 'alias' in self.config['zones'][source_zone]:
@@ -1376,8 +1359,7 @@ class Manager(object):
                     collected.append(self.processors[processor])
             except KeyError:
                 raise ManagerException(
-                    f'Zone {decoded_zone_name}, unknown '
-                    f'processor: {processor}'
+                    f'Zone {decoded_zone_name}, unknown processor: {processor}'
                 )
 
     def get_zone(self, zone_name):

--- a/octodns/processor/ownership.py
+++ b/octodns/processor/ownership.py
@@ -114,10 +114,7 @@ class OwnershipProcessor(BaseProcessor):
             name, _type = self._decode_ownership_name(record)
             if _type in owned[name]:
                 raise OwnershipException(
-                    f'{self.id}: refusing to take over {record.fqdn} '
-                    f'{_type}, owned by {record.values}, not '
-                    f'{self._txt_values}; set allow_takeover=true to '
-                    'override'
+                    f'{self.id}: refusing to take over {record.fqdn} {_type}, owned by {record.values}, not {self._txt_values}; set allow_takeover=true to override'
                 )
 
         # Cases:

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -103,11 +103,7 @@ class BaseProvider(BaseSource):
         '''
         super().__init__(id)
         self.log.debug(
-            '__init__: id=%s, apply_disabled=%s, '
-            'update_pcent_threshold=%.2f, '
-            'delete_pcent_threshold=%.2f, '
-            'strict_supports=%s, '
-            'root_ns_warnings=%s',
+            '__init__: id=%s, apply_disabled=%s, update_pcent_threshold=%.2f, delete_pcent_threshold=%.2f, strict_supports=%s, root_ns_warnings=%s',
             id,
             apply_disabled,
             update_pcent_threshold,
@@ -169,10 +165,7 @@ class BaseProvider(BaseSource):
                                     unsupported_pools.append(_id)
                         if unsupported_pools:
                             unsupported_pools = ','.join(unsupported_pools)
-                            msg = (
-                                f'"status" flag used in pools {unsupported_pools}'
-                                f' in {record.fqdn} is not supported'
-                            )
+                            msg = f'"status" flag used in pools {unsupported_pools} in {record.fqdn} is not supported'
                             fallback = (
                                 'will ignore it and respect the healthcheck'
                             )
@@ -254,8 +247,7 @@ class BaseProvider(BaseSource):
         if self.SUPPORTS_ROOT_NS:
             if not record and self.root_ns_warnings:
                 self.log.warning(
-                    'root NS record supported, but no record '
-                    'is configured for %s',
+                    'root NS record supported, but no record is configured for %s',
                     desired.decoded_name,
                 )
         else:
@@ -314,8 +306,7 @@ class BaseProvider(BaseSource):
         ):
             if self.root_ns_warnings:
                 self.log.info(
-                    'root NS record in existing, but not supported or '
-                    'not configured; ignoring it'
+                    'root NS record in existing, but not supported or not configured; ignoring it'
                 )
             existing.remove_record(existing_root_ns)
 

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -29,10 +29,7 @@ class TooMuchChange(UnsafePlan):
         existing_count,
         name,
     ):
-        msg = (
-            f'[{name}] {why}, {update_pcent:.2f}% is over {update_threshold:.2f}% '
-            f'({change_count}/{existing_count}), force required'
-        )
+        msg = f'[{name}] {why}, {update_pcent:.2f}% is over {update_threshold:.2f}% ({change_count}/{existing_count}), force required'
         super().__init__(msg)
 
 
@@ -274,8 +271,7 @@ class PlanMarkdown(_PlanFhOutput):
                 fh.write('\n\n')
 
                 fh.write(
-                    '| Operation | Name | Type | TTL | Value | Source |\n'
-                    '|--|--|--|--|--|--|\n'
+                    '| Operation | Name | Type | TTL | Value | Source |\n|--|--|--|--|--|--|\n'
                 )
 
                 if plan.exists is False:

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -35,15 +35,13 @@ class NameValidator(RecordValidator):
         n = len(fqdn)
         if n > 253:
             reasons.append(
-                f'invalid fqdn, "{idna_decode(fqdn)}" is too long at {n} '
-                'chars, max is 253'
+                f'invalid fqdn, "{idna_decode(fqdn)}" is too long at {n} chars, max is 253'
             )
         for label in name.split('.'):
             n = len(label)
             if n > 63:
                 reasons.append(
-                    f'invalid label, "{label}" is too long at {n}'
-                    ' chars, max is 63'
+                    f'invalid label, "{label}" is too long at {n} chars, max is 63'
                 )
         # in the case of endswith there's an implicit second . from the Zone
         if '..' in name or name.endswith('.'):
@@ -138,9 +136,7 @@ class Record(EqualityTupleMixin):
         super().__init_subclass__(**kwargs)
         if 'validate' in cls.__dict__:
             deprecated(
-                f'`{cls.__name__}.validate` override is DEPRECATED. '
-                'Add a RecordValidator to `VALIDATORS` instead. '
-                'Will be removed in 2.0',
+                f'`{cls.__name__}.validate` override is DEPRECATED. Add a RecordValidator to `VALIDATORS` instead. Will be removed in 2.0',
                 stacklevel=3,
             )
 

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -94,8 +94,7 @@ class CaaValueBestPracticeValidator(ValueValidator):
         tags = {v.get('tag') for v in data}
         if 'issue' in tags and 'issuewild' not in tags:
             return [
-                'CAA issue tag is present without issuewild; '
-                'add an explicit issuewild to clarify wildcard certificate policy'
+                'CAA issue tag is present without issuewild; add an explicit issuewild to clarify wildcard certificate policy'
             ]
         return []
 

--- a/octodns/record/change.py
+++ b/octodns/record/change.py
@@ -58,10 +58,7 @@ class Update(Change):
     # do nothing
     def __repr__(self, leader=''):
         source = self.new.source.id if self.new.source else ''
-        return (
-            f'Update\n{leader}    {self.existing} ->\n'
-            f'{leader}    {self.new} ({source})'
-        )
+        return f'Update\n{leader}    {self.existing} ->\n{leader}    {self.new} ({source})'
 
 
 class Delete(Change):

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -189,8 +189,7 @@ class DsValueBestPracticeValidator(ValueValidator):
                 digest_type = int(value['digest_type'])
                 if digest_type == 1:
                     reasons.append(
-                        'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; '
-                        'use digest_type 2 (SHA-256)'
+                        'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; use digest_type 2 (SHA-256)'
                     )
             except (KeyError, ValueError, TypeError):
                 pass

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -167,8 +167,7 @@ class _DynamicMixin(object):
     VALIDATORS = [DynamicValidator('dynamic', sets={'legacy', 'strict'})]
 
     geo_re = re.compile(
-        r'^(?P<continent_code>\w\w)(-(?P<country_code>\w\w)'
-        r'(-(?P<subdivision_code>\w\w))?)?$'
+        r'^(?P<continent_code>\w\w)(-(?P<country_code>\w\w)(-(?P<subdivision_code>\w\w))?)?$'
     )
 
     @classmethod
@@ -268,23 +267,20 @@ class _DynamicMixin(object):
                         weight = int(weight)
                         if weight < 1 or weight > 100:
                             reasons.append(
-                                f'invalid weight "{weight}" in '
-                                f'pool "{_id}" value {value_num}'
+                                f'invalid weight "{weight}" in pool "{_id}" value {value_num}'
                             )
                     except KeyError:
                         pass
                     except ValueError:
                         reasons.append(
-                            f'invalid weight "{weight}" in '
-                            f'pool "{_id}" value {value_num}'
+                            f'invalid weight "{weight}" in pool "{_id}" value {value_num}'
                         )
 
                     try:
                         status = value['status']
                         if status not in ['up', 'down', 'obey']:
                             reasons.append(
-                                f'invalid status "{status}" in '
-                                f'pool "{_id}" value {value_num}'
+                                f'invalid status "{status}" in pool "{_id}" value {value_num}'
                             )
                     except KeyError:
                         pass
@@ -298,8 +294,7 @@ class _DynamicMixin(object):
                         )
                     except KeyError:
                         reasons.append(
-                            f'missing value in pool "{_id}" '
-                            f'value {value_num}'
+                            f'missing value in pool "{_id}" value {value_num}'
                         )
 
                 if len(values) == 1 and values[0].get('weight', 1) != 1:
@@ -313,8 +308,7 @@ class _DynamicMixin(object):
                         pools_seen_as_fallback.add(fallback)
                     else:
                         reasons.append(
-                            f'undefined fallback "{fallback}" '
-                            f'for pool "{_id}"'
+                            f'undefined fallback "{fallback}" for pool "{_id}"'
                         )
 
                 # Check for loops
@@ -367,8 +361,7 @@ class _DynamicMixin(object):
                         )
                     elif pool in pools_seen and (subnets or geos):
                         reasons.append(
-                            f'rule {rule_num} invalid, target '
-                            f'pool "{pool}" reused'
+                            f'rule {rule_num} invalid, target pool "{pool}" reused'
                         )
                     pools_seen.add(pool)
 
@@ -516,8 +509,5 @@ class _DynamicMixin(object):
                 values = self.value
 
             klass = self.__class__.__name__
-            return (
-                f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, '
-                f'{values}, {self.dynamic}>'
-            )
+            return f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, {values}, {self.dynamic}>'
         return super().__repr__()

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -90,8 +90,7 @@ class GeoCodes(object):
 
 class GeoValue(EqualityTupleMixin):
     geo_re = re.compile(
-        r'^(?P<continent_code>\w\w)(-(?P<country_code>\w\w)'
-        r'(-(?P<subdivision_code>\w\w))?)?$'
+        r'^(?P<continent_code>\w\w)(-(?P<country_code>\w\w)(-(?P<subdivision_code>\w\w))?)?$'
     )
 
     @classmethod
@@ -209,8 +208,5 @@ class _GeoMixin(ValuesMixin):
     def __repr__(self):
         if self.geo:
             klass = self.__class__.__name__
-            return (
-                f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, '
-                f'{self.values}, {self.geo}>'
-            )
+            return f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, {self.values}, {self.geo}>'
         return super().__repr__()

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -291,10 +291,7 @@ class NaptrValue(EqualityTupleMixin, dict):
         flags = self.flags if self.flags is not None else ''
         service = self.service if self.service is not None else ''
         regexp = self.regexp if self.regexp is not None else ''
-        return (
-            f"'{self.order} {self.preference} \"{flags}\" \"{service}\" "
-            f"\"{regexp}\" {self.replacement}'"
-        )
+        return f"'{self.order} {self.preference} \"{flags}\" \"{service}\" \"{regexp}\" {self.replacement}'"
 
 
 class NaptrRecord(ValuesMixin, Record):

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -60,9 +60,7 @@ class SshfpValueValidator(ValueValidator):
                 actual = len(value['fingerprint'])
                 if actual != expected:
                     reasons.append(
-                        f'fingerprint length {actual} does not match '
-                        f'fingerprint_type {fingerprint_type} '
-                        f'(expected {expected})'
+                        f'fingerprint length {actual} does not match fingerprint_type {fingerprint_type} (expected {expected})'
                     )
         return reasons
 
@@ -118,8 +116,7 @@ class SshfpValueRfcValidator(ValueValidator):
                     expected = self._fingerprint_type_lengths[fingerprint_type]
                     if len(str(fp)) != expected:
                         reasons.append(
-                            f'fingerprint must be {expected} hex characters '
-                            f'for fingerprint_type {fingerprint_type}'
+                            f'fingerprint must be {expected} hex characters for fingerprint_type {fingerprint_type}'
                         )
         return reasons
 
@@ -148,8 +145,7 @@ class SshfpValueBestPracticeValidator(ValueValidator):
                 continue
             if fp_type == 1:
                 reasons.append(
-                    'SSHFP fingerprint_type 1 (SHA-1) is deprecated; '
-                    'use fingerprint_type 2 (SHA-256)'
+                    'SSHFP fingerprint_type 1 (SHA-1) is deprecated; use fingerprint_type 2 (SHA-256)'
                 )
         return reasons
 

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -28,8 +28,7 @@ class TlsaValueValidator(ValueValidator):
                     )
             except ValueError:
                 reasons.append(
-                    f'invalid certificate_usage '
-                    f'"{value["certificate_usage"]}"'
+                    f'invalid certificate_usage "{value["certificate_usage"]}"'
                 )
 
             try:
@@ -143,8 +142,7 @@ class TlsaValueBestPracticeValidator(ValueValidator):
                 continue
             if matching_type == 0:
                 reasons.append(
-                    'TLSA matching_type 0 (full data) is not recommended; '
-                    'use matching_type 1 (SHA-256) or 2 (SHA-512)'
+                    'TLSA matching_type 0 (full data) is not recommended; use matching_type 1 (SHA-256) or 2 (SHA-512)'
                 )
         return reasons
 

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -138,8 +138,7 @@ class ValidatorRegistry:
         legacy = getattr(value_type, 'validate', None)
         if legacy is not None:
             deprecated(
-                f'`{value_type.__name__}.validate` classmethod is DEPRECATED. '
-                'Add a ValueValidator to `VALIDATORS` instead. Will be removed in 2.0',
+                f'`{value_type.__name__}.validate` classmethod is DEPRECATED. Add a ValueValidator to `VALIDATORS` instead. Will be removed in 2.0',
                 stacklevel=3,
             )
             reasons.extend(legacy(values, _type))

--- a/octodns/schema/config.py
+++ b/octodns/schema/config.py
@@ -347,10 +347,7 @@ def build_config_schema():
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'title': 'octoDNS config file',
-        'description': (
-            'Schema for an octoDNS main configuration YAML file: '
-            'providers, processors, validators, secret_handlers, and zones.'
-        ),
+        'description': 'Schema for an octoDNS main configuration YAML file: providers, processors, validators, secret_handlers, and zones.',
         'type': 'object',
         'required': ['providers', 'zones'],
         'additionalProperties': False,

--- a/octodns/schema/zone.py
+++ b/octodns/schema/zone.py
@@ -172,10 +172,7 @@ def build_zone_schema():
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'title': 'octoDNS zone file',
-        'description': (
-            'Schema for an octoDNS zone YAML file: a mapping of record names '
-            'to a record or list of records.'
-        ),
+        'description': 'Schema for an octoDNS zone YAML file: a mapping of record names to a record or list of records.',
         'type': 'object',
         'propertyNames': _NAME_SCHEMA,
         'additionalProperties': {

--- a/octodns/yaml.py
+++ b/octodns/yaml.py
@@ -148,8 +148,7 @@ class SortEnforcingLoader(ContextLoader):
                 raise ConstructorError(
                     None,
                     None,
-                    'keys out of order: '
-                    f'expected {expected} got {key} at {context}',
+                    f'keys out of order: expected {expected} got {key} at {context}',
                 )
 
         return ret

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -597,8 +597,7 @@ class Zone(object):
             except KeyError:
                 if not target.supports(record):
                     self.log.debug(
-                        'changes:  skipping record=%s %s - %s does '
-                        'not support it',
+                        'changes:  skipping record=%s %s - %s does not support it',
                         record.fqdn,
                         record._type,
                         target.id,
@@ -613,8 +612,7 @@ class Zone(object):
                 change = record.changes(desired_record, target)
                 if change:
                     self.log.debug(
-                        'changes: zone=%s, modified\n'
-                        '    existing=%s,\n     desired=%s',
+                        'changes: zone=%s, modified\n    existing=%s,\n     desired=%s',
                         self,
                         record,
                         desired_record,
@@ -650,8 +648,7 @@ class Zone(object):
 
             if not target.supports(record):
                 self.log.debug(
-                    'changes:  skipping record=%s %s - %s does not '
-                    'support it',
+                    'changes:  skipping record=%s %s - %s does not support it',
                     record.fqdn,
                     record._type,
                     target.id,

--- a/octodns/zone/caa.py
+++ b/octodns/zone/caa.py
@@ -70,8 +70,7 @@ class CaaZoneValidator(ZoneValidator):
         if not apex_caa and self.presence == 'required':
             reasons.append(
                 ValidationReason(
-                    f'zone "{zone.decoded_name}" has no CAA records at the '
-                    'apex',
+                    f'zone "{zone.decoded_name}" has no CAA records at the apex',
                     set(),
                 )
             )
@@ -90,9 +89,7 @@ class CaaZoneValidator(ZoneValidator):
             if not has_issue and not has_issuewild:
                 reasons.append(
                     ValidationReason(
-                        f'CAA record "{record.fqdn}" has no ``issue`` '
-                        'or ``issuewild`` tag; having only ``iodef`` means any '
-                        'CA can issue certificates',
+                        f'CAA record "{record.fqdn}" has no ``issue`` or ``issuewild`` tag; having only ``iodef`` means any CA can issue certificates',
                         [record],
                     )
                 )
@@ -102,9 +99,7 @@ class CaaZoneValidator(ZoneValidator):
             if has_issue and not has_issuewild:
                 reasons.append(
                     ValidationReason(
-                        f'CAA record "{record.fqdn}" has ``issue`` but '
-                        'no ``issuewild``; consider adding an explicit '
-                        '``issuewild`` to define wildcard certificate policy',
+                        f'CAA record "{record.fqdn}" has ``issue`` but no ``issuewild``; consider adding an explicit ``issuewild`` to define wildcard certificate policy',
                         [record],
                     )
                 )


### PR DESCRIPTION
## Summary
- #1437 fixed two real bugs where a multi-line implicit string concatenation lost its `f` prefix on continuation lines, so a `{placeholder}` was emitted literally instead of interpolated.
- Audited the rest of `octodns/` for the same pattern: 57 other multi-line concatenations, 31 of them f-strings. None were actually broken (every piece was correctly prefixed), but collapsing them removes the risk and matches the style of the fix.
- Collapsed 55 of the 57 sites to single lines. Left two multi-line where collapsing would have pushed the line past ~175 chars: the `manager.py` `disable_validators` deprecation message, and `LOC.__repr__`'s 12-field string.

/cc #1436 found the original problem
/cc #1437 fixed the two real bugs; this follows up with the rest of the audit

## Test plan
- [x] `./script/test` passes (781 passed)
- [x] `./script/coverage` at 100%
- [x] `./script/lint` and `./script/format` clean