### PR TITLE
Add required validator_id parameter to ValidatorReason

### DIFF
--- a/.changelog/03bb923602674dd795bc41e348ecc850.md
+++ b/.changelog/03bb923602674dd795bc41e348ecc850.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add required validator_id parameter to ValidatorReason

--- a/octodns/zone/caa.py
+++ b/octodns/zone/caa.py
@@ -72,6 +72,7 @@ class CaaZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" has no CAA records at the apex',
                     set(),
+                    validator_id=self.id,
                 )
             )
 
@@ -91,6 +92,7 @@ class CaaZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'CAA record "{record.fqdn}" has no ``issue`` or ``issuewild`` tag; having only ``iodef`` means any CA can issue certificates',
                         [record],
+                        validator_id=self.id,
                     )
                 )
 
@@ -101,6 +103,7 @@ class CaaZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'CAA record "{record.fqdn}" has ``issue`` but no ``issuewild``; consider adding an explicit ``issuewild`` to define wildcard certificate policy',
                         [record],
+                        validator_id=self.id,
                     )
                 )
 

--- a/octodns/zone/cname.py
+++ b/octodns/zone/cname.py
@@ -24,6 +24,7 @@ class CnameCoexistenceValidator(ZoneValidator):
                         ValidationReason(
                             f'Invalid state, CNAME at {record.fqdn} cannot coexist with other records',
                             node,
+                            validator_id=self.id,
                         )
                     )
                 elif 'ALIAS' in types and ('A' in types or 'AAAA' in types):
@@ -32,6 +33,7 @@ class CnameCoexistenceValidator(ZoneValidator):
                         ValidationReason(
                             f'Invalid state, ALIAS at {record.fqdn} cannot coexist with A or AAAA records',
                             node,
+                            validator_id=self.id,
                         )
                     )
 
@@ -71,7 +73,9 @@ class NoCnameLoopZoneValidator(ZoneValidator):
                     }
                     reasons.append(
                         ValidationReason(
-                            f'Loop detected: {loop_path}', cycle_records
+                            f'Loop detected: {loop_path}',
+                            cycle_records,
+                            validator_id=self.id,
                         )
                     )
                     break
@@ -106,6 +110,7 @@ class CnameTargetResolvableInZoneZoneValidator(ZoneValidator):
                             ValidationReason(
                                 f'{record._type} record "{record.decoded_fqdn}" points to in-zone target "{target}" that does not exist',
                                 [record],
+                                validator_id=self.id,
                             )
                         )
         return reasons
@@ -125,6 +130,7 @@ class RootCnameZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'CNAME record at zone apex "{cname.decoded_fqdn}" is not allowed',
                     [cname],
+                    validator_id=self.id,
                 )
             )
         return reasons
@@ -148,6 +154,7 @@ class CnameTargetNotCnameZoneValidator(ZoneValidator):
                             ValidationReason(
                                 f'CNAME record "{record.decoded_fqdn}" points to target "{target}" which is also a CNAME',
                                 [record],
+                                validator_id=self.id,
                             )
                         )
         return reasons

--- a/octodns/zone/dname.py
+++ b/octodns/zone/dname.py
@@ -28,6 +28,7 @@ class DnameCoexistenceValidator(ZoneValidator):
                         ValidationReason(
                             f'Invalid state, DNAME at {dname_record.fqdn} cannot coexist with CNAME',
                             node,
+                            validator_id=self.id,
                         )
                     )
 
@@ -36,6 +37,7 @@ class DnameCoexistenceValidator(ZoneValidator):
                         ValidationReason(
                             f'Invalid state, DNAME at {dname_record.fqdn} cannot coexist with NS at a non-apex node',
                             node,
+                            validator_id=self.id,
                         )
                     )
 
@@ -51,6 +53,7 @@ class DnameCoexistenceValidator(ZoneValidator):
                         ValidationReason(
                             f'Record "{record.decoded_fqdn}" is occluded by DNAME "{dname.decoded_fqdn}"',
                             [record],
+                            validator_id=self.id,
                         )
                     )
 

