### PR TITLE
Convert record/value validator reasons to ValidationReason

### DIFF
--- a/.changelog/51bdc27f92b4424e8b39bc50d672dce5.md
+++ b/.changelog/51bdc27f92b4424e8b39bc50d672dce5.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Convert record/value validator reasons to `ValidationReason` objects, unifying with zone-level validators and surfacing `via: <validator-id>` attribution in record/value `ValidationError` messages

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -4,7 +4,7 @@
 
 from .base import Record, ValueMixin
 from .target import _TargetValue
-from .validator import RecordValidator
+from .validator import RecordValidator, ValidationReason
 
 
 class AliasValue(_TargetValue):
@@ -19,7 +19,11 @@ class AliasRootValidator(RecordValidator):
 
     def validate(self, record_cls, name, fqdn, data):
         if name != '':
-            return ['non-root ALIAS not allowed']
+            return [
+                ValidationReason(
+                    'non-root ALIAS not allowed', validator_id=self.id
+                )
+            ]
         return []
 
 

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -12,7 +12,7 @@ from ..equality import EqualityTupleMixin
 from ..idna import IdnaError, idna_decode, idna_encode
 from .change import Update
 from .exception import RecordException, ValidationError
-from .validator import RecordValidator, ValidatorRegistry
+from .validator import RecordValidator, ValidationReason, ValidatorRegistry
 
 
 def unquote(s):
@@ -31,21 +31,36 @@ class NameValidator(RecordValidator):
     def validate(self, record_cls, name, fqdn, data):
         reasons = []
         if name == '@':
-            reasons.append('invalid name "@", use "" instead')
+            reasons.append(
+                ValidationReason(
+                    'invalid name "@", use "" instead', validator_id=self.id
+                )
+            )
         n = len(fqdn)
         if n > 253:
             reasons.append(
-                f'invalid fqdn, "{idna_decode(fqdn)}" is too long at {n} chars, max is 253'
+                ValidationReason(
+                    f'invalid fqdn, "{idna_decode(fqdn)}" is too long at {n} chars, max is 253',
+                    validator_id=self.id,
+                )
             )
         for label in name.split('.'):
             n = len(label)
             if n > 63:
                 reasons.append(
-                    f'invalid label, "{label}" is too long at {n} chars, max is 63'
+                    ValidationReason(
+                        f'invalid label, "{label}" is too long at {n} chars, max is 63',
+                        validator_id=self.id,
+                    )
                 )
         # in the case of endswith there's an implicit second . from the Zone
         if '..' in name or name.endswith('.'):
-            reasons.append(f'invalid name, double `.` in "{idna_decode(fqdn)}"')
+            reasons.append(
+                ValidationReason(
+                    f'invalid name, double `.` in "{idna_decode(fqdn)}"',
+                    validator_id=self.id,
+                )
+            )
         # TODO: look at the idna lib for a lot more potential validations...
         return reasons
 
@@ -61,9 +76,13 @@ class TtlValidator(RecordValidator):
         try:
             ttl = int(data['ttl'])
             if ttl < 0:
-                reasons.append('invalid ttl')
+                reasons.append(
+                    ValidationReason('invalid ttl', validator_id=self.id)
+                )
         except KeyError:
-            reasons.append('missing ttl')
+            reasons.append(
+                ValidationReason('missing ttl', validator_id=self.id)
+            )
         return reasons
 
 
@@ -83,7 +102,11 @@ class HealthcheckValidator(RecordValidator):
                 'TCP',
                 'UDP',
             ):
-                reasons.append('invalid healthcheck protocol')
+                reasons.append(
+                    ValidationReason(
+                        'invalid healthcheck protocol', validator_id=self.id
+                    )
+                )
         except KeyError:
             pass
         return reasons

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -7,7 +7,7 @@ import re
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class CaaValueValidator(ValueValidator):
@@ -22,14 +22,27 @@ class CaaValueValidator(ValueValidator):
             try:
                 flags = int(value.get('flags', 0))
                 if flags < 0 or flags > 255:
-                    reasons.append(f'invalid flags "{flags}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid flags "{flags}"', validator_id=self.id
+                        )
+                    )
             except ValueError:
-                reasons.append(f'invalid flags "{value["flags"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid flags "{value["flags"]}"',
+                        validator_id=self.id,
+                    )
+                )
 
             if 'tag' not in value:
-                reasons.append('missing tag')
+                reasons.append(
+                    ValidationReason('missing tag', validator_id=self.id)
+                )
             if 'value' not in value:
-                reasons.append('missing value')
+                reasons.append(
+                    ValidationReason('missing value', validator_id=self.id)
+                )
         return reasons
 
 
@@ -57,19 +70,35 @@ class CaaValueRfcValidator(ValueValidator):
                 flags = int(value.get('flags', 0))
                 if flags not in (0, 128):
                     reasons.append(
-                        f'flags "{flags}" is not valid; must be 0 or 128'
+                        ValidationReason(
+                            f'flags "{flags}" is not valid; must be 0 or 128',
+                            validator_id=self.id,
+                        )
                     )
             except (ValueError, TypeError):
-                reasons.append(f'invalid flags "{value["flags"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid flags "{value["flags"]}"',
+                        validator_id=self.id,
+                    )
+                )
 
             tag = value.get('tag')
             if not tag:
-                reasons.append('missing tag')
+                reasons.append(
+                    ValidationReason('missing tag', validator_id=self.id)
+                )
             elif not self._tag_re.match(tag):
-                reasons.append(f'invalid tag "{tag}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid tag "{tag}"', validator_id=self.id
+                    )
+                )
 
             if 'value' not in value:
-                reasons.append('missing value')
+                reasons.append(
+                    ValidationReason('missing value', validator_id=self.id)
+                )
         return reasons
 
 
@@ -94,7 +123,10 @@ class CaaValueBestPracticeValidator(ValueValidator):
         tags = {v.get('tag') for v in data}
         if 'issue' in tags and 'issuewild' not in tags:
             return [
-                'CAA issue tag is present without issuewild; add an explicit issuewild to clarify wildcard certificate policy'
+                ValidationReason(
+                    'CAA issue tag is present without issuewild; add an explicit issuewild to clarify wildcard certificate policy',
+                    validator_id=self.id,
+                )
             ]
         return []
 

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -5,7 +5,7 @@
 import re
 
 from .base import ValuesMixin
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class ChunkedValueValidator(ValueValidator):
@@ -19,22 +19,37 @@ class ChunkedValueValidator(ValueValidator):
 
     def validate(self, value_cls, data, _type):
         if not data:
-            return ['missing value(s)']
+            return [ValidationReason('missing value(s)', validator_id=self.id)]
         elif not isinstance(data, (list, tuple)):
             data = (data,)
         reasons = []
         for value in data:
             if value is None:
-                reasons.append('missing value(s)')
+                reasons.append(
+                    ValidationReason('missing value(s)', validator_id=self.id)
+                )
                 continue
             if self._unescaped_semicolon_re.search(value):
-                reasons.append(f'unescaped ; in "{value}"')
+                reasons.append(
+                    ValidationReason(
+                        f'unescaped ; in "{value}"', validator_id=self.id
+                    )
+                )
             if self._double_escaped_semicolon_re.search(value):
-                reasons.append(f'double escaped ; in "{value}"')
+                reasons.append(
+                    ValidationReason(
+                        f'double escaped ; in "{value}"', validator_id=self.id
+                    )
+                )
             try:
                 value.encode('ascii')
             except UnicodeEncodeError:
-                reasons.append(f'non ASCII character in "{value}"')
+                reasons.append(
+                    ValidationReason(
+                        f'non ASCII character in "{value}"',
+                        validator_id=self.id,
+                    )
+                )
         return reasons
 
 

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -5,7 +5,7 @@
 from .base import Record, ValueMixin
 from .dynamic import _DynamicMixin
 from .target import _TargetValue
-from .validator import RecordValidator
+from .validator import RecordValidator, ValidationReason
 
 
 class CnameValue(_TargetValue):
@@ -20,7 +20,9 @@ class CnameRootValidator(RecordValidator):
 
     def validate(self, record_cls, name, fqdn, data):
         if name == '':
-            return ['root CNAME not allowed']
+            return [
+                ValidationReason('root CNAME not allowed', validator_id=self.id)
+            ]
         return []
 
 

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -9,7 +9,7 @@ from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin
 from .rr import RrParseError
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class DsValueValidator(ValueValidator):
@@ -36,47 +36,103 @@ class DsValueValidator(ValueValidator):
                 try:
                     int(value['flags'])
                 except KeyError:
-                    reasons.append('missing flags')
+                    reasons.append(
+                        ValidationReason('missing flags', validator_id=self.id)
+                    )
                 except ValueError:
-                    reasons.append(f'invalid flags "{value["flags"]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid flags "{value["flags"]}"',
+                            validator_id=self.id,
+                        )
+                    )
                 try:
                     int(value['protocol'])
                 except KeyError:
-                    reasons.append('missing protocol')
+                    reasons.append(
+                        ValidationReason(
+                            'missing protocol', validator_id=self.id
+                        )
+                    )
                 except ValueError:
-                    reasons.append(f'invalid protocol "{value["protocol"]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid protocol "{value["protocol"]}"',
+                            validator_id=self.id,
+                        )
+                    )
                 try:
                     int(value['algorithm'])
                 except KeyError:
-                    reasons.append('missing algorithm')
+                    reasons.append(
+                        ValidationReason(
+                            'missing algorithm', validator_id=self.id
+                        )
+                    )
                 except ValueError:
-                    reasons.append(f'invalid algorithm "{value["algorithm"]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid algorithm "{value["algorithm"]}"',
+                            validator_id=self.id,
+                        )
+                    )
                 if 'public_key' not in value:
-                    reasons.append('missing public_key')
+                    reasons.append(
+                        ValidationReason(
+                            'missing public_key', validator_id=self.id
+                        )
+                    )
 
             else:
                 try:
                     int(value['key_tag'])
                 except KeyError:
-                    reasons.append('missing key_tag')
+                    reasons.append(
+                        ValidationReason(
+                            'missing key_tag', validator_id=self.id
+                        )
+                    )
                 except ValueError:
-                    reasons.append(f'invalid key_tag "{value["key_tag"]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid key_tag "{value["key_tag"]}"',
+                            validator_id=self.id,
+                        )
+                    )
                 try:
                     int(value['algorithm'])
                 except KeyError:
-                    reasons.append('missing algorithm')
+                    reasons.append(
+                        ValidationReason(
+                            'missing algorithm', validator_id=self.id
+                        )
+                    )
                 except ValueError:
-                    reasons.append(f'invalid algorithm "{value["algorithm"]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid algorithm "{value["algorithm"]}"',
+                            validator_id=self.id,
+                        )
+                    )
                 try:
                     int(value['digest_type'])
                 except KeyError:
