### PR TITLE
Fix CAA rdata_text to quote the value field per RFC 8659

### DIFF
--- a/.changelog/c5ca474fdffc45f0bac3bf2515963ab6.md
+++ b/.changelog/c5ca474fdffc45f0bac3bf2515963ab6.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix CaaValue.rdata_text to quote the value field per RFC 8659, matching NAPTR/URI - #1447

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -212,7 +212,8 @@ class CaaValue(EqualityTupleMixin, dict):
 
     @property
     def rdata_text(self):
-        return f'{self.flags} {self.tag} {self.value}'
+        # RFC 8659 §4.1.1 requires value to be a quoted character-string
+        return f'{self.flags} {self.tag} "{self.value}"'
 
     def template(self, params):
         if '{' not in self.value:

--- a/tests/test_octodns_record_caa.py
+++ b/tests/test_octodns_record_caa.py
@@ -139,11 +139,21 @@ class TestRecordCaa(TestCase):
         self.assertEqual(1, a.values[0].flags)
         self.assertEqual('tag1', a.values[0].tag)
         self.assertEqual('99148c81', a.values[0].value)
-        self.assertEqual('1 tag1 99148c81', a.values[0].rdata_text)
+        self.assertEqual('1 tag1 "99148c81"', a.values[0].rdata_text)
         self.assertEqual(2, a.values[1].flags)
         self.assertEqual('tag2', a.values[1].tag)
         self.assertEqual('99148c44', a.values[1].value)
-        self.assertEqual('2 tag2 99148c44', a.values[1].rdata_text)
+        self.assertEqual('2 tag2 "99148c44"', a.values[1].rdata_text)
+
+        # value with whitespace/`;` round-trips through rdata_text and
+        # parse_rdata_text (the motivating case from #1447)
+        value = CaaValue(
+            {'flags': 0, 'tag': 'issue', 'value': 'ca.unit.tests; account=1'}
+        )
+        self.assertEqual('0 issue "ca.unit.tests; account=1"', value.rdata_text)
+        self.assertEqual(
+            dict(value.data), CaaValue.parse_rdata_text(value.rdata_text)
+        )
 
     def test_caa_value(self):
         a = CaaValue({'flags': 0, 'tag': 'a', 'value': 'v'})


### PR DESCRIPTION
## Summary
* `CaaValue.rdata_text` returned the `value` field unquoted, in violation of [RFC 8659 §4.1.1](https://datatracker.ietf.org/doc/html/rfc8659#section-4.1.1), which requires it as a quoted character-string. `NAPTR` and `URI` already quote their string fields correctly (`octodns/record/naptr.py`, `octodns/record/uri.py`) — CAA was the odd one out.
* Fixes `octodns/record/caa.py`'s `CaaValue.rdata_text` to emit `f'{flags} {tag} "{value}"'`. No parse-side change was needed: `CaaValue.parse_rdata_text` already calls `unquote()` on the value, so it already accepted quoted input — the round trip was already asymmetric only in the emit direction.
* Fixes #1447 (CAA half only; the TXT quoting/chunking half of that issue is separate/TBD per the issue discussion).

## Provider examination

Audited every local `octodns-*` provider repo for CAA / `rdata_text` usage before making this change, since a change to shared `rdata_text` behavior can affect providers relying on the old (buggy) output:

**Providers that already hand-quote CAA — direct evidence this was an oversight, and proof they're unaffected:**
* `octodns-powerdns`'s `_records_for_CAA` emits `f'{v.flags} {v.tag} "{v.value}"'` directly (not via `rdata_text`); its test fixture (`powerdns-full-data.json`) already expects the quoted form `"0 issue \"ca.unit.tests\""`.
* `octodns-ovh`'s `_params_for_CAA` does the same manual `f'{value.flags} {value.tag} "{value.value}"'`.
* Both providers worked around the `rdata_text` bug by building the quoted string themselves. They're untouched by this fix and could later be simplified to just call `.rdata_text`, but that's out of scope here.

**Provider that consumes CAA through the generic `rdata_text` path — the one this fix actually corrects:**
* `octodns-bind`'s `ZoneFileSource._apply` writes every record value via the generic `value.rdata_text` (only NS-apex naming and SPF/TXT chunking are special-cased). BIND zone-file syntax requires the CAA value quoted — the repo's own zone fixture (`tests/zones/unit.tests.tst`) has `caa 1800 IN CAA 0 issue "ca.unit.tests"`. Today `octodns-bind` writes that back out **unquoted**, which is invalid zonefile syntax / lossy. This fix corrects that. No existing bind test asserts the (buggy) unquoted output, so nothing breaks — but bind should get a follow-up PR adding a regression test that asserts the corrected quoted CAA output on write.

**Parse-side consumers — unaffected, since parsing already unquotes:**
* `octodns-hetzner` and `octodns-ultra` call `CaaValue.parse_rdata_text(...)` when populating from their APIs; `unquote()` already strips quotes when present, so quoted or unquoted upstream data both worked before and continue to work.

**Everything else** either has no CAA support or builds CAA payloads directly from `flags`/`tag`/`value` fields without touching `rdata_text`, so is unaffected.

/cc the [octodns-opusdns](https://github.com/relkian/octodns-opusdns) provider referenced in #1447, whose `Bad Request: DNS Error ... expecting a string` was the original symptom — it calls `record.values[i].rdata_text` directly and should get correctly quoted CAA values now.

## Test plan
- [x] `./script/test tests/test_octodns_record_caa.py` — updated the two existing `rdata_text` assertions to the quoted form, added a round-trip test with a value containing `;`/whitespace (the motivating opusdns case)
- [x] `./script/test` (full suite) — 807 passed, 100% coverage maintained