--- a/octodns/zone/exception.py
+++ b/octodns/zone/exception.py
@@ -12,13 +12,7 @@ class ZoneException(Exception):
 class ValidationError(ZoneException):
     @classmethod
     def build_message(cls, zone_name, reasons, context=None):
-        def _reason_str(r):
-            s = str(r)
-            if getattr(r, 'validator_id', None):
-                s += f'\n    via: {r.validator_id}'
-            return s
-
-        reasons = '\n  - '.join([_reason_str(r) for r in reasons])
+        reasons = '\n  - '.join([str(r) for r in reasons])
         msg = f'Invalid zone "{idna_decode(zone_name)}"'
         if context:
             msg += f', {context}'

--- a/octodns/zone/exception.py
+++ b/octodns/zone/exception.py
@@ -12,7 +12,13 @@ class ZoneException(Exception):
 class ValidationError(ZoneException):
     @classmethod
     def build_message(cls, zone_name, reasons, context=None):
-        reasons = '\n  - '.join([str(r) for r in reasons])
+        def _reason_str(r):
+            s = str(r)
+            if getattr(r, 'validator_id', None):
+                s += f'\n    via: {r.validator_id}'
+            return s
+
+        reasons = '\n  - '.join([_reason_str(r) for r in reasons])
         msg = f'Invalid zone "{idna_decode(zone_name)}"'
         if context:
             msg += f', {context}'

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -115,7 +115,9 @@ class MailZoneValidator(ZoneValidator):
             return None, None
         reason = None
         if len(values) > 1:
-            reason = ValidationReason(reason=multi_msg, records={txt_record})
+            reason = ValidationReason(
+                reason=multi_msg, records={txt_record}, validator_id=self.id
+            )
         return values[0], reason
 
     def _parse_dmarc_tags(self, dmarc_value):
@@ -158,6 +160,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" handles mail but is missing MX records at the apex',
                     records,
+                    validator_id=self.id,
                 )
             )
 
@@ -167,6 +170,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" handles mail but is missing an SPF TXT record at the apex',
                     records,
+                    validator_id=self.id,
                 )
             )
         elif not (
@@ -176,6 +180,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'SPF record at the apex of "{zone.decoded_name}" should terminate with "~all" or "-all"',
                     {apex_txt},
+                    validator_id=self.id,
                 )
             )
 
@@ -185,6 +190,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" handles mail but is missing a DMARC TXT record at _dmarc',
                     records,
+                    validator_id=self.id,
                 )
             )
         else:
@@ -194,6 +200,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'DMARC record at _dmarc.{zone.decoded_name} is missing a policy (p=...)',
                         [dmarc_txt],
+                        validator_id=self.id,
                     )
                 )
 
@@ -224,6 +231,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail but is missing a Null MX record (0 .)',
                     records,
+                    validator_id=self.id,
                 )
             )
         elif not self._is_null_mx(apex_mx_record):
@@ -231,6 +239,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail and should have a single Null MX record (0 .)',
                     [apex_mx_record],
+                    validator_id=self.id,
                 )
             )
 
@@ -240,6 +249,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail but is missing strict SPF TXT record "v=spf1 -all"',
                     records,
+                    validator_id=self.id,
                 )
             )
         elif not apex_spf_value == 'v=spf1 -all':
@@ -247,6 +257,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail and should have a single strict SPF TXT record "v=spf1 -all"',
                     [apex_txt],
+                    validator_id=self.id,
                 )
             )
 
@@ -256,6 +267,7 @@ class MailZoneValidator(ZoneValidator):
                 ValidationReason(
                     f'zone "{zone.decoded_name}" disables mail but is missing strict DMARC TXT record "v=DMARC1; p=reject;"',
                     records,
+                    validator_id=self.id,
                 )
             )
         else:
@@ -265,6 +277,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'zone "{zone.decoded_name}" disables mail and should have a DMARC TXT record with "v=DMARC1; p=reject;"',
                         [dmarc_txt],
+                        validator_id=self.id,
                     )
                 )
 
