### PR TITLE
Fix single-MX provider exemption when exchange lacks trailing dot

### DIFF
--- a/.changelog/a4c2beb49bad46cfa2d6a1e06d11f3a6.md
+++ b/.changelog/a4c2beb49bad46cfa2d6a1e06d11f3a6.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix MailZoneValidator's single-MX provider exemption to match known providers even when the MX exchange is missing its trailing dot (e.g. when the mx-value-best-practice validator is disabled for a zone)

--- a/octodns/zone/mail.py
+++ b/octodns/zone/mail.py
@@ -57,7 +57,10 @@ class MailZoneValidator(ZoneValidator):
     # MX exchanges of providers known to (correctly) operate with a single MX
     # record. A record with exactly one value whose exchange matches one of
     # these patterns is exempt from the ``min_mx`` redundancy check. Patterns
-    # are matched via re.search against the exchange including its trailing dot.
+    # are matched via re.search against the exchange, normalized to always
+    # include a trailing dot (see ``_is_single_mx_provider``) so an exchange
+    # missing one (e.g. the ``mx-value-best-practice`` trailing-dot check was
+    # disabled for the zone) still matches.
     #
     # PRs welcome: if you run across another reputable provider that only hands
     # out a single MX, please add it here.
@@ -94,6 +97,11 @@ class MailZoneValidator(ZoneValidator):
     def _is_single_mx_provider(self, mx_record):
         # called only when mx_record has exactly one value
         exchange = str(mx_record.values[0].exchange)
+        # normalize so a value missing its trailing dot (e.g. the
+        # trailing-dot best-practice validator was disabled for this zone)
+        # still matches the (dot-anchored) known-provider patterns.
+        if not exchange.endswith('.'):
+            exchange += '.'
         return any(r.search(exchange) for r in self._single_mx_res)
 
     def _is_null_mx(self, mx_record):

--- a/tests/test_octodns_zone_validators_mail.py
+++ b/tests/test_octodns_zone_validators_mail.py
@@ -1006,6 +1006,17 @@ class TestMailZoneValidator(TestCase):
         self.assertEqual(1, len(reasons))
         self.assertIn('should have at least 2 values', str(reasons[0]))
 
+    def test_single_mx_provider_matches_without_trailing_dot(self):
+        # A known single-MX provider's exchange must still be recognized as
+        # exempt from the redundancy check even without a trailing dot (e.g.
+        # when the `mx-value-best-practice` trailing-dot validator has been
+        # disabled for the zone, or the data simply omits it).
+        zone = self._make_valid_mail_zone(
+            [{'preference': 10, 'exchange': 'mx.sendgrid.net'}]
+        )
+        v = MailZoneValidator('test', mode='mail')
+        self.assertEqual([], v.validate(zone))
+
     def test_single_mx_provider_postmark_exempt(self):
         zone = self._make_valid_mail_zone(
             [{'preference': 10, 'exchange': 'inbound.postmarkapp.com.'}]


### PR DESCRIPTION
## Summary

- `MailZoneValidator._is_single_mx_provider` matches an MX record's exchange against `DEFAULT_SINGLE_MX_REGEXES`/`single_mx_regexes` to exempt known single-MX providers (SendGrid, HubSpot, etc.) from the `min_mx` redundancy check. Those patterns are anchored on a trailing dot (e.g. `r'^mx\.sendgrid\.net\.$'`).
- If the exchange value doesn't have a trailing dot — e.g. the `mx-value-best-practice` trailing-dot validator has been disabled for that zone (see #1441), or the data simply omits it — the pattern no longer matches, and a legitimately single-MX zone starts failing the redundancy check with `should have at least 2 values for redundancy, found 1`.
- Fixes this by normalizing the exchange to always include a trailing dot before matching, rather than making each regex's trailing dot optional. This covers both the built-in patterns and any user-supplied `single_mx_regexes` uniformly, since it's the input being matched that's normalized rather than every pattern needing its own optional-dot handling.

Found via review feedback on #1441 (per-zone validator disabling) — disabling the trailing-dot check for one zone exposed this pre-existing coupling in `MailZoneValidator`, unrelated to that PR's actual changes.

## Test plan

- [x] `./script/test` — 782 tests passing
- [x] `./script/coverage` — 100% coverage maintained
- [x] `./script/lint` / `./script/format --check` — clean
- [x] New regression test `test_single_mx_provider_matches_without_trailing_dot`; confirmed it fails without the fix (`should have at least 2 values for redundancy, found 1`) and passes with it