### PR TITLE
Add per-zone validator disabling

### DIFF
--- a/.changelog/160374cfc18149d0a3d82de130928937.md
+++ b/.changelog/160374cfc18149d0a3d82de130928937.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add per-zone validators.record.disable_validators and validators.zone.disable_validators to selectively disable built-in validators for individual zones, additive to the global manager.validators config

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -149,7 +149,9 @@ incrementally.
 Use ``disable_validators`` (see `Disabling built-in validators`_ below) when
 you want to permanently skip a *specific check* across all records of a given
 type — for example if a validator conflicts with your provider's requirements or
-your organisation's conventions.
+your organisation's conventions. Use a zone's own ``validators`` key (see
+`Disabling validators for a single zone`_ below) when that check should only be
+skipped for one zone rather than globally.
 
 .. _Lenience: records.rst#lenience
 
@@ -476,6 +478,46 @@ Individual built-in validators can be turned off under
 ``'*'`` removes the validator from every record type; a type string removes it
 only for that type. Bridge validators (``_``-prefixed ids) cannot be disabled
 and will raise a config error if listed here.
+
+Zone validators are disabled the same way, under
+``manager.validators.zone.disable_validators``, as a plain list of ids::
+
+  manager:
+    validators:
+      zone:
+        disable_validators:
+          - dname-coexistence
+
+Disabling validators for a single zone
+.......................................
+
+Everything above is global — it applies to every zone octoDNS manages. To
+relax a check for just one zone (e.g. a legacy zone that can't yet meet a
+stricter rule), give that zone its own ``validators`` key using the same
+shape, under the zone's entry in ``zones:``::
+
+  zones:
+    legacy.example.com.:
+      sources:
+        - config
+      targets:
+        - route53
+      validators:
+        record:
+          disable_validators:
+            '*':
+              - healthcheck
+            MX:
+              - mx-value
+        zone:
+          disable_validators:
+            - dname-coexistence
+
+A per-zone ``disable_validators`` is *additive* to the global config — it can
+only disable additional validators for that zone, not re-enable one disabled
+globally, and it has no effect on any other zone. As with the global form,
+bridge (``_``-prefixed) validator ids cannot be disabled and raise a config
+error if listed.
 
 Attaching validators programmatically
 ......................................

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1375,6 +1375,12 @@ class Manager(object):
             delete_pcent_threshold = zone.get("delete_pcent_threshold", None)
             ignore_subzone_adds = zone.get("ignore_subzone_adds", False)
             context = getattr(zone, 'context', None)