@@ -295,6 +308,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'"{mx_record.decoded_fqdn}" handles mail but is missing an SPF TXT record',
                         records,
+                        validator_id=self.id,
                     )
                 )
             elif not (
@@ -304,6 +318,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'SPF record at "{mx_record.decoded_fqdn}" should terminate with "~all" or "-all"',
                         {txt_record},
+                        validator_id=self.id,
                     )
                 )
         else:
@@ -312,6 +327,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'"{mx_record.decoded_fqdn}" disables mail and should have a single Null MX record (0 .)',
                         {mx_record},
+                        validator_id=self.id,
                     )
                 )
             if spf_value is None:
@@ -319,6 +335,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'"{mx_record.decoded_fqdn}" disables mail but is missing strict SPF TXT record "v=spf1 -all"',
                         records,
+                        validator_id=self.id,
                     )
                 )
             elif spf_value != 'v=spf1 -all':
@@ -326,6 +343,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'"{mx_record.decoded_fqdn}" disables mail and should have a strict SPF TXT record "v=spf1 -all"',
                         {txt_record},
+                        validator_id=self.id,
                     )
                 )
 
@@ -360,6 +378,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         f'MX record "{record.fqdn}" should have at least {self.min_mx} values for redundancy, found {len(record.values)}',
                         [record],
+                        validator_id=self.id,
                     )
                 )
 
@@ -386,6 +405,7 @@ class MailZoneValidator(ZoneValidator):
                     ValidationReason(
                         reason=f'zone "{zone.decoded_name}" has multiple DMARC values',
                         records={dmarc_txt},
+                        validator_id=self.id,
                     )
                 )
             dmarc_value = dmarc_value[0]
@@ -487,6 +507,7 @@ class MxTargetNotCnameZoneValidator(ZoneValidator):
                                 ValidationReason(
                                     f'MX record "{record.fqdn}" points to exchange "{target}" which is a CNAME',
                                     [record],
+                                    validator_id=self.id,
                                 )
                             )
         return reasons
@@ -518,6 +539,7 @@ class MxTargetResolvableInZoneZoneValidator(ZoneValidator):
                                 ValidationReason(
                                     f'MX record "{record.decoded_fqdn}" points to in-zone target "{target}" that does not exist',
                                     [record],
+                                    validator_id=self.id,
                                 )
                             )
         return reasons

--- a/octodns/zone/ns.py
+++ b/octodns/zone/ns.py
@@ -40,6 +40,7 @@ class GlueForInZoneNsZoneValidator(ZoneValidator):
                                 ValidationReason(
                                     f'NS record "{record.fqdn}" points to in-zone target "{target}" without glue records (A/AAAA)',
                                     [record],
+                                    validator_id=self.id,
                                 )
                             )
         return reasons
@@ -65,6 +66,7 @@ class NsTargetNotCnameZoneValidator(ZoneValidator):
                                 ValidationReason(
                                     f'NS record "{record.fqdn}" points to target "{target}" which is a CNAME',
                                     [record],
+                                    validator_id=self.id,
                                 )
                             )
         return reasons
@@ -86,6 +88,7 @@ class MultiValueNsZoneValidator(ZoneValidator):
                         ValidationReason(
                             f'NS record "{record.fqdn}" has only {len(record.values)} value; at least 2 are recommended for redundancy',
                             [record],
+                            validator_id=self.id,
                         )
                     )
         return reasons

--- a/octodns/zone/srv.py
+++ b/octodns/zone/srv.py
@@ -29,6 +29,7 @@ class SrvTargetNotCnameZoneValidator(ZoneValidator):
                                 ValidationReason(
                                     f'SRV record "{record.decoded_fqdn}" points to target "{target}" which is a CNAME',
                                     [record],
+                                    validator_id=self.id,
                                 )
                             )
         return reasons