-                    reasons.append('missing digest_type')
+                    reasons.append(
+                        ValidationReason(
+                            'missing digest_type', validator_id=self.id
+                        )
+                    )
                 except ValueError:
                     reasons.append(
-                        f'invalid digest_type "{value["digest_type"]}"'
+                        ValidationReason(
+                            f'invalid digest_type "{value["digest_type"]}"',
+                            validator_id=self.id,
+                        )
                     )
                 if 'digest' not in value:
-                    reasons.append('missing digest')
+                    reasons.append(
+                        ValidationReason('missing digest', validator_id=self.id)
+                    )
         return reasons
 
 
@@ -117,30 +173,52 @@ class DsValueRfcValidator(ValueValidator):
                 ('digest_type', 255),
             ):
                 if field not in value:
-                    reasons.append(f'missing {field}')
+                    reasons.append(
+                        ValidationReason(
+                            f'missing {field}', validator_id=self.id
+                        )
+                    )
                 else:
                     try:
                         int_val = int(value[field])
                         if not 0 <= int_val <= max_val:
                             reasons.append(
-                                f'invalid {field} "{int_val}"; must be 0-{max_val}'
+                                ValidationReason(
+                                    f'invalid {field} "{int_val}"; must be 0-{max_val}',
+                                    validator_id=self.id,
+                                )
                             )
                         elif field == 'digest_type':
                             digest_type = int_val
                     except (ValueError, TypeError):
-                        reasons.append(f'invalid {field} "{value[field]}"')
+                        reasons.append(
+                            ValidationReason(
+                                f'invalid {field} "{value[field]}"',
+                                validator_id=self.id,
+                            )
+                        )
 
             if 'digest' not in value:
-                reasons.append('missing digest')
+                reasons.append(
+                    ValidationReason('missing digest', validator_id=self.id)
+                )
             else:
                 digest = value['digest']
                 if not digest or not self._hex_re.match(str(digest)):
-                    reasons.append(f'invalid digest "{digest}"; must be hex')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid digest "{digest}"; must be hex',
+                            validator_id=self.id,
+                        )
+                    )
                 elif digest_type in self._digest_type_lengths:
                     expected = self._digest_type_lengths[digest_type]
                     if len(str(digest)) != expected:
                         reasons.append(
-                            f'digest must be {expected} hex characters for digest_type {digest_type}'
+                            ValidationReason(
+                                f'digest must be {expected} hex characters for digest_type {digest_type}',
+                                validator_id=self.id,
+                            )
                         )
         return reasons
 
@@ -181,7 +259,10 @@ class DsValueBestPracticeValidator(ValueValidator):
                 if algorithm in self._deprecated_algorithms:
                     name = self._deprecated_algorithms[algorithm]
                     reasons.append(
-                        f'DS algorithm {algorithm} ({name}) is deprecated per RFC 8624'
+                        ValidationReason(
+                            f'DS algorithm {algorithm} ({name}) is deprecated per RFC 8624',
+                            validator_id=self.id,
+                        )
                     )
             except (KeyError, ValueError, TypeError):
                 pass
@@ -189,7 +270,10 @@ class DsValueBestPracticeValidator(ValueValidator):
                 digest_type = int(value['digest_type'])
                 if digest_type == 1:
                     reasons.append(
-                        'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; use digest_type 2 (SHA-256)'
+                        ValidationReason(
+                            'DS digest_type 1 (SHA-1) is not recommended per RFC 8624; use digest_type 2 (SHA-256)',
+                            validator_id=self.id,
+                        )
                     )
             except (KeyError, ValueError, TypeError):
                 pass

--- a/octodns/record/dynamic.py
+++ b/octodns/record/dynamic.py
@@ -10,7 +10,7 @@ from .base import _process_value_validators
 from .change import Update
 from .geo import GeoCodes
 from .subnet import Subnets
-from .validator import RecordValidator
+from .validator import RecordValidator, ValidationReason
 
 
 class DynamicValidator(RecordValidator):
@@ -27,7 +27,11 @@ class DynamicValidator(RecordValidator):
         if 'dynamic' not in data:
             return reasons
         elif 'geo' in data:
-            reasons.append('"dynamic" record with "geo" content')
+            reasons.append(
+                ValidationReason(
+                    '"dynamic" record with "geo" content', validator_id=self.id
+                )
+            )
 
         try:
             pools = data['dynamic']['pools']
@@ -35,7 +39,7 @@ class DynamicValidator(RecordValidator):
             pools = {}
 
         pool_reasons, pools_exist, pools_seen_as_fallback = (
-            record_cls._validate_pools(pools)
+            record_cls._validate_pools(pools, validator_id=self.id)
         )
         reasons.extend(pool_reasons)
 
@@ -44,13 +48,19 @@ class DynamicValidator(RecordValidator):
         except KeyError:
             rules = []
 
-        rule_reasons, pools_seen = record_cls._validate_rules(pools, rules)
+        rule_reasons, pools_seen = record_cls._validate_rules(
+            pools, rules, validator_id=self.id
+        )
         reasons.extend(rule_reasons)
 
         unused = pools_exist - pools_seen - pools_seen_as_fallback
         if unused:
             unused = '", "'.join(sorted(unused))
-            reasons.append(f'unused pools: "{unused}"')
+            reasons.append(
+                ValidationReason(
+                    f'unused pools: "{unused}"', validator_id=self.id
+                )
+            )
 
         return reasons
 
@@ -239,23 +249,39 @@ class _DynamicMixin(object):
         }
 
     @classmethod
-    def _validate_pools(cls, pools):
+    def _validate_pools(cls, pools, validator_id=None):
         reasons = []
         pools_exist = set()
         pools_seen_as_fallback = set()
         if not isinstance(pools, dict):
-            reasons.append('pools must be a dict')
+            reasons.append(
+                ValidationReason(
+                    'pools must be a dict', validator_id=validator_id
+                )
+            )
         elif not pools:
-            reasons.append('missing pools')
+            reasons.append(
+                ValidationReason('missing pools', validator_id=validator_id)
+            )
         else:
             for _id, pool in sorted(pools.items()):
                 if not isinstance(pool, dict):
-                    reasons.append(f'pool "{_id}" must be a dict')
+                    reasons.append(
+                        ValidationReason(
+                            f'pool "{_id}" must be a dict',
+                            validator_id=validator_id,
+                        )
+                    )
                     continue
                 try:
                     values = pool['values']
                 except KeyError:
-                    reasons.append(f'pool "{_id}" is missing values')
+                    reasons.append(
+                        ValidationReason(
+                            f'pool "{_id}" is missing values',
+                            validator_id=validator_id,
+                        )
+                    )
                     continue
 
                 pools_exist.add(_id)
@@ -267,20 +293,29 @@ class _DynamicMixin(object):
                         weight = int(weight)
                         if weight < 1 or weight > 100:
                             reasons.append(
-                                f'invalid weight "{weight}" in pool "{_id}" value {value_num}'
+                                ValidationReason(
+                                    f'invalid weight "{weight}" in pool "{_id}" value {value_num}',
+                                    validator_id=validator_id,
+                                )
                             )
                     except KeyError:
                         pass
                     except ValueError:
                         reasons.append(
-                            f'invalid weight "{weight}" in pool "{_id}" value {value_num}'
+                            ValidationReason(
+                                f'invalid weight "{weight}" in pool "{_id}" value {value_num}',
+                                validator_id=validator_id,
+                            )
                         )
 
                     try:
                         status = value['status']
                         if status not in ['up', 'down', 'obey']:
                             reasons.append(
-                                f'invalid status "{status}" in pool "{_id}" value {value_num}'
+                                ValidationReason(
+                                    f'invalid status "{status}" in pool "{_id}" value {value_num}',
+                                    validator_id=validator_id,
+                                )
                             )
                     except KeyError:
                         pass
@@ -294,12 +329,18 @@ class _DynamicMixin(object):
                         )
                     except KeyError:
                         reasons.append(
-                            f'missing value in pool "{_id}" value {value_num}'
+                            ValidationReason(
+                                f'missing value in pool "{_id}" value {value_num}',
+                                validator_id=validator_id,
+                            )
                         )
 
                 if len(values) == 1 and values[0].get('weight', 1) != 1:
                     reasons.append(
-                        f'pool "{_id}" has single value with weight!=1'
+                        ValidationReason(
+                            f'pool "{_id}" has single value with weight!=1',
+                            validator_id=validator_id,
+                        )
                     )
 
                 fallback = pool.get('fallback', None)
@@ -308,7 +349,10 @@ class _DynamicMixin(object):
                         pools_seen_as_fallback.add(fallback)
                     else:
                         reasons.append(
-                            f'undefined fallback "{fallback}" for pool "{_id}"'
+                            ValidationReason(
+                                f'undefined fallback "{fallback}" for pool "{_id}"',
+                                validator_id=validator_id,
+                            )
                         )
 
                 # Check for loops
@@ -319,7 +363,12 @@ class _DynamicMixin(object):
                     fallback = pools.get(fallback, {}).get('fallback', None)
                     if fallback in seen:
                         loop = ' -> '.join(seen)
-                        reasons.append(f'loop in pool fallbacks: {loop}')
+                        reasons.append(
+                            ValidationReason(
+                                f'loop in pool fallbacks: {loop}',
+                                validator_id=validator_id,
+                            )
+                        )
                         # exit the loop
                         break
                     seen.append(fallback)
@@ -327,7 +376,7 @@ class _DynamicMixin(object):
         return reasons, pools_exist, pools_seen_as_fallback
 
     @classmethod
-    def _validate_rules(cls, pools, rules):
+    def _validate_rules(cls, pools, rules, validator_id=None):
         reasons = []
         pools_seen = set()
 
@@ -335,9 +384,15 @@ class _DynamicMixin(object):
         geos_seen = {}
 
         if not isinstance(rules, (list, tuple)):
-            reasons.append('rules must be a list')
+            reasons.append(
+                ValidationReason(
+                    'rules must be a list', validator_id=validator_id
+                )
+            )
         elif not rules:
-            reasons.append('missing rules')
+            reasons.append(
+                ValidationReason('missing rules', validator_id=validator_id)
+            )
         else:
             seen_default = False
 
@@ -346,22 +401,38 @@ class _DynamicMixin(object):
                 try:
                     pool = rule['pool']
                 except KeyError:
-                    reasons.append(f'rule {rule_num} missing pool')
+                    reasons.append(
+                        ValidationReason(
+                            f'rule {rule_num} missing pool',
+                            validator_id=validator_id,
+                        )
+                    )
                     continue
 
                 subnets = rule.get('subnets', [])
                 geos = rule.get('geos', [])
 
                 if not isinstance(pool, str):
