### PR TITLE
Fix lenient parameter leak across zones in validate_configs

### DIFF
--- a/.changelog/78a34a1984ca4ebba5e4f0021dc61c21.md
+++ b/.changelog/78a34a1984ca4ebba5e4f0021dc61c21.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix lenient parameter leak across zones in validate_configs

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1344,12 +1344,12 @@ class Manager(object):
                     f'Zone {decoded_zone_name}, unknown source: ' + source
                 )
 
-            lenient = lenient or config.get('lenient', False)
+            zone_lenient = lenient or config.get('lenient', False)
             for source in sources:
                 if isinstance(source, YamlProvider):
-                    source.populate(zone, lenient=lenient)
+                    source.populate(zone, lenient=zone_lenient)
 
-            zone.validate(lenient=lenient)
+            zone.validate(lenient=zone_lenient)
 
             # check that processors are in order if any are specified
             processors = config.get('processors') or []


### PR DESCRIPTION
Reassigning the `lenient` function parameter inside the zone loop caused it to stay True for all subsequent zones once any zone had `lenient: true` in its config. Use a loop-local `zone_lenient` variable instead so each zone is evaluated independently.