### PR TITLE
Fix cibuild-module to recognize PEP 621 provider modules

### DIFF
--- a/.changelog/dc67c65124e74bdc97704d4661adfb41.md
+++ b/.changelog/dc67c65124e74bdc97704d4661adfb41.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix cibuild-module to recognize PEP 621 (pyproject.toml [project] table) provider modules, not just setup.py and poetry

--- a/.changelog/dc67c65124e74bdc97704d4661adfb41.md
+++ b/.changelog/dc67c65124e74bdc97704d4661adfb41.md
@@ -1,4 +1,4 @@
 ---
-type: patch
+type: none
 ---
 Fix cibuild-module to recognize PEP 621 (pyproject.toml [project] table) provider modules, not just setup.py and poetry

--- a/script/cibuild-module
+++ b/script/cibuild-module
@@ -28,7 +28,13 @@ cd $TMP_DIR
 git clone "https://github.com/${module}.git"
 cd $(basename $module)
 echo "## install module dev requirements #############################################"
-if [ -e setup.py ]; then
+# setuptools/PEP 621 modules (a setup.py, or a pyproject.toml with a [project]
+# table) install cleanly with pip and, because octodns was built and installed
+# above, keep our local octodns rather than pulling it from PyPI. Legacy poetry
+# modules (deps only under [tool.poetry]) need special handling to avoid clobbering
+# that local octodns.
+if [ -e setup.py ] || grep -q '^\[project\]' pyproject.toml 2>/dev/null; then
+  pip_module=1
   pip install -e .[dev] pytest-network
 elif [ -f pyproject.toml ]; then
   # install poetry
@@ -38,16 +44,16 @@ elif [ -f pyproject.toml ]; then
   # now install all the deps
   poetry install --no-root -v
 else
-  echo "Unrecognized module management. Supports setup.py and poetry"
+  echo "Unrecognized module management. Supports setup.py, PEP 621, and poetry"
   exit 1
 fi
 echo "## installed modules ###########################################################"
 pip freeze
 echo "## run module tests ############################################################"
 export PYTHONPATH=.:$PYTHONPATH
-if [ -e setup.py ]; then
+if [ -n "$pip_module" ]; then
   pytest --disable-network
 elif [ -f poetry.toml ]; then
-  poetry run pytest []
+  poetry run pytest
 fi
 echo "## complete ####################################################################"


### PR DESCRIPTION
## Summary

`script/cibuild-module` (the reverse-CI in `.github/workflows/modules.yml` that clones each provider module and runs its tests against the locally-built `octodns`) only recognized two packaging styles: `setup.py`, or `pyproject.toml` assumed to be Poetry. With provider modules starting to migrate to declarative `pyproject.toml` (setuptools + PEP 621 `[project]` table, see #1444), that assumption breaks in two ways:

- The install step's `elif [ -f pyproject.toml ]` branch treats any non-setup.py module as Poetry: it runs `pip install poetry` and `poetry install --no-root`, and its `sed -i '/^octodns =/d'` guard (meant to stop Poetry pulling `octodns` from PyPI and clobbering the local build) only matches Poetry's own dependency syntax, not a PEP 621 `dependencies = [...]` array — so for a migrated module it silently does nothing, and `poetry install` risks overwriting the just-built local `octodns`.
- The test step keys off `[ -f poetry.toml ]`, which a setuptools/PEP 621 module also doesn't have, so **no tests run and the job exits 0** — a false green.

This adds a real branch for setuptools/PEP 621 modules (detected via `[ -e setup.py ] || grep -q '^\[project\]' pyproject.toml`), reusing the same `pip install -e .[dev]` + `pytest --disable-network` path already used for `setup.py`. Also fixes a stray `poetry run pytest []` (literal `[]`) noticed while touching this code.

## Test plan

- [x] Verified detection logic against 6 layouts: legacy `setup.py`-only, `setup.py` + tool-config `pyproject.toml` (today's real modules), migrated PEP 621 `pyproject.toml` (octodns-azure's `pyproject-modernize` branch), legacy Poetry (`[tool.poetry]` only, no `[project]`), neither file (still errors), and a PEP 621 file with `[project.scripts]` present.
- [x] Ran the full script logic end-to-end: built and installed a local `octodns` wheel in a fresh venv, cloned octodns-azure's `pyproject-modernize` branch, ran `pip install -e .[dev] pytest-network` — confirmed the locally-built `octodns` (not a PyPI release) was preserved — then ran `pytest --disable-network`: 65 passed.
- [x] `./script/lint`, `./script/format --check`, full test suite (807 passed, 100% coverage) via the pre-commit hook.