-                    reasons.append(f'rule {rule_num} invalid pool "{pool}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'rule {rule_num} invalid pool "{pool}"',
+                            validator_id=validator_id,
+                        )
+                    )
                 else:
                     if pool not in pools:
                         reasons.append(
-                            f'rule {rule_num} undefined pool ' f'"{pool}"'
+                            ValidationReason(
+                                f'rule {rule_num} undefined pool "{pool}"',
+                                validator_id=validator_id,
+                            )
                         )
                     elif pool in pools_seen and (subnets or geos):
                         reasons.append(
-                            f'rule {rule_num} invalid, target pool "{pool}" reused'
+                            ValidationReason(
+                                f'rule {rule_num} invalid, target pool "{pool}" reused',
+                                validator_id=validator_id,
+                            )
                         )
                     pools_seen.add(pool)
 
@@ -373,25 +444,45 @@ class _DynamicMixin(object):
                     if subnets and geos:
                         if not previous_subnets and previous_geos:
                             reasons.append(
-                                f'rule {rule_num} with subnet(s) and geo(s) should appear before all geo-only rules'
+                                ValidationReason(
+                                    f'rule {rule_num} with subnet(s) and geo(s) should appear before all geo-only rules',
+                                    validator_id=validator_id,
+                                )
                             )
                     elif subnets:
                         if previous_geos:
                             reasons.append(
-                                f'rule {rule_num} with only subnet targeting should appear before all geo targeting rules'
+                                ValidationReason(
+                                    f'rule {rule_num} with only subnet targeting should appear before all geo targeting rules',
+                                    validator_id=validator_id,
+                                )
                             )
 
                 if not (subnets or geos):
                     if seen_default:
-                        reasons.append(f'rule {rule_num} duplicate default')
+                        reasons.append(
+                            ValidationReason(
+                                f'rule {rule_num} duplicate default',
+                                validator_id=validator_id,
+                            )
+                        )
                     seen_default = True
 
                 if not isinstance(subnets, (list, tuple)):
-                    reasons.append(f'rule {rule_num} subnets must be a list')
+                    reasons.append(
+                        ValidationReason(
+                            f'rule {rule_num} subnets must be a list',
+                            validator_id=validator_id,
+                        )
+                    )
                 else:
                     for subnet in subnets:
                         reasons.extend(
-                            Subnets.validate(subnet, f'rule {rule_num} ')
+                            Subnets.validate(
+                                subnet,
+                                f'rule {rule_num} ',
+                                validator_id=validator_id,
+                            )
                         )
                     networks = []
                     for subnet in subnets:
@@ -413,24 +504,39 @@ class _DynamicMixin(object):
                         for seen, where in subnets_seen_version.items():
                             if subnet == seen:
                                 reasons.append(
-                                    f'rule {rule_num} targets subnet {subnet} which has previously been seen in rule {where}'
+                                    ValidationReason(
+                                        f'rule {rule_num} targets subnet {subnet} which has previously been seen in rule {where}',
+                                        validator_id=validator_id,
+                                    )
                                 )
                             elif subnet.subnet_of(seen):
                                 reasons.append(
-                                    f'rule {rule_num} targets subnet {subnet} which is more specific than the previously seen {seen} in rule {where}'
+                                    ValidationReason(
+                                        f'rule {rule_num} targets subnet {subnet} which is more specific than the previously seen {seen} in rule {where}',
+                                        validator_id=validator_id,
+                                    )
                                 )
 
                         subnets_seen_version[subnet] = rule_num
 
                 if not isinstance(geos, (list, tuple)):
-                    reasons.append(f'rule {rule_num} geos must be a list')
+                    reasons.append(
+                        ValidationReason(
+                            f'rule {rule_num} geos must be a list',
+                            validator_id=validator_id,
+                        )
+                    )
                 else:
                     # sorted so that NA would come before NA-US so that the code
                     # below can detect rules that have needlessly targeted a
                     # more specific location along with it's parent/ancestor
                     for geo in sorted(geos):
                         reasons.extend(
-                            GeoCodes.validate(geo, f'rule {rule_num} ')
+                            GeoCodes.validate(
+                                geo,
+                                f'rule {rule_num} ',
+                                validator_id=validator_id,
+                            )
                         )
 
                         # have we ever seen a broader version of the geo we're
@@ -439,18 +545,27 @@ class _DynamicMixin(object):
                         for seen, where in geos_seen.items():
                             if geo == seen:
                                 reasons.append(
-                                    f'rule {rule_num} targets geo {geo} which has previously been seen in rule {where}'
+                                    ValidationReason(
+                                        f'rule {rule_num} targets geo {geo} which has previously been seen in rule {where}',
+                                        validator_id=validator_id,
+                                    )
                                 )
                             elif geo.startswith(seen):
                                 reasons.append(
-                                    f'rule {rule_num} targets geo {geo} which is more specific than the previously seen {seen} in rule {where}'
+                                    ValidationReason(
+                                        f'rule {rule_num} targets geo {geo} which is more specific than the previously seen {seen} in rule {where}',
+                                        validator_id=validator_id,
+                                    )
                                 )
 
                         geos_seen[geo] = rule_num
 
             if rules[-1].get('subnets') or rules[-1].get('geos'):
                 reasons.append(
-                    'final rule has "subnets" and/or "geos" and is not catchall'
+                    ValidationReason(
+                        'final rule has "subnets" and/or "geos" and is not catchall',
+                        validator_id=validator_id,
+                    )
                 )
 
         return reasons, pools_seen

--- a/octodns/record/exception.py
+++ b/octodns/record/exception.py
@@ -12,7 +12,7 @@ class RecordException(Exception):
 class ValidationError(RecordException):
     @classmethod
     def build_message(cls, fqdn, reasons, context=None):
-        reasons = '\n  - '.join(reasons)
+        reasons = '\n  - '.join(str(r) for r in reasons)
         msg = f'Invalid record "{idna_decode(fqdn)}"'
         if context:
             msg += f', {context}'

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -10,14 +10,14 @@ from ..equality import EqualityTupleMixin
 from .base import ValuesMixin, _process_value_validators
 from .change import Update
 from .geo_data import geo_data
-from .validator import RecordValidator
+from .validator import RecordValidator, ValidationReason
 
 
 class GeoCodes(object):
     log = getLogger('GeoCodes')
 
     @classmethod
