### PR TITLE
Version 1.21.0 bump & changelog update

### DIFF
--- a/.changelog/03bb923602674dd795bc41e348ecc850.md
+++ b/.changelog/03bb923602674dd795bc41e348ecc850.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add required validator_id parameter to ValidatorReason

--- a/.changelog/160374cfc18149d0a3d82de130928937.md
+++ b/.changelog/160374cfc18149d0a3d82de130928937.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add per-zone validators.record.disable_validators and validators.zone.disable_validators to selectively disable built-in validators for individual zones, additive to the global manager.validators config

--- a/.changelog/51bdc27f92b4424e8b39bc50d672dce5.md
+++ b/.changelog/51bdc27f92b4424e8b39bc50d672dce5.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Convert record/value validator reasons to `ValidationReason` objects, unifying with zone-level validators and surfacing `via: <validator-id>` attribution in record/value `ValidationError` messages

--- a/.changelog/676debe981654a72bb40eb58c6a619c9.md
+++ b/.changelog/676debe981654a72bb40eb58c6a619c9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix broken f-string interpolation in alias zone error message and Geo repr

--- a/.changelog/78a34a1984ca4ebba5e4f0021dc61c21.md
+++ b/.changelog/78a34a1984ca4ebba5e4f0021dc61c21.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix lenient parameter leak across zones in validate_configs

--- a/.changelog/a4c2beb49bad46cfa2d6a1e06d11f3a6.md
+++ b/.changelog/a4c2beb49bad46cfa2d6a1e06d11f3a6.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix MailZoneValidator's single-MX provider exemption to match known providers even when the MX exchange is missing its trailing dot (e.g. when the mx-value-best-practice validator is disabled for a zone)

--- a/.changelog/b01976da4f474745b5c71935640d719a.md
+++ b/.changelog/b01976da4f474745b5c71935640d719a.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Collapse remaining multi-line string concatenations to avoid f-string interpolation bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.21.0 - 2026-07-08
+
+Minor:
+* Add per-zone validators.record.disable_validators and validators.zone.disable_validators to selectively disable built-in validators for individual zones, additive to the global manager.validators config - [#1441](https://github.com/octodns/octodns/pull/1441)
+* Convert record/value validator reasons to `ValidationReason` objects, unifying with zone-level validators and surfacing `via: <validator-id>` attribution in record/value `ValidationError` messages - [#1443](https://github.com/octodns/octodns/pull/1443)
+* Add required validator_id parameter to ValidatorReason - [#1439](https://github.com/octodns/octodns/pull/1439)
+
+Patch:
+* Fix MailZoneValidator's single-MX provider exemption to match known providers even when the MX exchange is missing its trailing dot (e.g. when the mx-value-best-practice validator is disabled for a zone) - [#1442](https://github.com/octodns/octodns/pull/1442)
+* Fix lenient parameter leak across zones in validate_configs - [#1440](https://github.com/octodns/octodns/pull/1440)
+* Collapse remaining multi-line string concatenations to avoid f-string interpolation bugs - [#1438](https://github.com/octodns/octodns/pull/1438)
+* Fix broken f-string interpolation in alias zone error message and Geo repr - [#1437](https://github.com/octodns/octodns/pull/1437)
+
 ## 1.20.0 - 2026-06-21
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.20.0'
+__version__ = __VERSION__ = '1.21.0'


### PR DESCRIPTION
## 1.21.0 - 2026-07-08

Minor:
* Add per-zone validators.record.disable_validators and validators.zone.disable_validators to selectively disable built-in validators for individual zones, additive to the global manager.validators config - [#1441](https://github.com/octodns/octodns/pull/1441)
* Convert record/value validator reasons to `ValidationReason` objects, unifying with zone-level validators and surfacing `via: <validator-id>` attribution in record/value `ValidationError` messages - [#1443](https://github.com/octodns/octodns/pull/1443)
* Add required validator_id parameter to ValidatorReason - [#1439](https://github.com/octodns/octodns/pull/1439)

Patch:
* Fix MailZoneValidator's single-MX provider exemption to match known providers even when the MX exchange is missing its trailing dot (e.g. when the mx-value-best-practice validator is disabled for a zone) - [#1442](https://github.com/octodns/octodns/pull/1442)
* Fix lenient parameter leak across zones in validate_configs - [#1440](https://github.com/octodns/octodns/pull/1440)
* Collapse remaining multi-line string concatenations to avoid f-string interpolation bugs - [#1438](https://github.com/octodns/octodns/pull/1438)
* Fix broken f-string interpolation in alias zone error message and Geo repr - [#1437](https://github.com/octodns/octodns/pull/1437)