+            # Per-zone validator config (e.g. `disable_validators`, additive
+            # to the global `manager.validators` config) is interpreted by
+            # Zone itself, which raises ZoneException for invalid entries
+            # (e.g. attempting to disable a bridge validator).
+            validators = zone.get('validators')
+
             return Zone(
                 idna_encode(zone_name),
                 sub_zones,
@@ -1382,6 +1388,7 @@ class Manager(object):
                 delete_pcent_threshold,
                 ignore_subzone_adds=ignore_subzone_adds,
                 context=context,
+                validators=validators,
             )
 
         raise ManagerException(f'Unknown zone name {idna_decode(zone_name)}')

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -429,7 +429,11 @@ class BaseProvider(BaseSource):
         '''
         self.log.info('plan: desired=%s', desired.decoded_name)
 
-        existing = Zone(desired.name, desired.sub_zones)
+        existing = Zone(
+            desired.name,
+            desired.sub_zones,
+            validators=desired.validators_config,
+        )
         exists = self.populate(existing, target=True, lenient=True)
         if exists is None:
             # If your code gets this warning see Source.populate for more

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -17,7 +17,7 @@ class AliasRootValidator(RecordValidator):
     type only has meaning at the apex.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         if name != '':
             return ['non-root ALIAS not allowed']
         return []

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -28,7 +28,7 @@ class NameValidator(RecordValidator):
     limits from RFC 1035, and flags empty/double-dot labels.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         reasons = []
         if name == '@':
             reasons.append('invalid name "@", use "" instead')
@@ -56,7 +56,7 @@ class TtlValidator(RecordValidator):
     integer.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         reasons = []
         try:
             ttl = int(data['ttl'])
@@ -73,7 +73,7 @@ class HealthcheckValidator(RecordValidator):
     present, is one of the supported protocols.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         reasons = []
         try:
             if data['octodns']['healthcheck']['protocol'] not in (
@@ -99,9 +99,12 @@ class ValueTypeValidator(RecordValidator):
     def __init__(self):
         super().__init__(id='_value-type')
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         return _process_value_validators(
-            record_cls._value_type, data.get('value', None), record_cls._type
+            record_cls._value_type,
+            data.get('value', None),
+            record_cls._type,
+            disabled=disabled,
         )
 
 
@@ -117,7 +120,7 @@ class ValuesTypeValidator(RecordValidator):
     def __init__(self):
         super().__init__(id='_values-type')
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         values = data.get('values', data.get('value', []))
         values = (
             values
@@ -125,7 +128,7 @@ class ValuesTypeValidator(RecordValidator):
             else ([] if values is None else [values])
         )
         return _process_value_validators(
-            record_cls._value_type, values, record_cls._type
+            record_cls._value_type, values, record_cls._type, disabled=disabled
         )
 
 
@@ -230,7 +233,8 @@ class Record(EqualityTupleMixin):
             if context:
                 msg += f', {context}'
             raise Exception(msg)
-        reasons.extend(_class.validate(name, fqdn, data))
+        disabled = zone.disabled_record_validators
+        reasons.extend(_class.validate(name, fqdn, data, disabled=disabled))
         try:
             lenient |= data['octodns']['lenient']
         except KeyError:
@@ -245,12 +249,14 @@ class Record(EqualityTupleMixin):
         return _class(zone, name, data, source=source, context=context)
 
     @classmethod
-    def _process_validators(cls, name, fqdn, data):
-        return cls.validators.process_record(cls, name, fqdn, data)
+    def _process_validators(cls, name, fqdn, data, disabled=None):
+        return cls.validators.process_record(
+            cls, name, fqdn, data, disabled=disabled
+        )
 
     @classmethod
-    def validate(cls, name, fqdn, data):
-        return cls._process_validators(name, fqdn, data)
+    def validate(cls, name, fqdn, data, disabled=None):
+        return cls._process_validators(name, fqdn, data, disabled=disabled)
 
     @classmethod
     def from_rrs(cls, zone, rrs, lenient=False, source=None):
@@ -435,8 +441,10 @@ class Record(EqualityTupleMixin):
         raise NotImplementedError('Abstract base class, __repr__ required')
 
 
-def _process_value_validators(value_type, values, _type):
-    return Record.validators.process_values(value_type, values, _type)
+def _process_value_validators(value_type, values, _type, disabled=None):
+    return Record.validators.process_values(
+        value_type, values, _type, disabled=disabled
+    )
 
 
 class ValuesMixin(object):

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -234,7 +234,16 @@ class Record(EqualityTupleMixin):
                 msg += f', {context}'
             raise Exception(msg)
         disabled = zone.disabled_record_validators
-        reasons.extend(_class.validate(name, fqdn, data, disabled=disabled))
+        try:
+            reasons.extend(_class.validate(name, fqdn, data, disabled=disabled))
+        except TypeError as e:
+            if "unexpected keyword argument 'disabled'" not in str(e):
+                raise
+            deprecated(
+                f'`validate` without the `disabled` param is DEPRECATED. Will be removed in 2.0. Class {_class.__name__}',
+                stacklevel=3,
+            )
+            reasons.extend(_class.validate(name, fqdn, data))
         try:
             lenient |= data['octodns']['lenient']
         except KeyError:

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -18,7 +18,7 @@ class CnameRootValidator(RecordValidator):
     RFC 1034/2181.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         if name == '':
             return ['root CNAME not allowed']
         return []

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -21,7 +21,7 @@ class DynamicValidator(RecordValidator):
     are defined but unused.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         reasons = []
 
         if 'dynamic' not in data:
@@ -35,7 +35,7 @@ class DynamicValidator(RecordValidator):
             pools = {}
 
         pool_reasons, pools_exist, pools_seen_as_fallback = (
-            record_cls._validate_pools(pools)
+            record_cls._validate_pools(pools, disabled=disabled)
         )
         reasons.extend(pool_reasons)
 
@@ -239,7 +239,7 @@ class _DynamicMixin(object):
         }
 
     @classmethod
-    def _validate_pools(cls, pools):
+    def _validate_pools(cls, pools, disabled=None):
         reasons = []
         pools_exist = set()
         pools_seen_as_fallback = set()
@@ -289,7 +289,10 @@ class _DynamicMixin(object):
                         value = value['value']
                         reasons.extend(
                             _process_value_validators(
-                                cls._value_type, value, cls._type
+                                cls._value_type,
+                                value,
+                                cls._type,
+                                disabled=disabled,
                             )
                         )
                     except KeyError:

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -135,7 +135,7 @@ class GeoValidator(RecordValidator):
     passes the record's value-type validation.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         reasons = []
         try:
             geo = dict(data['geo'])
@@ -147,7 +147,10 @@ class GeoValidator(RecordValidator):
                 reasons.extend(GeoValue._validate_geo(code))
                 reasons.extend(
                     _process_value_validators(
-                        record_cls._value_type, values, record_cls._type
+                        record_cls._value_type,
+                        values,
+                        record_cls._type,
+                        disabled=disabled,
                     )
                 )
         except KeyError:

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -12,7 +12,7 @@ class SpfRecordTypeValidator(RecordValidator):
     Validates that the deprecated SPF record type is not used.
     '''
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         return [
             'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0'
         ]

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -25,7 +25,7 @@ class SrvNameValidator(RecordValidator):
 
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         if not self._name_re.match(name):
             return ['invalid name for SRV record']
         return []
@@ -100,7 +100,7 @@ class SrvNameRfcValidator(RecordValidator):
             return False
         return all(c.isalnum() or c == '-' for c in body)
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         labels = name.split('.') if name else []
         if len(labels) < 2:
             return ['SRV name must have at least two labels (_service._proto)']

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -20,7 +20,7 @@ class UriNameValidator(RecordValidator):
 
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         if not self._name_re.match(name):
             return ['invalid name for URI record']
         return []