-    def validate(cls, code, prefix):
+    def validate(cls, code, prefix, validator_id=None):
         '''
         Validates an octoDNS geo code making sure that it is a valid and
         corresponding:
@@ -31,16 +31,36 @@ class GeoCodes(object):
         pieces = code.split('-')
         n = len(pieces)
         if n > 3:
-            reasons.append(f'{prefix}invalid geo code "{code}"')
+            reasons.append(
+                ValidationReason(
+                    f'{prefix}invalid geo code "{code}"',
+                    validator_id=validator_id,
+                )
+            )
         elif n > 0 and pieces[0] not in geo_data:
-            reasons.append(f'{prefix}unknown continent code "{code}"')
+            reasons.append(
+                ValidationReason(
+                    f'{prefix}unknown continent code "{code}"',
+                    validator_id=validator_id,
+                )
+            )
         elif n > 1 and pieces[1] not in geo_data[pieces[0]]:
-            reasons.append(f'{prefix}unknown country code "{code}"')
+            reasons.append(
+                ValidationReason(
+                    f'{prefix}unknown country code "{code}"',
+                    validator_id=validator_id,
+                )
+            )
         elif (
             n > 2
             and pieces[2] not in geo_data[pieces[0]][pieces[1]]['provinces']
         ):
-            reasons.append(f'{prefix}unknown province code "{code}"')
+            reasons.append(
+                ValidationReason(
+                    f'{prefix}unknown province code "{code}"',
+                    validator_id=validator_id,
+                )
+            )
 
         return reasons
 
@@ -94,11 +114,15 @@ class GeoValue(EqualityTupleMixin):
     )
 
     @classmethod
-    def _validate_geo(cls, code):
+    def _validate_geo(cls, code, validator_id=None):
         reasons = []
         match = cls.geo_re.match(code)
         if not match:
-            reasons.append(f'invalid geo "{code}"')
+            reasons.append(
+                ValidationReason(
+                    f'invalid geo "{code}"', validator_id=validator_id
+                )
+            )
         return reasons
 
     def __init__(self, geo, values):
@@ -144,7 +168,9 @@ class GeoValidator(RecordValidator):
                 stacklevel=99,
             )
             for code, values in geo.items():
-                reasons.extend(GeoValue._validate_geo(code))
+                reasons.extend(
+                    GeoValue._validate_geo(code, validator_id=self.id)
+                )
                 reasons.extend(
                     _process_value_validators(
                         record_cls._value_type, values, record_cls._type

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -3,7 +3,7 @@
 #
 
 
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class IpValueValidator(ValueValidator):
@@ -17,19 +17,28 @@ class IpValueValidator(ValueValidator):
         if not isinstance(data, (list, tuple)):
             data = (data,)
         if len(data) == 0:
-            return ['missing value(s)']
+            return [ValidationReason('missing value(s)', validator_id=self.id)]
         reasons = []
         for value in data:
             if value == '':
-                reasons.append('empty value')
+                reasons.append(
+                    ValidationReason('empty value', validator_id=self.id)
+                )
             elif value is None:
-                reasons.append('missing value(s)')
+                reasons.append(
+                    ValidationReason('missing value(s)', validator_id=self.id)
+                )
             else:
                 try:
                     value_cls._address_type(str(value))
                 except Exception:
                     addr_name = value_cls._address_name
-                    reasons.append(f'invalid {addr_name} address "{value}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid {addr_name} address "{value}"',
+                            validator_id=self.id,
+                        )
+                    )
         return reasons
 
 

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -5,7 +5,7 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class LocValueValidator(ValueValidator):
@@ -56,12 +56,22 @@ class LocValueValidator(ValueValidator):
                         )
                     ):
                         reasons.append(
-                            f'invalid value for {key} ' f'"{value[key]}"'
+                            ValidationReason(
+                                f'invalid value for {key} "{value[key]}"',
+                                validator_id=self.id,
+                            )
                         )
                 except KeyError:
-                    reasons.append(f'missing {key}')
+                    reasons.append(
+                        ValidationReason(f'missing {key}', validator_id=self.id)
+                    )
                 except ValueError:
-                    reasons.append(f'invalid {key} "{value[key]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid {key} "{value[key]}"',
+                            validator_id=self.id,
+                        )
+                    )
 
             for key in float_keys:
                 try:
@@ -83,26 +93,44 @@ class LocValueValidator(ValueValidator):
                         )
                     ):
                         reasons.append(
-                            f'invalid value for {key} ' f'"{value[key]}"'
+                            ValidationReason(
+                                f'invalid value for {key} "{value[key]}"',
+                                validator_id=self.id,
+                            )
                         )
                 except KeyError:
-                    reasons.append(f'missing {key}')
+                    reasons.append(
+                        ValidationReason(f'missing {key}', validator_id=self.id)
+                    )
                 except ValueError:
-                    reasons.append(f'invalid {key} "{value[key]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid {key} "{value[key]}"',
+                            validator_id=self.id,
+                        )
+                    )
 
             for key in direction_keys:
                 try:
                     str(value[key])
                     if key == 'lat_direction' and value[key] not in ['N', 'S']:
                         reasons.append(
-                            f'invalid direction for {key} ' f'"{value[key]}"'
+                            ValidationReason(
+                                f'invalid direction for {key} "{value[key]}"',
+                                validator_id=self.id,
+                            )
                         )
                     if key == 'long_direction' and value[key] not in ['E', 'W']:
                         reasons.append(
-                            f'invalid direction for {key} ' f'"{value[key]}"'
+                            ValidationReason(
+                                f'invalid direction for {key} "{value[key]}"',
+                                validator_id=self.id,
+                            )
                         )
                 except KeyError:
-                    reasons.append(f'missing {key}')
+                    reasons.append(
+                        ValidationReason(f'missing {key}', validator_id=self.id)
+                    )
         return reasons
 
 

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -11,7 +11,7 @@ from .target import (
     _check_target_not_ip,
     _check_target_trailing_dot,
 )
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class MxValueValidator(ValueValidator):
@@ -30,15 +30,26 @@ class MxValueValidator(ValueValidator):
                 except KeyError:
                     int(value['priority'])
             except KeyError:
-                reasons.append('missing preference')
+                reasons.append(
+                    ValidationReason('missing preference', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid preference "{value["preference"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid preference "{value["preference"]}"',
+                        validator_id=self.id,
+                    )
+                )
             exchange = None
             try:
                 exchange = value.get('exchange') or value['value']
-                reasons += _check_target_format(exchange, _type, 'exchange')
+                reasons += _check_target_format(
+                    exchange, _type, 'exchange', validator_id=self.id
+                )
             except KeyError:
-                reasons.append('missing exchange')
+                reasons.append(
+                    ValidationReason('missing exchange', validator_id=self.id)
+                )
         return reasons
 
 
@@ -68,23 +79,39 @@ class MxValueRfcValidator(ValueValidator):
                     preference = int(raw)
                     if not 0 <= preference <= 65535:
                         reasons.append(
-                            f'preference "{preference}" out of range 0-65535'
+                            ValidationReason(
+                                f'preference "{preference}" out of range 0-65535',
+                                validator_id=self.id,
+                            )
                         )
                 except (ValueError, TypeError):
-                    reasons.append(f'invalid preference "{raw}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid preference "{raw}"', validator_id=self.id
+                        )
+                    )
             else:
-                reasons.append('missing preference')
+                reasons.append(
+                    ValidationReason('missing preference', validator_id=self.id)
+                )
 
             exchange = value.get('exchange') or value.get('value')
             if not exchange:
-                reasons.append('missing exchange')
+                reasons.append(
+                    ValidationReason('missing exchange', validator_id=self.id)
+                )
             elif exchange == '.':
                 if preference is not None and preference != 0:
                     reasons.append(
-                        'preference must be 0 for null MX (exchange ".")'
+                        ValidationReason(
+                            'preference must be 0 for null MX (exchange ".")',
+                            validator_id=self.id,
+                        )
                     )
             else:
-                reasons += _check_target_format(exchange, _type, 'exchange')
+                reasons += _check_target_format(
+                    exchange, _type, 'exchange', validator_id=self.id
+                )
         return reasons
 
 
@@ -107,7 +134,7 @@ class MxValueBestPracticeValidator(ValueValidator):
             exchange = value.get('exchange') or value.get('value')
             if exchange:
                 reasons += _check_target_trailing_dot(
-                    exchange, _type, 'exchange'
+                    exchange, _type, 'exchange', validator_id=self.id
                 )
         return reasons
 
@@ -122,7 +149,9 @@ class MxValueNotIpValidator(ValueValidator):
         for value in data:
             exchange = value.get('exchange') or value.get('value')
             if exchange:
-                reasons += _check_target_not_ip(exchange, _type, 'exchange')
+                reasons += _check_target_not_ip(
+                    exchange, _type, 'exchange', validator_id=self.id
+                )
         return reasons
 
 

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -6,7 +6,7 @@ from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import _check_target_trailing_dot
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class NaptrValueValidator(ValueValidator):
@@ -22,26 +22,49 @@ class NaptrValueValidator(ValueValidator):
             try:
                 int(value['order'])
             except KeyError:
-                reasons.append('missing order')
+                reasons.append(
+                    ValidationReason('missing order', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid order "{value["order"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid order "{value["order"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 int(value['preference'])
             except KeyError:
-                reasons.append('missing preference')
+                reasons.append(
+                    ValidationReason('missing preference', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid preference "{value["preference"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid preference "{value["preference"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 flags = value['flags']
                 if flags not in value_cls.VALID_FLAGS:
-                    reasons.append(f'unrecognized flags "{flags}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'unrecognized flags "{flags}"',
+                            validator_id=self.id,
+                        )
+                    )
             except KeyError:
-                reasons.append('missing flags')
+                reasons.append(
+                    ValidationReason('missing flags', validator_id=self.id)
+                )
 
             # TODO: validate these... they're non-trivial
             for k in ('service', 'regexp', 'replacement'):
                 if k not in value:
-                    reasons.append(f'missing {k}')
+                    reasons.append(
+                        ValidationReason(f'missing {k}', validator_id=self.id)
+                    )
 
         return reasons
 
@@ -70,30 +93,55 @@ class NaptrValueRfcValidator(ValueValidator):
         for value in data:
             for field in ('order', 'preference'):
                 if field not in value:
-                    reasons.append(f'missing {field}')
+                    reasons.append(
+                        ValidationReason(
+                            f'missing {field}', validator_id=self.id
+                        )
+                    )
                 else:
                     try:
                         int_val = int(value[field])
                         if not 0 <= int_val <= 65535:
                             reasons.append(
-                                f'invalid {field} "{int_val}"; must be 0-65535'
+                                ValidationReason(
+                                    f'invalid {field} "{int_val}"; must be 0-65535',
+                                    validator_id=self.id,
+                                )
                             )
                     except (ValueError, TypeError):
-                        reasons.append(f'invalid {field} "{value[field]}"')
+                        reasons.append(
+                            ValidationReason(
+                                f'invalid {field} "{value[field]}"',
+                                validator_id=self.id,
+                            )
+                        )
 
             if 'flags' not in value:
-                reasons.append('missing flags')
+                reasons.append(
+                    ValidationReason('missing flags', validator_id=self.id)
+                )
             else:
                 flags = value['flags']
                 if flags and flags.upper() not in self._valid_flags:
-                    reasons.append(f'unrecognized flags "{flags}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'unrecognized flags "{flags}"',
+                            validator_id=self.id,
+                        )
+                    )
 
             for k in ('service', 'regexp'):
                 if k not in value:
-                    reasons.append(f'missing {k}')
+                    reasons.append(
+                        ValidationReason(f'missing {k}', validator_id=self.id)
+                    )
 
             if 'replacement' not in value:
-                reasons.append('missing replacement')
+                reasons.append(
+                    ValidationReason(
+                        'missing replacement', validator_id=self.id
+                    )
+                )
 
         return reasons
 
@@ -117,7 +165,7 @@ class NaptrValueBestPracticeValidator(ValueValidator):
             replacement = value.get('replacement')
             if replacement:
                 reasons += _check_target_trailing_dot(
-                    replacement, _type, 'replacement'
+                    replacement, _type, 'replacement', validator_id=self.id
                 )
         return reasons
 

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -3,7 +3,7 @@
 #
 
 from .base import Record, ValuesMixin
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class OpenpgpkeyValueValidator(ValueValidator):
@@ -14,7 +14,7 @@ class OpenpgpkeyValueValidator(ValueValidator):
 
     def validate(self, value_cls, data, _type):
         if not data or all(not d for d in data):
-            return ['missing value(s)']
+            return [ValidationReason('missing value(s)', validator_id=self.id)]
         return []
 
 

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -4,7 +4,7 @@
 
 from .base import Record
 from .chunked import _ChunkedValue, _ChunkedValuesMixin
-from .validator import RecordValidator
+from .validator import RecordValidator, ValidationReason
 
 
 class SpfRecordTypeValidator(RecordValidator):
@@ -14,7 +14,10 @@ class SpfRecordTypeValidator(RecordValidator):
 
     def validate(self, record_cls, name, fqdn, data):
         return [
-            'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0'
+            ValidationReason(
+                'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0',
+                validator_id=self.id,
+            )
         ]
 
 

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -13,7 +13,7 @@ from .target import (
     _check_target_not_ip,
     _check_target_trailing_dot,
 )
-from .validator import RecordValidator, ValueValidator
+from .validator import RecordValidator, ValidationReason, ValueValidator
 
 
 class SrvNameValidator(RecordValidator):
@@ -27,7 +27,11 @@ class SrvNameValidator(RecordValidator):
 
     def validate(self, record_cls, name, fqdn, data):
         if not self._name_re.match(name):
-            return ['invalid name for SRV record']
+            return [
+                ValidationReason(
+                    'invalid name for SRV record', validator_id=self.id
+                )
+            ]
         return []
 
 
@@ -44,26 +48,50 @@ class SrvValueValidator(ValueValidator):
             try:
                 int(value['priority'])
             except KeyError:
-                reasons.append('missing priority')
+                reasons.append(
+                    ValidationReason('missing priority', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid priority "{value["priority"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid priority "{value["priority"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 int(value['weight'])
             except KeyError:
-                reasons.append('missing weight')
+                reasons.append(
+                    ValidationReason('missing weight', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid weight "{value["weight"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid weight "{value["weight"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 int(value['port'])
             except KeyError:
-                reasons.append('missing port')
+                reasons.append(
+                    ValidationReason('missing port', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid port "{value["port"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid port "{value["port"]}"', validator_id=self.id
+                    )
+                )
             try:
                 target = value['target']
-                reasons += _check_target_format(target, _type, 'target')
+                reasons += _check_target_format(
+                    target, _type, 'target', validator_id=self.id
+                )
             except KeyError:
-                reasons.append('missing target')
+                reasons.append(
+                    ValidationReason('missing target', validator_id=self.id)
+                )
         return reasons
 
 
@@ -103,18 +131,32 @@ class SrvNameRfcValidator(RecordValidator):
     def validate(self, record_cls, name, fqdn, data):
         labels = name.split('.') if name else []
         if len(labels) < 2:
-            return ['SRV name must have at least two labels (_service._proto)']
+            return [
+                ValidationReason(
+                    'SRV name must have at least two labels (_service._proto)',
+                    validator_id=self.id,
+                )
+            ]
 
         reasons = []
         service, proto = labels[0], labels[1]
         if service != '*' and not (
             service.startswith('_') and self._is_valid_service_name(service[1:])
         ):
-            reasons.append(f'invalid SRV service label "{service}"')
+            reasons.append(
+                ValidationReason(
+                    f'invalid SRV service label "{service}"',
+                    validator_id=self.id,
+                )
+            )
         if not (
             proto.startswith('_') and self._is_valid_service_name(proto[1:])
         ):
-            reasons.append(f'invalid SRV proto label "{proto}"')
+            reasons.append(
+                ValidationReason(
+                    f'invalid SRV proto label "{proto}"', validator_id=self.id
+                )
+            )
         return reasons
 
 
@@ -156,15 +198,28 @@ class SrvValueRfcValidator(ValueValidator):
             }
             for name, v in fields.items():
                 if v is not None and not 0 <= v <= 65535:
-                    reasons.append(f'{name} "{v}" out of range 0-65535')
+                    reasons.append(
+                        ValidationReason(
+                            f'{name} "{v}" out of range 0-65535',
+                            validator_id=self.id,
+                        )
+                    )
             target = value.get('target')
             if target == '.':
                 for name, v in fields.items():
                     if v is not None and v != 0:
-                        reasons.append(f'{name} must be 0 when target is "."')
+                        reasons.append(
+                            ValidationReason(
+                                f'{name} must be 0 when target is "."',
+                                validator_id=self.id,
+                            )
+                        )
             elif target and fields['port'] == 0:
                 reasons.append(
-                    'port 0 is reserved; must be > 0 when target is not "."'
+                    ValidationReason(
+                        'port 0 is reserved; must be > 0 when target is not "."',
+                        validator_id=self.id,
+                    )
                 )
         return reasons
 
@@ -186,7 +241,9 @@ class SrvValueBestPracticeValidator(ValueValidator):
         for value in data:
             target = value.get('target')
             if target:
-                reasons += _check_target_trailing_dot(target, _type, 'target')
+                reasons += _check_target_trailing_dot(
+                    target, _type, 'target', validator_id=self.id
+                )
         return reasons
 
 
@@ -200,7 +257,9 @@ class SrvValueNotIpValidator(ValueValidator):
         for value in data:
             target = value.get('target')
             if target:
-                reasons += _check_target_not_ip(target, _type, 'target')
+                reasons += _check_target_not_ip(
+                    target, _type, 'target', validator_id=self.id
+                )
         return reasons
 
 

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -7,7 +7,7 @@ import re
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class SshfpValueValidator(ValueValidator):
@@ -29,11 +29,23 @@ class SshfpValueValidator(ValueValidator):
             try:
                 algorithm = int(value['algorithm'])
                 if algorithm not in value_cls.VALID_ALGORITHMS:
-                    reasons.append(f'unrecognized algorithm "{algorithm}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'unrecognized algorithm "{algorithm}"',
+                            validator_id=self.id,
+                        )
+                    )
             except KeyError:
-                reasons.append('missing algorithm')
+                reasons.append(
+                    ValidationReason('missing algorithm', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid algorithm "{value["algorithm"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid algorithm "{value["algorithm"]}"',
+                        validator_id=self.id,
+                    )
+                )
             # Start unset so the length check below can tell the difference
             # between a known-good fingerprint_type and a missing/invalid one.
             fingerprint_type = None
@@ -41,16 +53,30 @@ class SshfpValueValidator(ValueValidator):
                 fingerprint_type = int(value['fingerprint_type'])
                 if fingerprint_type not in value_cls.VALID_FINGERPRINT_TYPES:
                     reasons.append(
-                        'unrecognized fingerprint_type ' f'"{fingerprint_type}"'
+                        ValidationReason(
+                            f'unrecognized fingerprint_type "{fingerprint_type}"',
+                            validator_id=self.id,
+                        )
                     )
             except KeyError:
-                reasons.append('missing fingerprint_type')
+                reasons.append(
+                    ValidationReason(
+                        'missing fingerprint_type', validator_id=self.id
+                    )
+                )
             except ValueError:
                 reasons.append(
-                    'invalid fingerprint_type ' f'"{value["fingerprint_type"]}"'
+                    ValidationReason(
+                        f'invalid fingerprint_type "{value["fingerprint_type"]}"',
+                        validator_id=self.id,
+                    )
                 )
             if 'fingerprint' not in value:
-                reasons.append('missing fingerprint')
+                reasons.append(
+                    ValidationReason(
+                        'missing fingerprint', validator_id=self.id
+                    )
+                )
             # Only length-check when we have both a known fingerprint_type and
             # an actual fingerprint; unknown types and missing fingerprints
             # are already reported above and we don't want to stack a
@@ -60,7 +86,10 @@ class SshfpValueValidator(ValueValidator):
                 actual = len(value['fingerprint'])
                 if actual != expected:
                     reasons.append(
-                        f'fingerprint length {actual} does not match fingerprint_type {fingerprint_type} (expected {expected})'
+                        ValidationReason(
+                            f'fingerprint length {actual} does not match fingerprint_type {fingerprint_type} (expected {expected})',
+                            validator_id=self.id,
+                        )
                     )
         return reasons
 
@@ -94,29 +123,53 @@ class SshfpValueRfcValidator(ValueValidator):
                 ('fingerprint_type', 255),
             ):
                 if field not in value:
-                    reasons.append(f'missing {field}')
+                    reasons.append(
+                        ValidationReason(
+                            f'missing {field}', validator_id=self.id
+                        )
+                    )
                 else:
                     try:
                         int_val = int(value[field])
                         if not 0 <= int_val <= max_val:
                             reasons.append(
-                                f'invalid {field} "{int_val}"; must be 0-{max_val}'
+                                ValidationReason(
+                                    f'invalid {field} "{int_val}"; must be 0-{max_val}',
+                                    validator_id=self.id,
+                                )
                             )
                         elif field == 'fingerprint_type':
                             fingerprint_type = int_val
                     except (ValueError, TypeError):
-                        reasons.append(f'invalid {field} "{value[field]}"')
+                        reasons.append(
+                            ValidationReason(
+                                f'invalid {field} "{value[field]}"',
+                                validator_id=self.id,
+                            )
+                        )
             if 'fingerprint' not in value:
-                reasons.append('missing fingerprint')
+                reasons.append(
+                    ValidationReason(
+                        'missing fingerprint', validator_id=self.id
+                    )
+                )
             else:
                 fp = value['fingerprint']
                 if not fp or not self._hex_re.match(str(fp)):
-                    reasons.append(f'invalid fingerprint "{fp}"; must be hex')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid fingerprint "{fp}"; must be hex',
+                            validator_id=self.id,
+                        )
+                    )
                 elif fingerprint_type in self._fingerprint_type_lengths:
                     expected = self._fingerprint_type_lengths[fingerprint_type]
                     if len(str(fp)) != expected:
                         reasons.append(
-                            f'fingerprint must be {expected} hex characters for fingerprint_type {fingerprint_type}'
+                            ValidationReason(
+                                f'fingerprint must be {expected} hex characters for fingerprint_type {fingerprint_type}',
+                                validator_id=self.id,
+                            )
                         )
         return reasons
 
@@ -145,7 +198,10 @@ class SshfpValueBestPracticeValidator(ValueValidator):
                 continue
             if fp_type == 1:
                 reasons.append(
-                    'SSHFP fingerprint_type 1 (SHA-1) is deprecated; use fingerprint_type 2 (SHA-256)'
+                    ValidationReason(
+                        'SSHFP fingerprint_type 1 (SHA-1) is deprecated; use fingerprint_type 2 (SHA-256)',
+                        validator_id=self.id,
+                    )
                 )
         return reasons
 

--- a/octodns/record/subnet.py
+++ b/octodns/record/subnet.py
@@ -4,10 +4,12 @@
 
 import ipaddress
 
+from .validator import ValidationReason
+
 
 class Subnets(object):
     @classmethod
-    def validate(cls, subnet, prefix):
+    def validate(cls, subnet, prefix, validator_id=None):
         '''
         Validates an octoDNS subnet making sure that it is valid
         '''
@@ -16,7 +18,12 @@ class Subnets(object):
         try:
             cls.parse(subnet)
         except ValueError:
-            reasons.append(f'{prefix}invalid subnet "{subnet}"')
+            reasons.append(
+                ValidationReason(
+                    f'{prefix}invalid subnet "{subnet}"',
+                    validator_id=validator_id,
+                )
+            )
 
         return reasons
 

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -13,30 +13,41 @@ from .base import Record, ValuesMixin, unquote
 from .chunked import _ChunkedValue, chunked_value_validator
 from .rr import RrParseError
 from .target import _check_target_format, _check_target_trailing_dot
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 SUPPORTED_PARAMS = {}
 
 
-def validate_svcparam_port(svcparamvalue):
+def validate_svcparam_port(svcparamvalue, validator_id=None):
     reasons = []
     try:
         port = int(svcparamvalue)
         if 0 < port > 65535:
-            reasons.append(f'port {port} is not a valid number')
+            reasons.append(
+                ValidationReason(
+                    f'port {port} is not a valid number',
+                    validator_id=validator_id,
+                )
+            )
     except ValueError:
-        reasons.append('port is not a number')
+        reasons.append(
+            ValidationReason('port is not a number', validator_id=validator_id)
+        )
     return reasons
 
 
-def validate_list(svcparamkey, svcparamvalue):
+def validate_list(svcparamkey, svcparamvalue, validator_id=None):
     if not isinstance(svcparamvalue, list):
-        return [f'{svcparamkey} is not a list']
+        return [
+            ValidationReason(
+                f'{svcparamkey} is not a list', validator_id=validator_id
+            )
+        ]
     return list()
 
 
-def validate_svcparam_alpn(svcparamvalue):
-    reasons = validate_list('alpn', svcparamvalue)
+def validate_svcparam_alpn(svcparamvalue, validator_id=None):
+    reasons = validate_list('alpn', svcparamvalue, validator_id=validator_id)
     if len(reasons) != 0:
         return reasons
     return chunked_value_validator.validate(
@@ -44,8 +55,10 @@ def validate_svcparam_alpn(svcparamvalue):
     )
 
 
-def validate_svcparam_iphint(ip_version, svcparamvalue):
-    reasons = validate_list(f'ipv{ip_version}hint', svcparamvalue)
+def validate_svcparam_iphint(ip_version, svcparamvalue, validator_id=None):
+    reasons = validate_list(
+        f'ipv{ip_version}hint', svcparamvalue, validator_id=validator_id
+    )
     if len(reasons) != 0:
         return reasons
     for address in svcparamvalue:
@@ -56,21 +69,26 @@ def validate_svcparam_iphint(ip_version, svcparamvalue):
                 IPv6Address(address)
         except AddressValueError:
             reasons.append(
-                f'ipv{ip_version}hint "{address}" is not a valid IPv{ip_version} address'
+                ValidationReason(
+                    f'ipv{ip_version}hint "{address}" is not a valid IPv{ip_version} address',
+                    validator_id=validator_id,
+                )
             )
     return reasons
 
 
-def validate_svcparam_ipv4hint(svcparamvalue):
-    return validate_svcparam_iphint(4, svcparamvalue)
+def validate_svcparam_ipv4hint(svcparamvalue, validator_id=None):
+    return validate_svcparam_iphint(4, svcparamvalue, validator_id=validator_id)
 
 
-def validate_svcparam_ipv6hint(svcparamvalue):
-    return validate_svcparam_iphint(6, svcparamvalue)
+def validate_svcparam_ipv6hint(svcparamvalue, validator_id=None):
+    return validate_svcparam_iphint(6, svcparamvalue, validator_id=validator_id)
 
 
-def validate_svcparam_mandatory(svcparamvalue):
-    reasons = validate_list('mandatory', svcparamvalue)
+def validate_svcparam_mandatory(svcparamvalue, validator_id=None):
+    reasons = validate_list(
+        'mandatory', svcparamvalue, validator_id=validator_id
+    )
     if len(reasons) != 0:
         return reasons
     for mandatory in svcparamvalue:
@@ -78,26 +96,47 @@ def validate_svcparam_mandatory(svcparamvalue):
             mandatory not in SUPPORTED_PARAMS.keys()
             and not mandatory.startswith('key')
         ):
-            reasons.append(f'unsupported SvcParam "{mandatory}" in mandatory')
+            reasons.append(
+                ValidationReason(
+                    f'unsupported SvcParam "{mandatory}" in mandatory',
+                    validator_id=validator_id,
+                )
+            )
         if mandatory.startswith('key'):
-            reasons += validate_svckey_number(mandatory)
+            reasons += validate_svckey_number(
+                mandatory, validator_id=validator_id
+            )
     return reasons
 
 
-def validate_svcparam_ech(svcparamvalue):
+def validate_svcparam_ech(svcparamvalue, validator_id=None):
     try:
         b64decode(svcparamvalue, validate=True)
     except binascii_error:
-        return ['ech SvcParam is invalid Base64']
+        return [
+            ValidationReason(
+                'ech SvcParam is invalid Base64', validator_id=validator_id
+            )
+        ]
 
 
-def validate_svckey_number(paramkey):
+def validate_svckey_number(paramkey, validator_id=None):
     try:
         paramkeynum = int(paramkey[3:])
         if 7 < paramkeynum > 65535:
-            return [f'SvcParam key "{paramkey}" has wrong key number']
+            return [
+                ValidationReason(
+                    f'SvcParam key "{paramkey}" has wrong key number',
+                    validator_id=validator_id,
+                )
+            ]
     except ValueError:
-        return [f'SvcParam key "{paramkey}" has wrong format']
+        return [
+            ValidationReason(
+                f'SvcParam key "{paramkey}" has wrong format',
+                validator_id=validator_id,
+            )
+        ]
     return []
 
 
@@ -155,44 +194,76 @@ class SvcbValueValidator(ValueValidator):
         for value in data:
             svcpriority = -1
             if 'svcpriority' not in value:
-                reasons.append('missing svcpriority')
+                reasons.append(
+                    ValidationReason(
+                        'missing svcpriority', validator_id=self.id
+                    )
+                )
             else:
                 try:
                     svcpriority = int(value.get('svcpriority', 0))
                     if svcpriority < 0 or svcpriority > 65535:
-                        reasons.append(f'invalid priority ' f'"{svcpriority}"')
+                        reasons.append(
+                            ValidationReason(
+                                f'invalid priority "{svcpriority}"',
+                                validator_id=self.id,
+                            )
+                        )
                 except ValueError:
-                    reasons.append(f'invalid priority "{value["svcpriority"]}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid priority "{value["svcpriority"]}"',
+                            validator_id=self.id,
+                        )
+                    )
 
             reasons += _check_target_format(
-                value.get('targetname'), _type, 'targetname'
+                value.get('targetname'),
+                _type,
+                'targetname',
+                validator_id=self.id,
             )
 
             if 'svcparams' in value:
                 svcparams = value.get('svcparams', dict())
                 if svcpriority == 0 and len(svcparams) != 0:
-                    reasons.append('svcparams set on AliasMode SVCB record')
+                    reasons.append(
+                        ValidationReason(
+                            'svcparams set on AliasMode SVCB record',
+                            validator_id=self.id,
+                        )
+                    )
                 for svcparamkey, svcparamvalue in svcparams.items():
                     # XXX: Should we test for keys existing when set in 'mandatory'?
                     if svcparamkey.startswith('key'):
-                        reasons += validate_svckey_number(svcparamkey)
+                        reasons += validate_svckey_number(
+                            svcparamkey, validator_id=self.id
+                        )
                         continue
                     if (
                         svcparamkey not in SUPPORTED_PARAMS.keys()
                         and not svcparamkey.startswith('key')
                     ):
-                        reasons.append(f'Unknown SvcParam {svcparamkey}')
+                        reasons.append(
+                            ValidationReason(
+                                f'Unknown SvcParam {svcparamkey}',
+                                validator_id=self.id,
+                            )
+                        )
                         continue
                     if SUPPORTED_PARAMS[svcparamkey].get('has_arg', True):
                         reasons += SUPPORTED_PARAMS[svcparamkey]['validate'](
-                            svcparamvalue
+                            svcparamvalue, validator_id=self.id
                         )
                     if (
                         not SUPPORTED_PARAMS[svcparamkey].get('has_arg', True)
                         and svcparamvalue is not None
                     ):
                         reasons.append(
-                            f'SvcParam {svcparamkey} has value when it should not'
+                            ValidationReason(
+                                f'SvcParam {svcparamkey} has value when it should not',
+                                validator_id=self.id,
+                            )
                         )
 
         return reasons
@@ -344,7 +415,10 @@ class SvcbValueBestPracticeValidator(ValueValidator):
         reasons = []
         for value in data:
             reasons += _check_target_trailing_dot(
-                value.get('targetname'), _type, 'targetname'
+                value.get('targetname'),
+                _type,
+                'targetname',
+                validator_id=self.id,
             )
         return reasons
 

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -7,23 +7,28 @@ import ipaddress
 from fqdn import FQDN
 
 from ..idna import idna_encode
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
-def _check_target_format(target, _type, key='value'):
+def _check_target_format(target, _type, key='value', validator_id=None):
     if not target:
-        return [f'missing {key}']
+        return [ValidationReason(f'missing {key}', validator_id=validator_id)]
     if target == '.' and _type in ['HTTPS', 'MX', 'SVCB', 'SRV']:
         return []
     if '{' in target and '}' in target:
         return []
     target = idna_encode(target)
     if not FQDN(str(target), allow_underscores=True).is_valid:
-        return [f'{_type} {key} "{target}" is not a valid FQDN']
+        return [
+            ValidationReason(
+                f'{_type} {key} "{target}" is not a valid FQDN',
+                validator_id=validator_id,
+            )
+        ]
     return []
 
 
-def _check_target_not_ip(target, _type, key='value'):
+def _check_target_not_ip(target, _type, key='value', validator_id=None):
     if not target or target == '.':
         return []
     if '{' in target and '}' in target:
@@ -32,13 +37,18 @@ def _check_target_not_ip(target, _type, key='value'):
     t = target.rstrip('.')
     try:
         ipaddress.ip_address(t)
-        return [f'{_type} {key} "{target}" is an IP address']
+        return [
+            ValidationReason(
+                f'{_type} {key} "{target}" is an IP address',
+                validator_id=validator_id,
+            )
+        ]
     except ValueError:
         pass
     return []
 
 
-def _check_target_trailing_dot(target, _type, key='value'):
+def _check_target_trailing_dot(target, _type, key='value', validator_id=None):
     if not target:
         return []
     if target == '.' and _type in ['HTTPS', 'MX', 'SVCB', 'SRV']:
@@ -47,7 +57,12 @@ def _check_target_trailing_dot(target, _type, key='value'):
         return []
     target = idna_encode(target)
     if not target.endswith('.'):
-        return [f'{_type} {key} "{target}" missing trailing .']
+        return [
+            ValidationReason(
+                f'{_type} {key} "{target}" missing trailing .',
+                validator_id=validator_id,
+            )
+        ]
     return []
 
 
@@ -57,7 +72,7 @@ class TargetValueValidator(ValueValidator):
     '''
 
     def validate(self, value_cls, data, _type):