@@ -53,6 +54,7 @@ class SrvTargetResolvableInZoneZoneValidator(ZoneValidator):
                                 ValidationReason(
                                     f'SRV record "{record.decoded_fqdn}" points to in-zone target "{target}" that does not exist',
                                     [record],
+                                    validator_id=self.id,
                                 )
                             )
         return reasons

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -3,6 +3,7 @@
 #
 
 from logging import getLogger
+from warnings import deprecated
 
 from .exception import ZoneException
 
@@ -75,7 +76,13 @@ class ZoneValidatorRegistry:
 
 
 class ValidationReason:
-    def __init__(self, reason, records):
+    def __init__(self, reason, records, validator_id=None):
+        if validator_id is None:
+            deprecated(
+                'omitting `validator_id` is DEPRECATED. It will be a required parameter as of 2.0',
+                stacklevel=3,
+            )
+        self.validator_id = validator_id
         self.reason = reason
         self.records = set(records)
 
@@ -90,6 +97,8 @@ class ValidationReason:
         }
         if contexts:
             msg += f" ({', '.join(sorted(contexts))})"
+        if self.validator_id is not None:
+            msg += f'\n  via: {self.validator_id}'
         return msg
 
     def __repr__(self):

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -119,6 +119,9 @@ class ZoneValidator:
     kebab-case identifier (e.g. ``'multi-value-mx'``). Config-registered
     validators receive their config key as ``id`` automatically.
 
+    When creating ``ValidationReason`` instances, pass ``validator_id=self.id``
+    so that error output can attribute each reason to its source validator.
+
     A config-registered validator whose id matches a built-in's replaces
     that built-in in the registry — e.g. defining a ``validators:`` entry
     named after a built-in mail zone validator swaps it out for a custom

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -3,8 +3,8 @@
 #
 
 from logging import getLogger
-from warnings import deprecated
 
+from ..deprecation import deprecated
 from .exception import ZoneException
 
 

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -97,8 +97,6 @@ class ValidationReason:
         }
         if contexts:
             msg += f" ({', '.join(sorted(contexts))})"
-        if self.validator_id is not None:
-            msg += f'\n  via: {self.validator_id}'
         return msg
 
     def __repr__(self):

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -97,6 +97,8 @@ class ValidationReason:
         }
         if contexts:
             msg += f" ({', '.join(sorted(contexts))})"