@@ -225,7 +225,7 @@ class UriNameRfcValidator(RecordValidator):
             return False
         return all(c.isalnum() or c == '-' for c in body)
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         labels = name.split('.') if name else []
         if len(labels) < 2:
             return ['URI name must have at least two labels (_service._proto)']

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -121,19 +121,39 @@ class ValidatorRegistry:
             },
         }
 
-    def process_record(self, record_cls, name, fqdn, data):
+    def process_record(self, record_cls, name, fqdn, data, disabled=None):
         if not self.configured:
             self.log.warning(
                 '_process_validators: no validators configured, automatically enabling legacy set'
             )
             self.enable_sets({'legacy'})
+        disabled = disabled or {}
         reasons = []
         for key in ('*', record_cls._type):
+            skip = disabled.get(key, ())
             for validator in self.active_record.get(key, {}).values():
-                reasons.extend(validator.validate(record_cls, name, fqdn, data))
+                if validator.id in skip and not validator.id.startswith('_'):
+                    continue
+                try:
+                    reasons.extend(
+                        validator.validate(
+                            record_cls, name, fqdn, data, disabled=disabled
+                        )
+                    )
+                except TypeError as e:
+                    if "unexpected keyword argument 'disabled'" not in str(e):
+                        raise
+                    deprecated(
+                        f'`validate` without the `disabled` param is DEPRECATED. Will be removed in 2.0. Class {validator.__class__.__name__}',
+                        stacklevel=3,
+                    )
+                    reasons.extend(
+                        validator.validate(record_cls, name, fqdn, data)
+                    )
         return reasons
 
-    def process_values(self, value_type, values, _type):
+    def process_values(self, value_type, values, _type, disabled=None):
+        disabled = disabled or {}
         reasons = []
         legacy = getattr(value_type, 'validate', None)
         if legacy is not None:
@@ -143,7 +163,10 @@ class ValidatorRegistry:
             )
             reasons.extend(legacy(values, _type))
         for key in ('*', _type):
+            skip = disabled.get(key, ())
             for validator in self.active_value.get(key, {}).values():
+                if validator.id in skip and not validator.id.startswith('_'):
+                    continue
                 reasons.extend(validator.validate(value_type, values, _type))
         return reasons
 
@@ -195,7 +218,7 @@ class RecordValidator:
         self.id = id
         self.sets = set(sets) if sets is not None else None
 
-    def validate(self, record_cls, name, fqdn, data):
+    def validate(self, record_cls, name, fqdn, data, disabled=None):
         '''
         Validate a record's non-value attributes.
 
@@ -216,6 +239,14 @@ class RecordValidator:
             The raw record config dict (as loaded from YAML/JSON) including
             ``ttl``, ``type``, ``value``/``values``, and any type-specific
             fields like ``dynamic``, ``geo``, or ``octodns``.
+        disabled : dict or None
+            The zone's per-type map of disabled validator ids (``record_cls
+            ._type`` or ``'*'`` -> set of ids), as configured via the zone's
+            ``validators.record.disable_validators``. Most validators can
+            ignore this; it only matters to validators that themselves
+            dispatch to other validators (e.g. value-type bridges, ``geo``
+            and ``dynamic`` validators), which must forward it along so the
+            disabled ids are honored down the chain.
 
         Returns
         -------
@@ -231,6 +262,12 @@ class RecordValidator:
         reported via the returned list. Reason strings are surfaced
         verbatim in ``ValidationError`` messages, so phrasing and
         punctuation should be stable across releases.
+
+        Third-party validators that predate the ``disabled`` parameter and
+        implement ``validate(self, record_cls, name, fqdn, data)`` continue to
+        work: the caller detects the ``TypeError`` and falls back to calling
+        without it, emitting a deprecation warning. Support for the
+        parameter-less form will be removed in 2.0.
         '''
         return []
 

--- a/octodns/schema/config.py
+++ b/octodns/schema/config.py
@@ -316,6 +316,29 @@ def _manager_def():
     }
 
 
+def _zone_validators_def():
+    # Per-zone validator config. Additive to the global
+    # `manager.validators` config; only disabling is currently supported
+    # (enabling/sets are global-only), so this intentionally exposes a
+    # subset of `_manager_def()`'s `validators` shape.
+    return {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'record': {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {'disable_validators': _TYPE_TO_NAMES_MAP},
+            },
+            'zone': {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {'disable_validators': _STRING_ARRAY},
+            },
+        },
+    }
+
+
 def _zone_def():
     return {
         'oneOf': [
@@ -335,6 +358,7 @@ def _zone_def():
                     'lenient': {'type': 'boolean'},
                     'glob': {'type': 'string'},
                     'regex': {'type': 'string'},
+                    'validators': _zone_validators_def(),
                 },
                 'additionalProperties': False,
             },

--- a/octodns/zone/base.py
+++ b/octodns/zone/base.py
@@ -9,7 +9,7 @@ from logging import getLogger
 from ..deprecation import deprecated
 from ..idna import idna_decode, idna_encode
 from ..record import Create, Delete
-from .exception import ValidationError
+from .exception import ValidationError, ZoneException
 from .validator import ZoneValidatorRegistry
 
 
@@ -142,6 +142,7 @@ class Zone(object):
         delete_pcent_threshold=None,
         ignore_subzone_adds=False,
         context=None,