-        return _check_target_format(data, _type)
+        return _check_target_format(data, _type, validator_id=self.id)
 
 
 class TargetsValueValidator(ValueValidator):
@@ -67,11 +82,11 @@ class TargetsValueValidator(ValueValidator):
 
     def validate(self, value_cls, data, _type):
         if not data:
-            return ['missing value(s)']
+            return [ValidationReason('missing value(s)', validator_id=self.id)]
 
         reasons = []
         for value in data:
-            reasons += _check_target_format(value, _type)
+            reasons += _check_target_format(value, _type, validator_id=self.id)
 
         return reasons
 
@@ -82,7 +97,7 @@ class TargetValueNotIpValidator(ValueValidator):
     '''
 
     def validate(self, value_cls, data, _type):
-        return _check_target_not_ip(data, _type)
+        return _check_target_not_ip(data, _type, validator_id=self.id)
 
 
 class TargetsValueNotIpValidator(ValueValidator):
@@ -94,7 +109,9 @@ class TargetsValueNotIpValidator(ValueValidator):
         reasons = []
         if data:
             for value in data:
-                reasons += _check_target_not_ip(value, _type)
+                reasons += _check_target_not_ip(
+                    value, _type, validator_id=self.id
+                )
         return reasons
 
 
@@ -112,7 +129,7 @@ class TargetValueBestPracticeValidator(ValueValidator):
     '''
 
     def validate(self, value_cls, data, _type):