+        if self.validator_id:
+            msg += f', via: {self.validator_id}'
         return msg
 
     def __repr__(self):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -214,7 +214,11 @@ class TestZoneValidator(ZoneValidator):
             mx_records = zone.get('', type='MX')
             if not mx_records:
                 return [
-                    ValidationReason('zone apex is missing an MX record', [])
+                    ValidationReason(
+                        'zone apex is missing an MX record',
+                        [],
+                        validator_id=self.id,
+                    )
                 ]
         return []
 

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -668,7 +668,11 @@ class TestManager(TestCase):
             with patch.object(
                 Zone.validators,
                 'process_zone',
-                return_value=[ValidationReason('zone is broken', [])],
+                return_value=[
+                    ValidationReason(
+                        'zone is broken', [], validator_id='test-mock'
+                    )
+                ],
             ):
                 with self.assertRaises(ValidationError) as ctx:
                     Manager(
@@ -683,7 +687,11 @@ class TestManager(TestCase):
             with patch.object(
                 Zone.validators,
                 'process_zone',
-                return_value=[ValidationReason('zone is broken', [])],
+                return_value=[
+                    ValidationReason(
+                        'zone is broken', [], validator_id='test-mock'
+                    )
+                ],
             ):
                 with self.assertLogs('Zone', level='WARNING') as logs:
                     Manager(

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -575,7 +575,11 @@ class TestManager(TestCase):
                 with patch.object(
                     Zone.validators,
                     'process_zone',
-                    return_value=[ValidationReason('zone is broken', [])],
+                    return_value=[
+                        ValidationReason(
+                            'zone is broken', [], validator_id='test-mock'
+                        )
+                    ],
                 ):
                     with self.assertRaises(ValidationError) as ctx:
                         manager.sync(
@@ -596,7 +600,11 @@ class TestManager(TestCase):
                 with patch.object(
                     Zone.validators,
                     'process_zone',
-                    return_value=[ValidationReason('zone is broken', [])],
+                    return_value=[
+                        ValidationReason(
+                            'zone is broken', [], validator_id='test-mock'
+                        )
+                    ],
                 ):
                     with self.assertLogs('Zone', level='WARNING') as logs:
                         manager.sync(dry_run=True)
@@ -613,7 +621,11 @@ class TestManager(TestCase):
                 with patch.object(
                     Zone.validators,
                     'process_zone',
-                    return_value=[ValidationReason('zone is broken', [])],
+                    return_value=[
+                        ValidationReason(
+                            'zone is broken', [], validator_id='test-mock'
+                        )
+                    ],
                 ):
                     with self.assertRaises(ValidationError) as ctx:
                         manager.dump(
@@ -632,7 +644,11 @@ class TestManager(TestCase):
                 with patch.object(
                     Zone.validators,
                     'process_zone',
-                    return_value=[ValidationReason('zone is broken', [])],
+                    return_value=[
+                        ValidationReason(
+                            'zone is broken', [], validator_id='test-mock'
+                        )
+                    ],
                 ):
                     with self.assertLogs('Zone', level='WARNING') as logs:
                         manager.dump(

--- a/tests/test_octodns_zone_context.py
+++ b/tests/test_octodns_zone_context.py
@@ -22,7 +22,9 @@ class TestZoneContext(TestCase):
     def test_zone_validate_context(self):
         class DummyValidator(ZoneValidator):
             def validate(self, zone):
-                return [ValidationReason('test-reason', [])]
+                return [
+                    ValidationReason('test-reason', [], validator_id=self.id)
+                ]
 
         with zone_validators_snapshot():
             Zone.register_zone_validator(DummyValidator('dummy'))
@@ -46,7 +48,9 @@ class TestZoneContext(TestCase):
         )
         r2.context = 'ctx2'
 
-        reason = ValidationReason('problem', [r1, r2])
+        reason = ValidationReason(
+            'problem', [r1, r2], validator_id='test-validator'
+        )
         self.assertIn('problem (ctx1, ctx2)', str(reason))
 
     def test_manager_get_zone_context(self):

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -27,7 +27,7 @@ def _add_record(zone, name, data, lenient=True):
 
 class TestValidationError(TestCase):
     def test_validation_error_context(self):
-        v = ValidationReason('reason', [])
+        v = ValidationReason('reason', [], validator_id='test-validator')
         err = ValidationError('unit.tests.', [v], context='ctx')
         self.assertIn('ctx', str(err))
         self.assertEqual('ctx', err.context)
@@ -66,7 +66,9 @@ class TestZoneValidatorBase(TestCase):
 
     def test_validation_reason(self):
         r1 = _add_record(_make_zone(), 'r1', {'type': 'A', 'value': '1.2.3.4'})
-        reason = ValidationReason('problem', [r1])
+        reason = ValidationReason(
+            'problem', [r1], validator_id='test-validator'
+        )
         self.assertEqual('problem', str(reason))
         self.assertEqual('problem', repr(reason))
         self.assertFalse(reason.lenient)
@@ -76,7 +78,9 @@ class TestZoneValidatorBase(TestCase):
             'r2',
             {'type': 'A', 'value': '1.2.3.4', 'octodns': {'lenient': True}},
         )
-        reason2 = ValidationReason('lenient problem', [r2])
+        reason2 = ValidationReason(
+            'lenient problem', [r2], validator_id='test-validator'
+        )
         self.assertTrue(reason2.lenient)
 
     def test_validation_reason_validator_id(self):

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -36,6 +36,21 @@ class TestValidationError(TestCase):
         err2 = ValidationError('unit.tests.', [v])
         self.assertNotIn('ctx', str(err2))
 
+    def test_validation_error_via(self):
+        # build_message includes "via: <id>" indented under each reason that has
+        # a validator_id, and omits it when validator_id is absent.
+        with_id = ValidationReason('flagged', [], validator_id='my-validator')
+        without_id = ValidationReason('also-flagged', [])
+
+        msg = ValidationError.build_message(
+            'unit.tests.', [with_id, without_id]
+        )
+        self.assertIn('flagged', msg)
+        self.assertIn('    via: my-validator', msg)
+        self.assertIn('also-flagged', msg)
+        # "via:" should only appear once (for the reason that has a validator_id)
+        self.assertEqual(msg.count('via:'), 1)
+
 
 class TestZoneValidatorBase(TestCase):
     def test_zone_validator_base(self):
@@ -63,6 +78,18 @@ class TestZoneValidatorBase(TestCase):
         )
         reason2 = ValidationReason('lenient problem', [r2])
         self.assertTrue(reason2.lenient)
+
+    def test_validation_reason_validator_id(self):
+        # validator_id is stored and does not appear in str() — that belongs to
+        # build_message so that presentation concerns stay in one place.
+        reason = ValidationReason('problem', [], validator_id='my-validator')
+        self.assertEqual('my-validator', reason.validator_id)
+        self.assertEqual('problem', str(reason))
+        self.assertNotIn('via:', str(reason))
+
+        # Omitting validator_id emits a DeprecationWarning.
+        with self.assertWarns(DeprecationWarning):
+            ValidationReason('problem', [])
 
     def test_registry(self):
         registry = ZoneValidatorRegistry()

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -37,16 +37,16 @@ class TestValidationError(TestCase):
         self.assertNotIn('ctx', str(err2))
 
     def test_validation_error_via(self):
-        # build_message includes "via: <id>" indented under each reason that has
-        # a validator_id, and omits it when validator_id is absent.
+        # build_message relies on ValidationReason.__str__ to append ", via:
+        # <id>" on the same line for reasons that have a validator_id, and
+        # omit it when validator_id is absent.
         with_id = ValidationReason('flagged', [], validator_id='my-validator')
         without_id = ValidationReason('also-flagged', [])
 
         msg = ValidationError.build_message(
             'unit.tests.', [with_id, without_id]
         )
-        self.assertIn('flagged', msg)
-        self.assertIn('    via: my-validator', msg)
+        self.assertIn('flagged, via: my-validator', msg)
         self.assertIn('also-flagged', msg)
         # "via:" should only appear once (for the reason that has a validator_id)
         self.assertEqual(msg.count('via:'), 1)
@@ -69,7 +69,7 @@ class TestZoneValidatorBase(TestCase):
         reason = ValidationReason(
             'problem', [r1], validator_id='test-validator'
         )
-        self.assertEqual('problem', str(reason))
+        self.assertEqual('problem, via: test-validator', str(reason))
         self.assertEqual('problem', repr(reason))
         self.assertFalse(reason.lenient)
 
@@ -84,12 +84,14 @@ class TestZoneValidatorBase(TestCase):
         self.assertTrue(reason2.lenient)
 
     def test_validation_reason_validator_id(self):
-        # validator_id is stored and does not appear in str() — that belongs to
-        # build_message so that presentation concerns stay in one place.
+        # validator_id is stored and appears in str() as a ", via: <id>" suffix
+        # on the same line as the reason.
         reason = ValidationReason('problem', [], validator_id='my-validator')
         self.assertEqual('my-validator', reason.validator_id)
-        self.assertEqual('problem', str(reason))
-        self.assertNotIn('via:', str(reason))
+        self.assertEqual('problem, via: my-validator', str(reason))
+
+        without_id = ValidationReason('problem', [])
+        self.assertEqual('problem', str(without_id))
 
         # Omitting validator_id emits a DeprecationWarning.
         with self.assertWarns(DeprecationWarning):


### PR DESCRIPTION
First step of a few improving Validators. This adds a required `validator_id` param to the `ValidationReason` object. This should allow the warnings/errors to include the id of the validator that originated the message. Which should make it easier to know what to disable if users are so-inclined or otherwise allow them to dig deeper into what's going in if need be.

/cc https://github.com/octodns/octodns/issues/1431#issuecomment-4837536493 which lead to these changes