+        validators=None,
     ):
         '''
         Initialize a DNS zone.
@@ -170,9 +171,28 @@ class Zone(object):
         :param context: The context in which the zone was defined (e.g. the
                         filename and line number it was found at).
         :type context: str or None
+        :param validators: Per-zone validator configuration, additive to any
+                    globally-disabled validators. Mirrors the shape of the
+                    global ``manager.validators`` config::
+
+                      {
+                          'record': {'disable_validators': {'MX': ['mx-value']}},
+                          'zone': {'disable_validators': ['dname-coexistence']},
+                      }
+
+                    Only ``disable_validators`` is currently honored (record
+                    ids cover both record and value validators for the
+                    type); other keys are accepted but ignored so config can
+                    stay forward-compatible as more per-zone validator
+                    controls are added. Framework bridge validators (ids
+                    starting with ``_``) cannot be disabled and raise
+                    ``ZoneException`` if listed.
+        :type validators: dict or None
 
         :raises InvalidNameError: If the zone name is invalid (missing trailing
                                   dot, contains double dots, or has whitespace).
+        :raises ZoneException: If ``validators`` lists a bridge validator id
+                               (starting with ``_``) to disable.
 
         .. important::
            - Zone names must end with a dot (.)
@@ -213,12 +233,47 @@ class Zone(object):
         self.ignore_subzone_adds = ignore_subzone_adds
         self.context = context
 
+        # Kept raw (not named `validators` to avoid shadowing the
+        # class-level `validators` registry, see below) so `copy()` can
+        # forward it unchanged and any future per-zone validator knobs only
+        # need to be understood here, not by every caller that constructs a
+        # Zone.
+        self.validators_config = validators or {}
+        self.disabled_record_validators, self.disabled_zone_validators = (
+            self._parse_validators_config(self.validators_config)
+        )
+
         # Copy-on-write semantics support, when `not None` this property will
         # point to a location with records for this `Zone`. Once `hydrated`
         # this property will be set to None
         self._origin = None
 
         self.log.debug('__init__: zone=%s, sub_zones=%s', self, sub_zones)
+
+    def _parse_validators_config(self, validators_config):
+        record_config = validators_config.get('record') or {}
+        disabled_record_validators = {}
+        for record_type, ids in (
+            record_config.get('disable_validators') or {}
+        ).items():
+            ids = set(ids)
+            for validator_id in ids:
+                if validator_id.startswith('_'):
+                    raise ZoneException(
+                        f'Cannot disable bridge validator "{validator_id}" in zone {self.decoded_name}'
+                    )
+            disabled_record_validators[record_type] = frozenset(ids)
+
+        zone_config = validators_config.get('zone') or {}
+        disabled_zone_validators = set()
+        for validator_id in zone_config.get('disable_validators') or []:
+            if validator_id.startswith('_'):
+                raise ZoneException(
+                    f'Cannot disable bridge zone validator "{validator_id}" in zone {self.decoded_name}'
+                )
+            disabled_zone_validators.add(validator_id)
+
+        return disabled_record_validators, frozenset(disabled_zone_validators)
 
     @property
     def records(self):
@@ -752,6 +807,7 @@ class Zone(object):
             self.delete_pcent_threshold,
             ignore_subzone_adds=self.ignore_subzone_adds,
             context=self.context,
+            validators=self.validators_config,
         )
         copy._origin = self
         return copy

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -67,8 +67,11 @@ class ZoneValidatorRegistry:
             )
             self.enable_sets({'legacy'})
 
+        disabled = zone.disabled_zone_validators
         reasons = []
         for validator in self.active.values():
+            if validator.id in disabled and not validator.id.startswith('_'):
+                continue
             reasons.extend(validator.validate(zone))
 
         return reasons

--- a/tests/config/zone-disable-validators-bridge.yaml
+++ b/tests/config/zone-disable-validators-bridge.yaml
@@ -1,0 +1,23 @@
+manager:
+  max_workers: 2
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config/zone-disable-validators
+    strict_supports: False
+  dump:
+    class: octodns.provider.yaml.YamlProvider
+    directory: env/YAML_TMP_DIR
+    supports_root_ns: False
+    strict_supports: False
+zones:
+  zone-disable-validators-a.tests.:
+    validators:
+      record:
+        disable_validators:
+          MX:
+            - _values-type
+    sources:
+      - in
+    targets:
+      - dump

--- a/tests/config/zone-disable-validators.yaml
+++ b/tests/config/zone-disable-validators.yaml
@@ -1,0 +1,29 @@
+manager:
+  max_workers: 2
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config/zone-disable-validators
+    strict_supports: False
+  dump:
+    class: octodns.provider.yaml.YamlProvider
+    directory: env/YAML_TMP_DIR
+    supports_root_ns: False
+    strict_supports: False
+zones:
+  zone-disable-validators-a.tests.:
+    validators:
+      record:
+        disable_validators:
+          '*':
+            - healthcheck
+    sources:
+      - in
+    targets:
+      - dump
+
+  zone-disable-validators-b.tests.:
+    sources:
+      - in
+    targets:
+      - dump

--- a/tests/config/zone-disable-validators/zone-disable-validators-a.tests.yaml
+++ b/tests/config/zone-disable-validators/zone-disable-validators-a.tests.yaml
@@ -1,0 +1,9 @@
+---
+'':
+  octodns:
+    healthcheck:
+      protocol: BOGUS
+  ttl: 300
+  type: A
+  values:
+  - 1.2.3.4

--- a/tests/config/zone-disable-validators/zone-disable-validators-b.tests.yaml
+++ b/tests/config/zone-disable-validators/zone-disable-validators-b.tests.yaml
@@ -1,0 +1,9 @@
+---
+'':
+  octodns:
+    healthcheck:
+      protocol: BOGUS
+  ttl: 300
+  type: A
+  values:
+  - 1.2.3.4

--- a/tests/test_octodns_config_schema.py
+++ b/tests/test_octodns_config_schema.py
@@ -650,12 +650,64 @@ class TestConfigSchema(TestCase):
                         'processors': ['p1'],
                         'lenient': True,
                         'glob': '*.example.*',
+                        'validators': {
+                            'record': {
+                                'disable_validators': {'MX': ['mx-value']}
+                            },
+                            'zone': {
+                                'disable_validators': ['dname-coexistence']
+                            },
+                        },
                     },
                     '*.arpa.': {
                         'sources': ['config'],
                         'targets': ['route53'],
                         'regex': r'^.*\.arpa\.$',
                     },
+                },
+            }
+        )
+
+    def test_zone_validators_unknown_key_rejected(self):
+        self._invalid(
+            {
+                'providers': {},
+                'zones': {
+                    'example.com.': {
+                        'sources': ['config'],
+                        'targets': ['route53'],
+                        'validators': {'typo_record': {}},
+                    }
+                },
+            }
+        )
+
+    def test_zone_validators_record_unknown_key_rejected(self):
+        self._invalid(
+            {
+                'providers': {},
+                'zones': {
+                    'example.com.': {
+                        'sources': ['config'],
+                        'targets': ['route53'],
+                        'validators': {
+                            'record': {'typo_disable_validators': {}}
+                        },
+                    }
+                },
+            }
+        )
+
+    def test_zone_validators_zone_unknown_key_rejected(self):
+        self._invalid(
+            {
+                'providers': {},
+                'zones': {
+                    'example.com.': {
+                        'sources': ['config'],
+                        'targets': ['route53'],
+                        'validators': {'zone': {'typo_disable_validators': []}},
+                    }
                 },
             }
         )

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -33,11 +33,12 @@ from octodns.manager import (
 from octodns.processor.base import BaseProcessor
 from octodns.provider.yaml import YamlProvider
 from octodns.record import Create, Delete, Record, Update
+from octodns.record.exception import ValidationError as RecordValidationError
 from octodns.record.validator import RecordValidator
 from octodns.secret.environ import EnvironSecretsException
 from octodns.yaml import safe_load
 from octodns.zone import Zone
-from octodns.zone.exception import ValidationError
+from octodns.zone.exception import ValidationError, ZoneException
 
 config_dir = join(dirname(__file__), 'config')
 
@@ -2118,6 +2119,61 @@ class TestManager(TestCase):
 
             zone_with_defaults = manager.get_zone('defaultignore.tests.')
             self.assertFalse(zone_with_defaults.ignore_subzone_adds)
+
+    def test_zone_disable_validators(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+
+            manager = Manager(
+                get_config_filename('zone-disable-validators.yaml')
+            )
+
+            zone_a = manager.get_zone('zone-disable-validators-a.tests.')
+            self.assertEqual(
+                {'*': frozenset({'healthcheck'})},
+                zone_a.disabled_record_validators,
+            )
+            zone_b = manager.get_zone('zone-disable-validators-b.tests.')
+            self.assertEqual({}, zone_b.disabled_record_validators)
+
+            # Zone A has the healthcheck validator disabled for this zone
+            # only: it syncs cleanly despite the (deliberately) invalid
+            # `octodns.healthcheck.protocol` value.
+            manager.sync(eligible_zones=['zone-disable-validators-a.tests.'])
+
+            # Zone B has no per-zone override: the same style of invalid
+            # healthcheck protocol is still caught by the global validator.
+            with self.assertRaises(RecordValidationError) as ctx:
+                manager.sync(
+                    eligible_zones=['zone-disable-validators-b.tests.']
+                )
+            self.assertIn('invalid healthcheck protocol', str(ctx.exception))
+            self.assertIn(
+                'zone-disable-validators-b.tests.', str(ctx.exception)
+            )
+
+            # Running both zones together (through the thread pool
+            # executor) proves the per-zone disable doesn't leak across
+            # zones in either direction: A still succeeds, B still raises.
+            with self.assertRaises(RecordValidationError) as ctx:
+                manager.sync()
+            self.assertIn(
+                'zone-disable-validators-b.tests.', str(ctx.exception)
+            )
+
+    def test_zone_disable_validators_bridge(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+
+            manager = Manager(
+                get_config_filename('zone-disable-validators-bridge.yaml')
+            )
+            with self.assertRaises(ZoneException) as ctx:
+                manager.get_zone('zone-disable-validators-a.tests.')
+            self.assertIn(
+                'Cannot disable bridge validator "_values-type"',
+                str(ctx.exception),
+            )
 
     def test_preprocess_zones_original(self):
         # these will be unused

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -183,6 +183,32 @@ class TestBaseProvider(TestCase):
         self.assertEqual(1, len(plan.changes))
         self.assertIsNone(plan.meta)
 
+    def test_plan_existing_zone_inherits_validators_config(self):
+        # The `existing` zone built inside plan() must carry over the
+        # `desired` zone's per-zone validators config, otherwise a
+        # validator disabled for this zone via `desired` would still run
+        # (and warn, since populate(existing, ...) is always lenient) when
+        # populating the current/existing state.
+        class CapturingProvider(HelperProvider):
+            def populate(self, zone, target=False, lenient=False):
+                self.captured_zone = zone
+                return True
+
+        desired = Zone(
+            'unit.tests.',
+            [],
+            validators={
+                'record': {'disable_validators': {'*': ['healthcheck']}}
+            },
+        )
+        provider = CapturingProvider([])
+        provider.plan(desired)
+
+        self.assertEqual(
+            desired.disabled_record_validators,
+            provider.captured_zone.disabled_record_validators,
+        )
+
     def test_plan_meta(self):
         class HasMetaProvider(HelperProvider):
             def _plan_meta(self, *args, **kwargs):

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -952,3 +952,72 @@ class TestValidators(TestCase):
             and 'LegacyRecord.validate' in str(w.message)
         ]
         self.assertTrue(matched)
+
+    def test_legacy_record_validate_new_still_works(self):
+        # A 3rd-party Record subclass whose overridden `validate` classmethod
+        # predates the `disabled` param must still be usable via Record.new
+        # (falls back to calling it without `disabled`, with a deprecation
+        # warning) rather than raising a TypeError.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
+
+            class LegacyValidateRecord(ValuesMixin, Record):
+                _type = 'LEGACY-VALIDATE-TEST'
+                _value_type = NsValue
+
+                @classmethod
+                def validate(cls, name, fqdn, data):
+                    return []
+
+        Record.register_type(LegacyValidateRecord)
+
+        zone = Zone('unit.tests.', [])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            record = Record.new(
+                zone,
+                'www',
+                {
+                    'type': 'LEGACY-VALIDATE-TEST',
+                    'ttl': 300,
+                    'value': 'does.not.matter.',
+                },
+            )
+        self.assertEqual('www', record.name)
+        matched = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and 'disabled' in str(w.message)
+            and 'LegacyValidateRecord' in str(w.message)
+        ]
+        self.assertTrue(matched)
+
+    def test_record_new_reraises_unrelated_typeerror(self):
+        # A TypeError raised by validate() for a reason unrelated to the
+        # `disabled` param must propagate rather than being misidentified
+        # as an old-signature validator and silently retried.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
+
+            class BuggyValidateRecord(ValuesMixin, Record):
+                _type = 'BUGGY-VALIDATE-TEST'
+                _value_type = NsValue
+
+                @classmethod
+                def validate(cls, name, fqdn, data, disabled=None):
+                    return 'not-a-list' + 5
+
+        Record.register_type(BuggyValidateRecord)
+
+        zone = Zone('unit.tests.', [])
+        with self.assertRaises(TypeError):
+            Record.new(
+                zone,
+                'www',
+                {
+                    'type': 'BUGGY-VALIDATE-TEST',
+                    'ttl': 300,
+                    'value': 'does.not.matter.',
+                },
+            )

--- a/tests/test_octodns_record_validators.py
+++ b/tests/test_octodns_record_validators.py
@@ -9,6 +9,7 @@ from octodns.record import (
     AliasRecord,
     ARecord,
     CnameRecord,
+    MxRecord,
     Record,
     RecordException,
 )
@@ -498,6 +499,139 @@ class TestValidatorRegistry(TestCase):
             for w in caught
             if issubclass(w.category, DeprecationWarning)
             and 'LegacyValueType.validate' in str(w.message)
+        ]
+        self.assertTrue(matched)
+
+    def test_process_record_disabled_skips_by_id(self):
+        class Forbidden(RecordValidator):
+            def validate(self, record_cls, name, fqdn, data, disabled=None):
+                return ['forbidden']
+
+        reg = ValidatorRegistry()
+        reg.register(Forbidden('test-disableable'), types=['MX'])
+        reg.enable('test-disableable', types=['MX'])
+
+        # Not disabled: reason fires.
+        self.assertEqual(
+            ['forbidden'],
+            reg.process_record(MxRecord, 'foo', 'foo.unit.tests.', {}),
+        )
+        # Disabled for this type: skipped.
+        self.assertEqual(
+            [],
+            reg.process_record(
+                MxRecord,
+                'foo',
+                'foo.unit.tests.',
+                {},
+                disabled={'MX': {'test-disableable'}},
+            ),
+        )
+        # Disabled for a different type: still fires.
+        self.assertEqual(
+            ['forbidden'],
+            reg.process_record(
+                MxRecord,
+                'foo',
+                'foo.unit.tests.',
+                {},
+                disabled={'A': {'test-disableable'}},
+            ),
+        )
+
+    def test_process_record_disabled_never_skips_bridge(self):
+        class Bridge(RecordValidator):
+            def __init__(self):
+                super().__init__(id='_test-bridge')
+
+            def validate(self, record_cls, name, fqdn, data, disabled=None):
+                return ['bridge reason']
+
+        reg = ValidatorRegistry()
+        reg.register(Bridge(), types=['MX'])
+        reg.enable('_test-bridge', types=['MX'])
+        # Even explicitly listed, bridge (underscore) ids are never skipped.
+        self.assertEqual(
+            ['bridge reason'],
+            reg.process_record(
+                MxRecord,
+                'foo',
+                'foo.unit.tests.',
+                {},
+                disabled={'MX': {'_test-bridge'}},
+            ),
+        )
+
+    def test_process_record_reraises_unrelated_typeerror(self):
+        class Buggy(RecordValidator):
+            def validate(self, record_cls, name, fqdn, data, disabled=None):
+                # Deliberately trigger a TypeError unrelated to the
+                # `disabled` param so process_record must re-raise it
+                # rather than treat it as an old-signature validator.
+                return 'not-a-list' + 5
+
+        reg = ValidatorRegistry()
+        reg.register(Buggy('test-buggy'), types=['MX'])
+        reg.enable('test-buggy', types=['MX'])
+        with self.assertRaises(TypeError):
+            reg.process_record(MxRecord, 'foo', 'foo.unit.tests.', {})
+
+    def test_process_values_disabled_skips_by_id(self):
+        class ForbidWord(ValueValidator):
+            def validate(self, value_cls, data, _type):
+                return ['forbidden value']
+
+        reg = ValidatorRegistry()
+        reg.register(ForbidWord('test-disableable-value'), types=['TXT'])
+        reg.enable('test-disableable-value', types=['TXT'])
+
+        self.assertEqual(
+            ['forbidden value'], reg.process_values(str, ['x'], 'TXT')
+        )
+        self.assertEqual(
+            [],
+            reg.process_values(
+                str, ['x'], 'TXT', disabled={'TXT': {'test-disableable-value'}}
+            ),
+        )
+
+    def test_process_values_disabled_never_skips_bridge(self):
+        class Bridge(ValueValidator):
+            def __init__(self):
+                super().__init__(id='_test-bridge-value')
+
+            def validate(self, value_cls, data, _type):
+                return ['bridge value reason']
+
+        reg = ValidatorRegistry()
+        reg.register(Bridge(), types=['TXT'])
+        reg.enable('_test-bridge-value', types=['TXT'])
+        self.assertEqual(
+            ['bridge value reason'],
+            reg.process_values(
+                str, ['x'], 'TXT', disabled={'TXT': {'_test-bridge-value'}}
+            ),
+        )
+
+    def test_process_record_legacy_validator_deprecation(self):
+        # A validator that predates the `disabled` param still works, via
+        # the TypeError-detection fallback, but emits a deprecation warning.
+        class Legacy(RecordValidator):
+            def validate(self, record_cls, name, fqdn, data):
+                return ['legacy reason']
+
+        reg = ValidatorRegistry()
+        reg.register(Legacy('test-legacy'), types=['MX'])
+        reg.enable('test-legacy', types=['MX'])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            reasons = reg.process_record(MxRecord, 'foo', 'foo.unit.tests.', {})
+        self.assertEqual(['legacy reason'], reasons)
+        matched = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and 'Legacy' in str(w.message)
         ]
         self.assertTrue(matched)
 

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -24,7 +24,7 @@ from octodns.zone import (
     SubzoneRecordException,
     Zone,
 )
-from octodns.zone.exception import ValidationError
+from octodns.zone.exception import ValidationError, ZoneException
 
 
 class TestZone(TestCase):
@@ -983,6 +983,89 @@ class TestZone(TestCase):
         # finally remove the root NS, no more
         zone.remove_record(root_ns)
         self.assertFalse(zone.root_ns)
+
+
+class TestZoneValidatorsConfig(TestCase):
+    def test_defaults(self):
+        zone = Zone('unit.tests.', [])
+        self.assertEqual({}, zone.validators_config)
+        self.assertEqual({}, zone.disabled_record_validators)
+        self.assertEqual(frozenset(), zone.disabled_zone_validators)
+
+    def test_disabled_record_validators(self):
+        zone = Zone(
+            'unit.tests.',
+            [],
+            validators={
+                'record': {
+                    'disable_validators': {
+                        'MX': ['mx-value'],
+                        '*': ['healthcheck'],
+                    }
+                }
+            },
+        )
+        self.assertEqual(
+            {'MX': frozenset({'mx-value'}), '*': frozenset({'healthcheck'})},
+            zone.disabled_record_validators,
+        )
+        self.assertEqual(frozenset(), zone.disabled_zone_validators)
+
+    def test_disabled_zone_validators(self):
+        zone = Zone(
+            'unit.tests.',
+            [],
+            validators={'zone': {'disable_validators': ['dname-coexistence']}},
+        )
+        self.assertEqual(
+            frozenset({'dname-coexistence'}), zone.disabled_zone_validators
+        )
+        self.assertEqual({}, zone.disabled_record_validators)
+
+    def test_bridge_record_validator_rejected(self):
+        with self.assertRaises(ZoneException) as ctx:
+            Zone(
+                'unit.tests.',
+                [],
+                validators={
+                    'record': {'disable_validators': {'MX': ['_values-type']}}
+                },
+            )
+        self.assertIn(
+            'Cannot disable bridge validator "_values-type"', str(ctx.exception)
+        )
+        self.assertIn('unit.tests.', str(ctx.exception))
+
+    def test_bridge_zone_validator_rejected(self):
+        with self.assertRaises(ZoneException) as ctx:
+            Zone(
+                'unit.tests.',
+                [],
+                validators={'zone': {'disable_validators': ['_internal']}},
+            )
+        self.assertIn(
+            'Cannot disable bridge zone validator "_internal"',
+            str(ctx.exception),
+        )
+        self.assertIn('unit.tests.', str(ctx.exception))
+
+    def test_copy_propagates_validators_config(self):
+        zone = Zone(
+            'unit.tests.',
+            [],
+            validators={
+                'record': {'disable_validators': {'MX': ['mx-value']}},
+                'zone': {'disable_validators': ['dname-coexistence']},
+            },
+        )
+        copy = zone.copy()
+        self.assertEqual(zone.validators_config, copy.validators_config)
+        self.assertEqual(
+            zone.disabled_record_validators, copy.disabled_record_validators
+        )
+        self.assertEqual(
+            zone.disabled_zone_validators, copy.disabled_zone_validators
+        )
 
 
 class TestZoneGet(TestCase):

--- a/tests/test_octodns_zone_validators.py
+++ b/tests/test_octodns_zone_validators.py
@@ -122,3 +122,45 @@ class TestZoneValidatorBase(TestCase):
         registry.register(replacement, replace=True)
         self.assertIs(replacement, registry.available['replace-test'])
         self.assertIsNot(original, registry.available['replace-test'])
+
+    def test_process_zone_disabled_skips_by_id(self):
+        class Flagged(ZoneValidator):
+            def validate(self, zone):
+                return [ValidationReason('flagged', [])]
+
+        registry = ZoneValidatorRegistry()
+        registry.register(Flagged('test-flagged'))
+        registry.enable('test-flagged')
+
+        # Not disabled: reason fires.
+        zone = _make_zone()
+        reasons = registry.process_zone(zone)
+        self.assertEqual(['flagged'], [str(r) for r in reasons])
+
+        # Disabled for this zone: skipped.
+        disabled_zone = Zone(
+            'unit.tests.',
+            [],
+            validators={'zone': {'disable_validators': ['test-flagged']}},
+        )
+        self.assertEqual([], registry.process_zone(disabled_zone))
+
+    def test_process_zone_disabled_never_skips_bridge(self):
+        class Bridge(ZoneValidator):
+            def __init__(self):
+                super().__init__(id='_test-bridge-zone')
+
+            def validate(self, zone):
+                return [ValidationReason('bridge', [])]
+
+        registry = ZoneValidatorRegistry()
+        registry.register(Bridge())
+        registry.enable('_test-bridge-zone')
+
+        # A bridge id can't even be listed via config (Zone.__init__ raises),
+        # so simulate a zone whose disabled set somehow contains one anyway
+        # and confirm process_zone's own guard still refuses to skip it.
+        zone = _make_zone()
+        zone.disabled_zone_validators = frozenset({'_test-bridge-zone'})
+        reasons = registry.process_zone(zone)
+        self.assertEqual(['bridge'], [str(r) for r in reasons])


### PR DESCRIPTION
## Summary

- Adds a per-zone `validators` config key (mirroring the global `manager.validators` shape) that lets a zone additively disable specific built-in record, value, or zone validators without affecting any other zone.
- `Zone.__init__` now takes a `validators` dict, parses it itself via `_parse_validators_config`, and raises `ZoneException` for invalid entries (e.g. attempting to disable a framework bridge validator) — `Manager.get_zone` just passes the zone's config through.
- The per-zone disable set is threaded explicitly through `Record.new` → `RecordValidator.validate(..., disabled=None)` → the registry's `process_record`/`process_values`, with a TypeError-based deprecation fallback (matching the existing `lenient`-param pattern in `manager.py`/`provider/base.py`) so third-party validators on the old 4-arg signature keep working.
- Fixes a related bug found during review: `BaseProvider.plan()` built the "existing" state zone without forwarding the desired zone's per-zone validators config, so a validator disabled for a zone would still run (and warn) while populating current state.

```yaml
zones:
  legacy.example.com.:
    sources: [config]
    targets: [route53]
    validators:
      record:
        disable_validators:
          '*': [healthcheck]
          MX: [mx-value]
      zone:
        disable_validators:
          - dname-coexistence
```

Builds on the validator infrastructure from #1378, #1380, #1387, #1396, and follows the same disable-by-id shape as #1434.

## Test plan

- [x] `./script/test` — 801 tests passing
- [x] `./script/coverage` — 100% coverage maintained
- [x] `./script/lint` / `./script/format --check` — clean
- [x] New unit tests for skip logic, the TypeError deprecation fallback, and bridge-id rejection in `record/validator.py`, `zone/base.py`, `zone/validator.py`
- [x] New manager-level integration test (`test_zone_disable_validators`) driving a real `sync()` through the thread-pool executor across two zones — one with a per-zone disable, one without — confirming no cross-zone leakage
- [x] New regression test (`test_plan_existing_zone_inherits_validators_config`) covering the `BaseProvider.plan()` fix; confirmed it fails without the fix
- [x] Docs updated in `docs/configuration.rst`