-        return _check_target_trailing_dot(data, _type)
+        return _check_target_trailing_dot(data, _type, validator_id=self.id)
 
 
 class TargetsValueBestPracticeValidator(ValueValidator):
@@ -130,7 +147,9 @@ class TargetsValueBestPracticeValidator(ValueValidator):
     def validate(self, value_cls, data, _type):
         reasons = []
         for value in data:
-            reasons += _check_target_trailing_dot(value, _type)
+            reasons += _check_target_trailing_dot(
+                value, _type, validator_id=self.id
+            )
         return reasons
 
 

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -7,7 +7,7 @@ import re
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class TlsaValueValidator(ValueValidator):
@@ -24,37 +24,76 @@ class TlsaValueValidator(ValueValidator):
                 certificate_usage = int(value.get('certificate_usage', 0))
                 if certificate_usage < 0 or certificate_usage > 3:
                     reasons.append(
-                        f'invalid certificate_usage ' f'"{certificate_usage}"'
+                        ValidationReason(
+                            f'invalid certificate_usage "{certificate_usage}"',
+                            validator_id=self.id,
+                        )
                     )
             except ValueError:
                 reasons.append(
-                    f'invalid certificate_usage "{value["certificate_usage"]}"'
+                    ValidationReason(
+                        f'invalid certificate_usage "{value["certificate_usage"]}"',
+                        validator_id=self.id,
+                    )
                 )
 
             try:
                 selector = int(value.get('selector', 0))
                 if selector < 0 or selector > 1:
-                    reasons.append(f'invalid selector "{selector}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid selector "{selector}"',
+                            validator_id=self.id,
+                        )
+                    )
             except ValueError:
-                reasons.append(f'invalid selector "{value["selector"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid selector "{value["selector"]}"',
+                        validator_id=self.id,
+                    )
+                )
 
             try:
                 matching_type = int(value.get('matching_type', 0))
                 if matching_type < 0 or matching_type > 2:
-                    reasons.append(f'invalid matching_type "{matching_type}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'invalid matching_type "{matching_type}"',
+                            validator_id=self.id,
+                        )
+                    )
             except ValueError:
                 reasons.append(
-                    f'invalid matching_type ' f'"{value["matching_type"]}"'
+                    ValidationReason(
+                        f'invalid matching_type "{value["matching_type"]}"',
+                        validator_id=self.id,
+                    )
                 )
 
             if 'certificate_usage' not in value:
-                reasons.append('missing certificate_usage')
+                reasons.append(
+                    ValidationReason(
+                        'missing certificate_usage', validator_id=self.id
+                    )
+                )
             if 'selector' not in value:
-                reasons.append('missing selector')
+                reasons.append(
+                    ValidationReason('missing selector', validator_id=self.id)
+                )
             if 'matching_type' not in value:
-                reasons.append('missing matching_type')
+                reasons.append(
+                    ValidationReason(
+                        'missing matching_type', validator_id=self.id
+                    )
+                )
             if 'certificate_association_data' not in value:
-                reasons.append('missing certificate_association_data')
+                reasons.append(
+                    ValidationReason(
+                        'missing certificate_association_data',
+                        validator_id=self.id,
+                    )
+                )
         return reasons
 
 
@@ -86,32 +125,55 @@ class TlsaValueRfcValidator(ValueValidator):
             matching_type = None
             for field in ('certificate_usage', 'selector', 'matching_type'):
                 if field not in value:
-                    reasons.append(f'missing {field}')
+                    reasons.append(
+                        ValidationReason(
+                            f'missing {field}', validator_id=self.id
+                        )
+                    )
                 else:
                     try:
                         int_val = int(value[field])
                         if not 0 <= int_val <= 255:
                             reasons.append(
-                                f'invalid {field} "{int_val}"; must be 0-255'
+                                ValidationReason(
+                                    f'invalid {field} "{int_val}"; must be 0-255',
+                                    validator_id=self.id,
+                                )
                             )
                         elif field == 'matching_type':
                             matching_type = int_val
                     except (ValueError, TypeError):
-                        reasons.append(f'invalid {field} "{value[field]}"')
+                        reasons.append(
+                            ValidationReason(
+                                f'invalid {field} "{value[field]}"',
+                                validator_id=self.id,
+                            )
+                        )
 
             if 'certificate_association_data' not in value:
-                reasons.append('missing certificate_association_data')
+                reasons.append(
+                    ValidationReason(
+                        'missing certificate_association_data',
+                        validator_id=self.id,
+                    )
+                )
             else:
                 cad = value['certificate_association_data']
                 if not cad or not self._hex_re.match(str(cad)):
                     reasons.append(
-                        f'invalid certificate_association_data "{cad}"; must be hex'
+                        ValidationReason(
+                            f'invalid certificate_association_data "{cad}"; must be hex',
+                            validator_id=self.id,
+                        )
                     )
                 elif matching_type in self._matching_type_lengths:
                     expected = self._matching_type_lengths[matching_type]
                     if len(str(cad)) != expected:
                         reasons.append(
-                            f'certificate_association_data must be {expected} hex characters for matching_type {matching_type}'
+                            ValidationReason(
+                                f'certificate_association_data must be {expected} hex characters for matching_type {matching_type}',
+                                validator_id=self.id,
+                            )
                         )
         return reasons
 
@@ -142,7 +204,10 @@ class TlsaValueBestPracticeValidator(ValueValidator):
                 continue
             if matching_type == 0:
                 reasons.append(
-                    'TLSA matching_type 0 (full data) is not recommended; use matching_type 1 (SHA-256) or 2 (SHA-512)'
+                    ValidationReason(
+                        'TLSA matching_type 0 (full data) is not recommended; use matching_type 1 (SHA-256) or 2 (SHA-512)',
+                        validator_id=self.id,
+                    )
                 )
         return reasons
 

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -8,7 +8,7 @@ from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import RecordValidator, ValueValidator
+from .validator import RecordValidator, ValidationReason, ValueValidator
 
 
 class UriNameValidator(RecordValidator):
@@ -22,7 +22,11 @@ class UriNameValidator(RecordValidator):
 
     def validate(self, record_cls, name, fqdn, data):
         if not self._name_re.match(name):
-            return ['invalid name for URI record']
+            return [
+                ValidationReason(
+                    'invalid name for URI record', validator_id=self.id
+                )
+            ]
         return []
 
 
@@ -39,26 +43,44 @@ class UriValueValidator(ValueValidator):
             try:
                 int(value['priority'])
             except KeyError:
-                reasons.append('missing priority')
+                reasons.append(
+                    ValidationReason('missing priority', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid priority "{value["priority"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid priority "{value["priority"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 int(value['weight'])
             except KeyError:
-                reasons.append('missing weight')
+                reasons.append(
+                    ValidationReason('missing weight', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid weight "{value["weight"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid weight "{value["weight"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 target = value['target']
                 if not target:
-                    reasons.append('missing target')
+                    reasons.append(
+                        ValidationReason('missing target', validator_id=self.id)
+                    )
                     continue
                 # actual validation of the target is non-trivial and specific
                 # to the details of the schema etc. rfc3986 has support for
                 # validation, but we don't currently require the module and
                 # this seems too esoteric a use case to add it
             except KeyError:
-                reasons.append('missing target')
+                reasons.append(
+                    ValidationReason('missing target', validator_id=self.id)
+                )
         return reasons
 
 
@@ -81,18 +103,32 @@ class UriValueRfcValidator(ValueValidator):
         for value in data:
             for field in ('priority', 'weight'):
                 if field not in value:
-                    reasons.append(f'missing {field}')
+                    reasons.append(
+                        ValidationReason(
+                            f'missing {field}', validator_id=self.id
+                        )
+                    )
                 else:
                     try:
                         int_val = int(value[field])
                         if not 0 <= int_val <= 65535:
                             reasons.append(
-                                f'invalid {field} "{int_val}"; must be 0-65535'
+                                ValidationReason(
+                                    f'invalid {field} "{int_val}"; must be 0-65535',
+                                    validator_id=self.id,
+                                )
                             )
                     except (ValueError, TypeError):
-                        reasons.append(f'invalid {field} "{value[field]}"')
+                        reasons.append(
+                            ValidationReason(
+                                f'invalid {field} "{value[field]}"',
+                                validator_id=self.id,
+                            )
+                        )
             if 'target' not in value:
-                reasons.append('missing target')
+                reasons.append(
+                    ValidationReason('missing target', validator_id=self.id)
+                )
         return reasons
 
 
@@ -228,18 +264,32 @@ class UriNameRfcValidator(RecordValidator):
     def validate(self, record_cls, name, fqdn, data):
         labels = name.split('.') if name else []
         if len(labels) < 2:
-            return ['URI name must have at least two labels (_service._proto)']
+            return [
+                ValidationReason(
+                    'URI name must have at least two labels (_service._proto)',
+                    validator_id=self.id,
+                )
+            ]
 
         reasons = []
         service, proto = labels[0], labels[1]
         if service != '*' and not (
             service.startswith('_') and self._is_valid_service_name(service[1:])
         ):
-            reasons.append(f'invalid URI service label "{service}"')
+            reasons.append(
+                ValidationReason(
+                    f'invalid URI service label "{service}"',
+                    validator_id=self.id,
+                )
+            )
         if not (
             proto.startswith('_') and self._is_valid_service_name(proto[1:])
         ):
-            reasons.append(f'invalid URI proto label "{proto}"')
+            reasons.append(
+                ValidationReason(
+                    f'invalid URI proto label "{proto}"', validator_id=self.id
+                )
+            )
         return reasons
 
 

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -5,7 +5,7 @@
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin, unquote
 from .rr import RrParseError
-from .validator import ValueValidator
+from .validator import ValidationReason, ValueValidator
 
 
 class UrlfwdValueValidator(ValueValidator):
@@ -21,30 +21,68 @@ class UrlfwdValueValidator(ValueValidator):
             try:
                 code = int(value['code'])
                 if code not in value_cls.VALID_CODES:
-                    reasons.append(f'unrecognized return code "{code}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'unrecognized return code "{code}"',
+                            validator_id=self.id,
+                        )
+                    )
             except KeyError:
-                reasons.append('missing code')
+                reasons.append(
+                    ValidationReason('missing code', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid return code "{value["code"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid return code "{value["code"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 masking = int(value['masking'])
                 if masking not in value_cls.VALID_MASKS:
-                    reasons.append(f'unrecognized masking setting "{masking}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'unrecognized masking setting "{masking}"',
+                            validator_id=self.id,
+                        )
+                    )
             except KeyError:
-                reasons.append('missing masking')
+                reasons.append(
+                    ValidationReason('missing masking', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid masking setting "{value["masking"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid masking setting "{value["masking"]}"',
+                        validator_id=self.id,
+                    )
+                )
             try:
                 query = int(value['query'])
                 if query not in value_cls.VALID_QUERY:
-                    reasons.append(f'unrecognized query setting "{query}"')
+                    reasons.append(
+                        ValidationReason(
+                            f'unrecognized query setting "{query}"',
+                            validator_id=self.id,
+                        )
+                    )
             except KeyError:
-                reasons.append('missing query')
+                reasons.append(
+                    ValidationReason('missing query', validator_id=self.id)
+                )
             except ValueError:
-                reasons.append(f'invalid query setting "{value["query"]}"')
+                reasons.append(
+                    ValidationReason(
+                        f'invalid query setting "{value["query"]}"',
+                        validator_id=self.id,
+                    )
+                )
             for k in ('path', 'target'):
                 if k not in value:
-                    reasons.append(f'missing {k}')
+                    reasons.append(
+                        ValidationReason(f'missing {k}', validator_id=self.id)
+                    )
         return reasons
 
 

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -130,7 +130,10 @@ class ValidatorRegistry:
         reasons = []
         for key in ('*', record_cls._type):
             for validator in self.active_record.get(key, {}).values():
-                reasons.extend(validator.validate(record_cls, name, fqdn, data))
+                reasons.extend(
+                    _as_reason(r, validator.id)
+                    for r in validator.validate(record_cls, name, fqdn, data)
+                )
         return reasons
 
     def process_values(self, value_type, values, _type):
@@ -141,11 +144,78 @@ class ValidatorRegistry:
                 f'`{value_type.__name__}.validate` classmethod is DEPRECATED. Add a ValueValidator to `VALIDATORS` instead. Will be removed in 2.0',
                 stacklevel=3,
             )
-            reasons.extend(legacy(values, _type))
+            legacy_id = f'{value_type.__name__}.validate'
+            reasons.extend(
+                _as_reason(r, legacy_id, warn=False)
+                for r in legacy(values, _type)
+            )
         for key in ('*', _type):
             for validator in self.active_value.get(key, {}).values():
-                reasons.extend(validator.validate(value_type, values, _type))
+                reasons.extend(
+                    _as_reason(r, validator.id)
+                    for r in validator.validate(value_type, values, _type)
+                )
         return reasons
+
+
+class ValidationReason(str):
+    '''
+    A single validation failure reason.
+
+    Behaves as a plain ``str`` (its content is the bare, human-readable
+    reason text) so existing code that compares or joins reasons as
+    strings keeps working unchanged. In addition it carries the set of
+    ``records`` the failure applies to and the ``validator_id`` of the
+    validator that produced it, which ``__str__`` uses to append context
+    and ``, via: <validator_id>`` attribution — richer output that only
+    appears where a caller explicitly renders with ``str(reason)``
+    (e.g. in ``ValidationError`` messages); plain string joins/comparisons
+    see only the bare reason.
+    '''
+
+    def __new__(cls, reason, records=(), validator_id=None):
+        return super().__new__(cls, reason)
+
+    def __init__(self, reason, records=(), validator_id=None):
+        if validator_id is None:
+            deprecated(
+                'omitting `validator_id` is DEPRECATED. It will be a required parameter as of 2.0',
+                stacklevel=3,
+            )
+        self.validator_id = validator_id
+        self.reason = reason
+        self.records = set(records)
+
+    @property
+    def lenient(self):
+        return bool(self.records) and all(r.lenient for r in self.records)
+
+    def __str__(self):
+        msg = self.reason
+        contexts = {
+            r.context for r in self.records if getattr(r, 'context', None)
+        }
+        if contexts:
+            msg += f" ({', '.join(sorted(contexts))})"
+        if self.validator_id:
+            msg += f', via: {self.validator_id}'
+        return msg
+
+    def __repr__(self):
+        return self.reason
+
+
+def _as_reason(reason, validator_id, warn=True):
+    if not isinstance(reason, ValidationReason):
+        if warn:
+            deprecated(
+                'validators returning `str` reasons is DEPRECATED; return `ValidationReason`. Will be required in 2.0',
+                stacklevel=4,
+            )
+        return ValidationReason(reason, validator_id=validator_id)
+    if reason.validator_id is None:
+        reason.validator_id = validator_id
+    return reason
 
 
 class RecordValidator:
@@ -219,18 +289,23 @@ class RecordValidator:
 
         Returns
         -------
-        list[str]
-            A list of human-readable reason strings describing validation
-            failures. Must return an empty list when the record is valid.
-            Reasons from multiple validators are concatenated by the caller,
-            so each reason must stand alone without context from the others.
+        list[ValidationReason]
+            A list of ``ValidationReason`` objects describing validation
+            failures — construct each with ``ValidationReason(reason,
+            validator_id=self.id)``. Must return an empty list when the
+            record is valid. Reasons from multiple validators are
+            concatenated by the caller, so each reason must stand alone
+            without context from the others. Returning bare ``str``
+            reasons is DEPRECATED — the registry wraps them in
+            ``ValidationReason`` and emits a deprecation warning; support
+            will be removed in 2.0.
 
         Notes
         -----
         Implementations must not raise on invalid input — all failures are
-        reported via the returned list. Reason strings are surfaced
-        verbatim in ``ValidationError`` messages, so phrasing and
-        punctuation should be stable across releases.
+        reported via the returned list. Reason text is surfaced verbatim
+        in ``ValidationError`` messages, so phrasing and punctuation
+        should be stable across releases.
         '''
         return []
 
@@ -239,8 +314,8 @@ class ValueValidator:
     '''
     Base class for value-level validators.
 
-    Subclasses override ``validate`` to return a list of reason strings
-    describing any validation failures. An empty list indicates the value is
+    Subclasses override ``validate`` to return a list of ``ValidationReason``
+    objects describing any validation failures. An empty list indicates the value is
     valid. ``value_cls`` is the concrete value class being validated.
     Per-instance configuration should live on the validator instance
     (``self``); ``value_cls`` is only the right home for state that's
@@ -306,12 +381,16 @@ class ValueValidator:
 
         Returns
         -------
-        list[str]
-            A list of human-readable reason strings describing validation
-            failures. Must return an empty list when the values are
-            valid. Reasons from multiple validators are concatenated by
-            the caller, so each reason must stand alone without context
-            from the others.
+        list[ValidationReason]
+            A list of ``ValidationReason`` objects describing validation
+            failures — construct each with ``ValidationReason(reason,
+            validator_id=self.id)``. Must return an empty list when the
+            values are valid. Reasons from multiple validators are
+            concatenated by the caller, so each reason must stand alone
+            without context from the others. Returning bare ``str``
+            reasons is DEPRECATED — the registry wraps them in
+            ``ValidationReason`` and emits a deprecation warning; support
+            will be removed in 2.0.
 
         Notes
         -----

--- a/octodns/record/validator.py
+++ b/octodns/record/validator.py
@@ -174,6 +174,10 @@ class ValidationReason(str):
     '''
 
     def __new__(cls, reason, records=(), validator_id=None):
+        # str content is fixed at __new__ time (str is immutable), so this
+        # must exist to make the content `reason` alone; otherwise str.__new__
+        # would be called with `records`/`validator_id` too and raise a
+        # TypeError.
         return super().__new__(cls, reason)
 
     def __init__(self, reason, records=(), validator_id=None):

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -4,8 +4,10 @@
 
 from logging import getLogger
 
-from ..deprecation import deprecated
+from ..record.validator import ValidationReason
 from .exception import ZoneException
+
+__all__ = ['ValidationReason', 'ZoneValidator', 'ZoneValidatorRegistry']
 
 
 class ZoneValidatorRegistry:
@@ -73,36 +75,6 @@ class ZoneValidatorRegistry:
             reasons.extend(validator.validate(zone))
 
         return reasons
-
-
-class ValidationReason:
-    def __init__(self, reason, records, validator_id=None):
-        if validator_id is None:
-            deprecated(
-                'omitting `validator_id` is DEPRECATED. It will be a required parameter as of 2.0',
-                stacklevel=3,
-            )
-        self.validator_id = validator_id
-        self.reason = reason
-        self.records = set(records)
-
-    @property
-    def lenient(self):
-        return bool(self.records) and all(r.lenient for r in self.records)
-
-    def __str__(self):
-        msg = self.reason
-        contexts = {
-            r.context for r in self.records if getattr(r, 'context', None)
-        }
-        if contexts:
-            msg += f" ({', '.join(sorted(contexts))})"
-        if self.validator_id:
-            msg += f', via: {self.validator_id}'
-        return msg
-
-    def __repr__(self):
-        return self.reason
 
 
 class ZoneValidator:

--- a/tests/test_octodns_record_validators.py
+++ b/tests/test_octodns_record_validators.py
@@ -25,6 +25,7 @@ from octodns.record.srv import SrvNameValidator, SrvRecord
 from octodns.record.uri import UriNameValidator, UriRecord
 from octodns.record.validator import (
     RecordValidator,
+    ValidationReason,
     ValidatorRegistry,
     ValueValidator,
 )
@@ -435,6 +436,49 @@ class TestValidatorRegistry(TestCase):
         self.assertEqual(
             [], reg.process_record(ARecord, 'ok', 'ok.unit.tests.', {'ttl': 30})
         )
+
+    def test_process_record_stamps_missing_validator_id(self):
+        # A validator that constructs its own `ValidationReason` but leaves
+        # `validator_id` unset should have it stamped by the registry with
+        # the validator's own id, without re-wrapping the object or firing
+        # the "returning str reasons" deprecation.
+        class ForbidBadPrefixReason(RecordValidator):
+            def __init__(self, prefix):
+                super().__init__(id='test-forbid-bad-prefix-reason')
+                self.prefix = prefix
+
+            def validate(self, record_cls, name, fqdn, data):
+                if name.startswith(self.prefix):
+                    with warnings.catch_warnings():
+                        # constructing without validator_id emits its own
+                        # deprecation; not what we're testing here
+                        warnings.simplefilter('ignore', DeprecationWarning)
+                        reason = ValidationReason(
+                            f'name starts with "{self.prefix}"'
+                        )
+                    return [reason]
+                return []
+
+        reg = ValidatorRegistry()
+        reg.register(ForbidBadPrefixReason('bad-'), types=['A'])
+        reg.enable('test-forbid-bad-prefix-reason', types=['A'])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            reasons = reg.process_record(
+                ARecord, 'bad-name', 'bad-name.unit.tests.', {'ttl': 30}
+            )
+        self.assertEqual(1, len(reasons))
+        self.assertEqual('name starts with "bad-"', reasons[0])
+        self.assertEqual(
+            'test-forbid-bad-prefix-reason', reasons[0].validator_id
+        )
+        matched = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and 'returning `str` reasons' in str(w.message)
+        ]
+        self.assertFalse(matched)
 
     def test_process_record_lazy_init(self):
         reg = ValidatorRegistry()


### PR DESCRIPTION
## Summary
- Unify record/value validator output with the existing zone-level `ValidationReason` mechanism (previously record/value validators returned bare `list[str]`, while zone validators already returned `list[ValidationReason]`).
- `ValidationReason` moves to `octodns/record/validator.py` as a `str` subclass (bare reason text as content, rich `via: <id>` rendering via `__str__`), and stays importable from `octodns.zone.validator` (re-exported via `__all__`) for 3rd-party back-compat.
- Every first-party record/value validator now constructs `ValidationReason(text, validator_id=self.id)` directly; the registry (`ValidatorRegistry.process_record`/`process_values`) wraps any bare `str` still returned by 3rd-party validators (emitting a deprecation warning) and stamps `validator_id` onto reasons that don't already have one — conditional stamping means the `_values-type`/`_value-type` bridge validators never clobber the real inner value-validator's id.
- Record/value `ValidationError` messages now render with `via: <id>` attribution, matching zone error messages.

Related prior work: #1439 (zone validator ids), b6c6851b (moved `via:` into `ValidationReason.__str__`).

## Test plan
- [x] `./script/test` — 785 passed, 100% coverage
- [x] `./script/lint` clean
- [x] Manually verified `via: ttl-rfc` / `via: mx-value` etc. appear in record `ValidationError` messages
- [x] Confirmed bare-string list equality (`e.reasons == ['missing ttl']`) still holds due to the `str` subclass design — zero pre-existing test churn
- [x] Confirmed 3rd-party validators returning bare strings get wrapped + stamped with a deprecation warning, and the legacy `value_type.validate` classmethod path doesn't double-warn
- [x] Added `test_process_record_stamps_missing_validator_id` covering the "already a `ValidationReason` but missing `validator_id`" stamping branch