### PR TITLE
Make TXT/SPF rdata_text RFC 1035-compliant

### DIFF
--- a/.changelog/c3ff045cd56c4ed6b630fbbbf1567936.md
+++ b/.changelog/c3ff045cd56c4ed6b630fbbbf1567936.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Make TXT/SPF rdata_text return RFC 1035 presentation-format text (quoted, chunked) and parse_rdata_text properly reverse it, fixing corruption of values containing ; or " on a from_rrs round-trip

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -337,9 +337,9 @@ Processors
    * - `NameRejectlistFilter`_
      - Filter that IGNORES records that match specified naming patterns, all others will be managed
    * - `ValueAllowlistFilter`_
-     - Filter that ONLY manages records that match specified value patterns based on `rdata_text`, all others will be ignored
+     - Filter that ONLY manages records that match specified value patterns, all others will be ignored
    * - `ValueRejectlistFilter`_
-     - Filter that IGNORES records that match specified value patterns based on `rdata_text`, all others will be managed
+     - Filter that IGNORES records that match specified value patterns, all others will be managed
    * - `OwnershipProcessor`_
      - Processor that implements ownership in octoDNS so that it can manage only the records in a zone in sources and will ignore all others.
    * - `SpfDnsLookupProcessor`_

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -232,9 +232,13 @@ class _ValueBaseFilter(_FilterProcessor):
         for record in zone.records:
             values = []
             if hasattr(record, 'values'):
-                values = [value.rdata_text for value in record.values]
+                values = [
+                    v if isinstance(v, str) else v.rdata_text
+                    for v in record.values
+                ]
             elif record.value is not None:
-                values = [record.value.rdata_text]
+                value = record.value
+                values = [value if isinstance(value, str) else value.rdata_text]
             else:
                 self.log.warning(
                     'value for %s is NoneType, ignoring', record.fqdn

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -4,6 +4,12 @@
 
 import re
 
+import dns.exception
+import dns.rdata
+import dns.rdataclass
+import dns.rdatatype
+import dns.rdtypes.ANY.TXT
+
 from .base import ValuesMixin
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
@@ -61,61 +67,60 @@ chunked_value_validator = ChunkedValueValidator(
 
 _unescaped_semicolon_re = re.compile(r'(?<!\\);')
 
+# dnspython already implements RFC 1035 presentation-format parsing/rendering
+# (quoting, 255-byte-per-character-string chunking, \"/\\/\DDD escaping) for
+# every string-ish rdata type, including TXT. octoDNS's TXT/SPF values are
+# handled identically (that's why they share this module), so rather than
+# hand-roll our own copy of that logic we delegate to dnspython's TXT rdata
+# class for it; the class used doesn't matter as it's the same wire format
+# regardless of the actual record type.
+_RDCLASS = dns.rdataclass.IN
+_RDTYPE = dns.rdatatype.TXT
+
 
 def _escape_unescaped_semicolons(value):
     '''
     Escapes any ``;`` in `value` that isn't already escaped, leaving
     already-escaped ``\\;`` untouched.
+
+    This is octoDNS's own long-standing internal convention for marking a
+    literal ``;`` in its stored values, enforced by ChunkedValueValidator.
+    It's not an RFC concept (a bare ``;`` needs no escaping inside a quoted
+    RFC 1035 character-string), so it's applied as a separate step on top of
+    the real presentation-format handling below, never mixed into it.
     '''
     return _unescaped_semicolon_re.sub('\\\\;', value)
 
 
-def _tokenize(value):
+def _parse_presentation_text(value):
     '''
-    Tokenizes an RFC 1035 presentation-format rdata string into a sequence
-    of (is_quoted, text) pairs, one per whitespace-separated
-    character-string. Escaped double quotes (\\") inside a quoted
-    character-string are unescaped as part of tokenizing. Raises
-    RrParseError if a quoted character-string is never closed.
+    Parses `value` as RFC 1035 presentation-format rdata text (quoted and/or
+    chunked, with \\", \\\\, and \\DDD escapes as dnspython emits/expects)
+    and returns the fully decoded, unmarked raw content as a str.
+
+    Raises RrParseError if `value` isn't valid presentation-format text,
+    e.g. an unterminated quote or an over-long (>255 byte) single
+    character-string.
     '''
-    n = len(value)
-    i = 0
-    while i < n:
-        c = value[i]
-        if c.isspace():
-            # whitespace between character-strings, skip over it
-            i += 1
-            continue
-        if c == '"':
-            # quoted character-string, run until we hit an unescaped
-            # closing quote
-            i += 1
-            start = i
-            buf = []
-            while True:
-                j = value.find('"', i)
-                if j == -1:
-                    # never found a closing quote
-                    raise RrParseError()
-                if value[j - 1] == '\\':
-                    # it was an escaped quote, keep the " and keep looking
-                    # for the real closing quote
-                    buf.append(value[start : j - 1])
-                    buf.append('"')
-                    i = j + 1
-                    start = i
-                else:
-                    # found our closing quote
-                    buf.append(value[start:j])
-                    i = j + 1
-                    break
-            yield True, ''.join(buf)
-        else:
-            # unquoted character-string, run until whitespace or a quote
-            start = i
-            while i < n and not value[i].isspace() and value[i] != '"':
-                i += 1
-            yield False, value[start:i]
+    try:
+        rdata = dns.rdata.from_text(_RDCLASS, _RDTYPE, value)
+    except dns.exception.DNSException as e:
+        raise RrParseError() from e
+    raw = b''.join(rdata.strings)
+    # latin1 maps each byte 0-255 to the identical code point, so this never
+    # raises and never loses information; genuinely non-ASCII content is
+    # still caught downstream by ChunkedValueValidator at validation time,
+    # the same parse-vs-validate split used elsewhere in the codebase
+    return raw.decode('latin1')
+
+
+def _render_presentation_text(chunks):
+    '''
+    Renders `chunks`, an iterable of <=255-byte bytestrings, as RFC 1035
+    presentation-format rdata text: quoted, escaped, and space-joined.
+    '''
+    rdata = dns.rdtypes.ANY.TXT.TXT(_RDCLASS, _RDTYPE, chunks)
+    return rdata.to_text()
 
 
 class _ChunkedValuesMixin(ValuesMixin):
@@ -148,24 +153,8 @@ class _ChunkedValue(str):
             # already parsed/processed, nothing to do
             return value
 
-        tokens = list(_tokenize(value))
-        if not tokens:
-            # nothing but whitespace
-            return cls('')
-        elif len(tokens) == 1:
-            # a single character-string, quoted or not, is unambiguous
-            text = tokens[0][1]
-        elif all(is_quoted for is_quoted, _ in tokens):
-            # multiple quoted character-strings, e.g. a previously chunked
-            # value, concatenate them to reconstruct the original value
-            text = ''.join(text for _, text in tokens)
-        else:
-            # multiple unquoted, and/or a mix of quoted & unquoted,
-            # character-strings are ambiguous to concatenate without
-            # loss, we don't guess
-            raise RrParseError()
-
-        return cls(_escape_unescaped_semicolons(text))
+        raw = _parse_presentation_text(value)
+        return cls(_escape_unescaped_semicolons(raw))
 
     @classmethod
     def _schema(cls):
@@ -180,35 +169,42 @@ class _ChunkedValue(str):
                 # record.data, leave it alone
                 ret.append(v)
                 continue
-            if v and v[0] == '"':
-                v = v[1:-1]
-            ret.append(cls(v.replace('" "', '')))
+            if v is None:
+                # a missing value: validation (not this lenient step) is
+                # the real gate for this, but leave it as None rather than
+                # coercing it into the literal string "None"
+                ret.append(v)
+                continue
+            if v and v[:1] == '"':
+                # looks like real presentation-format text, e.g. pasted
+                # from dig/a zone file. Parse it properly, but stay
+                # lenient: this is user-authored YAML, not wire data, and
+                # validators (not this step) are the actual gate for
+                # malformed content, so fall back to using it as-typed if
+                # it doesn't actually parse
+                try:
+                    v = _escape_unescaped_semicolons(
+                        _parse_presentation_text(v)
+                    )
+                except RrParseError:
+                    pass
+            ret.append(cls(v))
         return ret
 
     def chunked(self, chunk_size=None):
         if chunk_size is None:
             chunk_size = self.CHUNK_SIZE
-        value = self.replace('"', '\\"')
-        vs = []
-        i = 0
-        n = len(value)
-        # until we've processed the whole string
-        while i < n:
-            # start with a full chunk size
-            c = min(chunk_size, n - i)
-            # make sure that we don't break on escape chars
-            while value[i + c - 1] == '\\':
-                c -= 1
-            # we have our chunk now
-            vs.append(value[i : i + c])
-            # and can step over it
-            i += c
-        vs = '" "'.join(vs)
-        # a plain str, not self.__class__: this is presentation-format
-        # rdata text, not an internal/processed value, and returning cls
-        # here would make parse_rdata_text's already-processed shortcut
-        # misfire on it
-        return f'"{vs}"'
+        # un-mark our own ;-convention back to true raw content before
+        # handing it to dnspython, which knows nothing about it and would
+        # otherwise double-escape the marker's backslash
+        raw = self.replace('\\;', ';').encode('latin1')
+        n = len(raw)
+        chunks = [raw[i : i + chunk_size] for i in range(0, n, chunk_size)]
+        text = _render_presentation_text(chunks or [b''])
+        # re-mark afterwards: dnspython leaves a bare ; alone since it has
+        # no special meaning inside a quoted character-string, but octoDNS's
+        # own convention always marks it
+        return _escape_unescaped_semicolons(text)
 
     @property
     def rdata_text(self):

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -5,6 +5,7 @@
 import re
 
 from .base import ValuesMixin
+from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -58,49 +59,113 @@ chunked_value_validator = ChunkedValueValidator(
 )
 
 
+_unescaped_semicolon_re = re.compile(r'(?<!\\);')
+
+
+def _escape_unescaped_semicolons(value):
+    '''
+    Escapes any ``;`` in `value` that isn't already escaped, leaving
+    already-escaped ``\\;`` untouched.
+    '''
+    return _unescaped_semicolon_re.sub('\\\\;', value)
+
+
+def _tokenize(value):
+    '''
+    Tokenizes an RFC 1035 presentation-format rdata string into a sequence
+    of (is_quoted, text) pairs, one per whitespace-separated
+    character-string. Escaped double quotes (\\") inside a quoted
+    character-string are unescaped as part of tokenizing. Raises
+    RrParseError if a quoted character-string is never closed.
+    '''
+    n = len(value)
+    i = 0
+    while i < n:
+        c = value[i]
+        if c.isspace():
+            # whitespace between character-strings, skip over it
+            i += 1
+            continue
+        if c == '"':
+            # quoted character-string, run until we hit an unescaped
+            # closing quote
+            i += 1
+            start = i
+            buf = []
+            while True:
+                j = value.find('"', i)
+                if j == -1:
+                    # never found a closing quote
+                    raise RrParseError()
+                if value[j - 1] == '\\':
+                    # it was an escaped quote, keep the " and keep looking
+                    # for the real closing quote
+                    buf.append(value[start : j - 1])
+                    buf.append('"')
+                    i = j + 1
+                    start = i
+                else:
+                    # found our closing quote
+                    buf.append(value[start:j])
+                    i = j + 1
+                    break
+            yield True, ''.join(buf)
+        else:
+            # unquoted character-string, run until whitespace or a quote
+            start = i
+            while i < n and not value[i].isspace() and value[i] != '"':
+                i += 1
+            yield False, value[start:i]
+
+
 class _ChunkedValuesMixin(ValuesMixin):
     CHUNK_SIZE = 255
 
     def chunked_value(self, value):
-        value = value.replace('"', '\\"')
-        vs = []
-        i = 0
-        n = len(value)
-        # until we've processed the whole string
-        while i < n:
-            # start with a full chunk size
-            c = min(self.CHUNK_SIZE, n - i)
-            # make sure that we don't break on escape chars
-            while value[i + c - 1] == '\\':
-                c -= 1
-            # we have our chunk now
-            vs.append(value[i : i + c])
-            # and can step over if
-            i += c
-        vs = '" "'.join(vs)
-        return self._value_type(f'"{vs}"')
+        # compat shim for external callers, re-wrap the quoted/chunked
+        # text in _value_type so it still behaves like the value types
+        # they're used to working with
+        chunked = self._value_type(value).chunked(self.CHUNK_SIZE)
+        return self._value_type(chunked)
 
     @property
     def chunked_values(self):
-        values = []
-        for v in self.values:
-            values.append(self.chunked_value(v))
-        return values
-
-    @property
-    def rr_values(self):
-        return self.chunked_values
+        return [self.chunked_value(v) for v in self.values]
 
 
 class _ChunkedValue(str):
     VALIDATORS = [chunked_value_validator]
 
+    # default chunk size used by rdata_text, distinct from
+    # _ChunkedValuesMixin.CHUNK_SIZE which providers/tests may override
+    CHUNK_SIZE = 255
+
     @classmethod
     def parse_rdata_text(cls, value):
-        try:
-            return value.replace(';', '\\;')
-        except AttributeError:
+        if not isinstance(value, str) or not value:
             return value
+        if isinstance(value, cls):
+            # already parsed/processed, nothing to do
+            return value
+
+        tokens = list(_tokenize(value))
+        if not tokens:
+            # nothing but whitespace
+            return cls('')
+        elif len(tokens) == 1:
+            # a single character-string, quoted or not, is unambiguous
+            text = tokens[0][1]
+        elif all(is_quoted for is_quoted, _ in tokens):
+            # multiple quoted character-strings, e.g. a previously chunked
+            # value, concatenate them to reconstruct the original value
+            text = ''.join(text for _, text in tokens)
+        else:
+            # multiple unquoted, and/or a mix of quoted & unquoted,
+            # character-strings are ambiguous to concatenate without
+            # loss, we don't guess
+            raise RrParseError()
+
+        return cls(_escape_unescaped_semicolons(text))
 
     @classmethod
     def _schema(cls):
@@ -110,14 +175,44 @@ class _ChunkedValue(str):
     def process(cls, values):
         ret = []
         for v in values:
+            if isinstance(v, cls):
+                # already processed, e.g. round-tripping through
+                # record.data, leave it alone
+                ret.append(v)
+                continue
             if v and v[0] == '"':
                 v = v[1:-1]
             ret.append(cls(v.replace('" "', '')))
         return ret
 
+    def chunked(self, chunk_size=None):
+        if chunk_size is None:
+            chunk_size = self.CHUNK_SIZE
+        value = self.replace('"', '\\"')
+        vs = []
+        i = 0
+        n = len(value)
+        # until we've processed the whole string
+        while i < n:
+            # start with a full chunk size
+            c = min(chunk_size, n - i)
+            # make sure that we don't break on escape chars
+            while value[i + c - 1] == '\\':
+                c -= 1
+            # we have our chunk now
+            vs.append(value[i : i + c])
+            # and can step over it
+            i += c
+        vs = '" "'.join(vs)
+        # a plain str, not self.__class__: this is presentation-format
+        # rdata text, not an internal/processed value, and returning cls
+        # here would make parse_rdata_text's already-processed shortcut
+        # misfire on it
+        return f'"{vs}"'
+
     @property
     def rdata_text(self):
-        return self
+        return self.chunked()
 
     def template(self, params):
         if '{' not in self:

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -10,6 +10,7 @@ from os import listdir
 from os.path import join
 
 from ..record import Record
+from ..record.chunked import _ChunkedValuesMixin, _escape_unescaped_semicolons
 from .base import BaseSource
 
 
@@ -340,7 +341,15 @@ class TinyDnsBaseSource(BaseSource):
             ttl = self._ttl_for(lines, 3)
 
             rdatas = [l[2] for l in lines]
-            yield _type, name, ttl, _class.parse_rdata_texts(rdatas)
+            if issubclass(_class, _ChunkedValuesMixin):
+                # tinydns rdata isn't RFC 1035 presentation format, e.g. it
+                # isn't quoted, so it can't go through the strict
+                # parse_rdata_text, just escape any unescaped ; and use it
+                # as-is
+                values = [_escape_unescaped_semicolons(r) for r in rdatas]
+            else:
+                values = _class.parse_rdata_texts(rdatas)
+            yield _type, name, ttl, values
 
     def _records_for_six(self, zone, name, lines, arpa=False):
         # 6fqdn:ip:ttl:timestamp:lo

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -38,39 +38,72 @@ class TestRecordChunked(TestCase):
             _ChunkedValue.parse_rdata_text('"has \\"quotes\\" here"'),
         )
 
-        # semi-colons are escaped, whether quoted or not
+        # semi-colons inside quotes are escaped (marked) per octoDNS's own
+        # convention -- RFC-wise a bare ; needs no escaping inside quotes,
+        # this is purely octoDNS's internal representation
         self.assertEqual(
             'Hello\\; World!', _ChunkedValue.parse_rdata_text('"Hello; World!"')
         )
+        # an unquoted, already backslash-escaped ; is valid RFC 1035
+        # presentation format too (a bare \X escape), and is unambiguous
         self.assertEqual(
-            'Hello\\;World!', _ChunkedValue.parse_rdata_text('Hello;World!')
+            'Hello\\;World!', _ChunkedValue.parse_rdata_text('Hello\\;World!')
         )
         # already escaped semi-colons are left alone, not double-escaped
         self.assertEqual(
             'Hello\\; World!',
             _ChunkedValue.parse_rdata_text('"Hello\\; World!"'),
         )
+        # a *bare*, unescaped, unquoted ; is zone-file comment syntax and
+        # truncates everything after it -- standard presentation-format
+        # behavior, not something we work around
+        self.assertEqual(
+            'Hello', _ChunkedValue.parse_rdata_text('Hello;World!')
+        )
 
-        # nothing but whitespace tokenizes to nothing
-        self.assertEqual('', _ChunkedValue.parse_rdata_text('   '))
+        # multiple bare (unquoted) tokens, and mixes of quoted & unquoted
+        # tokens, are simply concatenated -- this is standard RFC 1035
+        # multi-character-string handling, not something we need to guess
+        # about or reject
+        self.assertEqual(
+            'HelloWorld!', _ChunkedValue.parse_rdata_text('Hello World!')
+        )
+        self.assertEqual('quoted', _ChunkedValue.parse_rdata_text('"quo" ted'))
 
         # already-processed values pass straight through
         already = TxtValue('some.target.')
         self.assertIs(already, TxtValue.parse_rdata_text(already))
 
-        # multiple unquoted tokens are ambiguous to concatenate, we don't
-        # guess
-        with self.assertRaises(RrParseError):
-            _ChunkedValue.parse_rdata_text('Hello; World!')
+        # a literal backslash: escaped correctly on the way out, and
+        # correctly unescaped (not doubled) on the way back in -- this used
+        # to raise RrParseError (trailing backslash before a real closing
+        # quote) or silently double the backslash (mid-string), depending
+        # on position
+        for content in ('a\\z', 'a\\', 'a\\\\z', 'a\\\\'):
+            rdata = TxtValue(content).rdata_text
+            self.assertEqual(content, _ChunkedValue.parse_rdata_text(rdata))
 
-        # mixing quoted & unquoted tokens is likewise ambiguous
+        # control characters round-trip via dnspython's \DDD decimal-octet
+        # escapes -- previously not decoded at all (stored as literal
+        # garbage), and not escaped on the way out (which would produce
+        # invalid presentation text, e.g. dnspython itself refuses to parse
+        # a raw embedded newline)
+        for content in ('a\tb', 'a\nb', 'a\x00b', 'a\x7fb'):
+            rdata = TxtValue(content).rdata_text
+            self.assertEqual(content, _ChunkedValue.parse_rdata_text(rdata))
+
+        # nothing but whitespace isn't valid presentation-format text
         with self.assertRaises(RrParseError):
-            _ChunkedValue.parse_rdata_text('"quo" ted')
+            _ChunkedValue.parse_rdata_text('   ')
 
         # unterminated quoted string
         for value in ('"no closing quote', '"no closing \\" quote either'):
             with self.assertRaises(RrParseError):
                 _ChunkedValue.parse_rdata_text(value)
+
+        # a single character-string over the 255 byte RFC limit
+        with self.assertRaises(RrParseError):
+            _ChunkedValue.parse_rdata_text('"' + ('x' * 256) + '"')
 
         # since we're always a string validate and __init__ don't
         # parse_rdata_text
@@ -149,7 +182,11 @@ class TestChunkedValue(TestCase):
             super().__init__(None, None, {'values': values})
 
     def test_splitting(self):
-
+        # chunk boundaries are computed on the raw/unmarked byte content
+        # (matching the true RFC 255-byte-per-character-string limit), not
+        # on octoDNS's marker-inflated internal string, so a \; marker
+        # shifts the split point by one byte relative to counting the
+        # marker's characters directly
         for value, expected in (
             # shorter
             ('0123', '"0123"'),
@@ -160,19 +197,21 @@ class TestChunkedValue(TestCase):
             # 1 extra
             ('012345678', '"01234567" "8"'),
             # escape in the middle
-            ('01234\\;56789', '"01234\\;5" "6789"'),
+            ('01234\\;56789', '"01234\\;56" "789"'),
             # escape before the boundary
-            ('012345\\;6789', '"012345\\;" "6789"'),
+            ('012345\\;6789', '"012345\\;6" "789"'),
             # escape after the boundary
             ('01234567\\;89', '"01234567" "\\;89"'),
             # escape spanning the boundary
-            ('0123456\\;789', '"0123456" "\\;789"'),
+            ('0123456\\;789', '"0123456\\;" "789"'),
             # multiple escapes at the boundary
-            ('012345\\\\;6789', '"012345" "\\\\;6789"'),
+            ('012345\\\\;6789', '"012345\\\\;" "6789"'),
             # exact size escape
             ('012345\\;', '"012345\\;"'),
             # spanning ending
-            ('0123456\\;', '"0123456" "\\;"'),
+            ('0123456\\;', '"0123456\\;"'),
+            # a literal quote near the boundary
+            ('0123456"89', '"0123456\\"" "89"'),
         ):
             sc = self.SmallerChunkedMixin(value)
             self.assertEqual([expected], sc.chunked_values)
@@ -198,6 +237,11 @@ class TestChunkedValue(TestCase):
         for v in ('hello world', 'hello  world', ' leading space'):
             self.assertEqual([v], TxtValue.process([v]))
 
+        # a missing (None) value is left as None rather than being coerced
+        # into the literal string "None" -- reachable via lenient=True
+        # construction of an already-invalid record
+        self.assertEqual([None], TxtValue.process([None]))
+
         # a fully quoted string has its outer quotes removed
         self.assertEqual(['hello world'], TxtValue.process(['"hello world"']))
 
@@ -205,6 +249,26 @@ class TestChunkedValue(TestCase):
         self.assertEqual(
             ['hello world'], TxtValue.process(['"hello" " world"'])
         )
+
+        # a quoted string with escaped quotes inside it is properly
+        # unescaped, not just naively stripped of its outer quotes
+        self.assertEqual(
+            ['has "embedded" quotes'],
+            TxtValue.process(['"has \\"embedded\\" quotes"']),
+        )
+
+        # a quote not in the leading position isn't treated as quoted at
+        # all, left completely as-is
+        self.assertEqual(
+            ['has a " in the middle'],
+            TxtValue.process(['has a " in the middle']),
+        )
+
+        # quoted-looking input that doesn't actually parse (unterminated
+        # quote) falls back to being used as-typed rather than raising --
+        # process() is the lenient YAML path, validators are the real gate
+        # for malformed data
+        self.assertEqual(['"unterminated'], TxtValue.process(['"unterminated']))
 
         # values that are already TxtValue instances, e.g. round-tripping
         # through record.data, are left untouched rather than re-processed
@@ -220,3 +284,25 @@ class TestChunkedValue(TestCase):
 
         # an explicit chunk_size overrides it
         self.assertEqual('"01234567" "89"', value.chunked(8))
+
+    def test_rdata_text_escaping(self):
+        # a literal backslash is escaped, matching real RFC 1035
+        # presentation-format output (verified against dnspython) -- this
+        # used to be left completely unescaped, which a real consumer would
+        # misinterpret as escaping the following character
+        self.assertEqual('"a\\\\b"', _ChunkedValue('a\\b').rdata_text)
+
+        # control characters are escaped with \DDD decimal-octet escapes,
+        # matching dnspython's own convention -- previously left raw, which
+        # for a literal embedded newline dnspython itself refuses to parse
+        # back (SyntaxError: newline in quoted string)
+        self.assertEqual('"a\\009b"', _ChunkedValue('a\tb').rdata_text)
+        self.assertEqual('"a\\010b"', _ChunkedValue('a\nb').rdata_text)
+        self.assertEqual('"a\\000b"', _ChunkedValue('a\x00b').rdata_text)
+
+        # a literal quote is still escaped as before
+        self.assertEqual('"a\\"b"', _ChunkedValue('a"b').rdata_text)
+
+        # an already-marked semi-colon renders as-is (still marked), not
+        # bare and not double-escaped
+        self.assertEqual('"a\\;b"', _ChunkedValue('a\\;b').rdata_text)

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 from octodns.record.base import _process_value_validators
 from octodns.record.chunked import _ChunkedValue, _ChunkedValuesMixin
+from octodns.record.rr import RrParseError
 from octodns.record.spf import SpfRecord
 from octodns.record.txt import TxtValue
 from octodns.zone import Zone
@@ -13,32 +14,70 @@ from octodns.zone import Zone
 
 class TestRecordChunked(TestCase):
     def test_chunked_value_rdata_text(self):
-        for s in (
-            None,
-            '',
-            'word',
-            42,
-            42.43,
-            '1.2.3',
-            'some.words.that.here',
-            '1.2.word.4',
-            '1.2.3.4',
-            # quotes are not removed
-            '"Hello World!"',
-        ):
+        # non-strings, and empty/falsy values, pass through untouched
+        for s in (None, '', 42, 42.43):
             self.assertEqual(s, _ChunkedValue.parse_rdata_text(s))
 
-        # semi-colons are escaped
+        # a single unquoted token is unambiguous, no quoting needed
+        for s in ('word', '1.2.3', '1.2.word.4', '1.2.3.4'):
+            self.assertEqual(s, _ChunkedValue.parse_rdata_text(s))
+
+        # quotes are removed
         self.assertEqual(
-            'Hello\\; World!', _ChunkedValue.parse_rdata_text('Hello; World!')
+            'Hello World!', _ChunkedValue.parse_rdata_text('"Hello World!"')
         )
+
+        # multiple quoted character-strings are concatenated/dechunked
+        self.assertEqual(
+            'HelloWorld!', _ChunkedValue.parse_rdata_text('"Hello" "World!"')
+        )
+
+        # escaped double quotes are unescaped
+        self.assertEqual(
+            'has "quotes" here',
+            _ChunkedValue.parse_rdata_text('"has \\"quotes\\" here"'),
+        )
+
+        # semi-colons are escaped, whether quoted or not
+        self.assertEqual(
+            'Hello\\; World!', _ChunkedValue.parse_rdata_text('"Hello; World!"')
+        )
+        self.assertEqual(
+            'Hello\\;World!', _ChunkedValue.parse_rdata_text('Hello;World!')
+        )
+        # already escaped semi-colons are left alone, not double-escaped
+        self.assertEqual(
+            'Hello\\; World!',
+            _ChunkedValue.parse_rdata_text('"Hello\\; World!"'),
+        )
+
+        # nothing but whitespace tokenizes to nothing
+        self.assertEqual('', _ChunkedValue.parse_rdata_text('   '))
+
+        # already-processed values pass straight through
+        already = TxtValue('some.target.')
+        self.assertIs(already, TxtValue.parse_rdata_text(already))
+
+        # multiple unquoted tokens are ambiguous to concatenate, we don't
+        # guess
+        with self.assertRaises(RrParseError):
+            _ChunkedValue.parse_rdata_text('Hello; World!')
+
+        # mixing quoted & unquoted tokens is likewise ambiguous
+        with self.assertRaises(RrParseError):
+            _ChunkedValue.parse_rdata_text('"quo" ted')
+
+        # unterminated quoted string
+        for value in ('"no closing quote', '"no closing \\" quote either'):
+            with self.assertRaises(RrParseError):
+                _ChunkedValue.parse_rdata_text(value)
 
         # since we're always a string validate and __init__ don't
         # parse_rdata_text
 
         zone = Zone('unit.tests.', [])
         a = SpfRecord(zone, 'a', {'ttl': 42, 'value': 'some.target.'})
-        self.assertEqual('some.target.', a.values[0].rdata_text)
+        self.assertEqual('"some.target."', a.values[0].rdata_text)
 
 
 class TestChunkedValue(TestCase):
@@ -152,3 +191,32 @@ class TestChunkedValue(TestCase):
         got = value.template({'needle': 42})
         self.assertIsNot(value, got)
         self.assertEqual('this.does.42.have.templating.', got)
+
+    def test_process(self):
+        # plain/unquoted strings pass through as-is, unstripped, matching
+        # the lenient handling of user-authored YAML values
+        for v in ('hello world', 'hello  world', ' leading space'):
+            self.assertEqual([v], TxtValue.process([v]))
+
+        # a fully quoted string has its outer quotes removed
+        self.assertEqual(['hello world'], TxtValue.process(['"hello world"']))
+
+        # multiple quoted chunks are dechunked
+        self.assertEqual(
+            ['hello world'], TxtValue.process(['"hello" " world"'])
+        )
+
+        # values that are already TxtValue instances, e.g. round-tripping
+        # through record.data, are left untouched rather than re-processed
+        already = TxtValue('"still quoted"')
+        self.assertEqual([already], TxtValue.process([already]))
+        self.assertIs(already, TxtValue.process([already])[0])
+
+    def test_chunked_custom_size(self):
+        # .chunked() defaults to the class-level CHUNK_SIZE
+        value = _ChunkedValue('0123456789')
+        self.assertEqual('"0123456789"', value.chunked(255))
+        self.assertEqual('"0123456789"', value.rdata_text)
+
+        # an explicit chunk_size overrides it
+        self.assertEqual('"01234567" "89"', value.chunked(8))

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -174,8 +174,8 @@ class TestRecordTxt(TestCase):
         )
         vals = [
             '"before"',
-            '"v=DKIM1\\; h=sha256\\; k=rsa\\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH" '
-            '"2s9a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB"',
+            '"v=DKIM1\\; h=sha256\\; k=rsa\\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH2s9" '
+            '"a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB"',
             '"z after"',
         ]
         self.assertEqual(('txt.unit.tests.', 42, 'TXT', vals), record.rrs)
@@ -191,6 +191,14 @@ class TestRecordTxt(TestCase):
             'has "quote" in it',
             'v=spf1 include:_spf.example.com ~all',
             'a' * 254 + '\\;' + 'b' * 10,
+            # a literal backslash -- used to raise or get doubled depending
+            # on where it fell relative to a chunk/quote boundary
+            'a\\b',
+            'a\\',
+            # control characters -- used to be left completely unescaped,
+            # which real RFC consumers (dnspython/BIND) can't parse back
+            'a\tb',
+            'a\nb',
         ):
             record = Record.new(
                 zone, 'txt', {'ttl': 32, 'type': 'TXT', 'value': value}

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
+from octodns.record.rr import Rr
 from octodns.record.txt import TxtRecord
 from octodns.zone import Zone
 
@@ -178,3 +179,25 @@ class TestRecordTxt(TestCase):
             '"z after"',
         ]
         self.assertEqual(('txt.unit.tests.', 42, 'TXT', vals), record.rrs)
+
+    def test_rrs_round_trip(self):
+        # values that should survive a full rrs -> from_rrs round-trip,
+        # including the ; and " cases that used to get corrupted
+        zone = Zone('unit.tests.', [])
+        for value in (
+            'foo bar',
+            'a' * 300,
+            'has \\; semi',
+            'has "quote" in it',
+            'v=spf1 include:_spf.example.com ~all',
+            'a' * 254 + '\\;' + 'b' * 10,
+        ):
+            record = Record.new(
+                zone, 'txt', {'ttl': 32, 'type': 'TXT', 'value': value}
+            )
+            fqdn, ttl, _type, rdatas = record.rrs
+            rrs = [Rr(fqdn, _type, ttl, rdata) for rdata in rdatas]
+            (roundtripped,) = Record.from_rrs(zone, rrs)
+            self.assertEqual(
+                record.values, roundtripped.values, msg=repr(value)
+            )

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -17,7 +17,7 @@ class TestTinyDnsFileSource(TestCase):
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)
-        self.assertEqual(30, len(got.records))
+        self.assertEqual(31, len(got.records))
 
         expected = Zone('example.com.', [])
         for name, data in (
@@ -197,6 +197,14 @@ class TestTinyDnsFileSource(TestCase):
                 },
             ),
             ('arbitrary-a', {'type': 'A', 'ttl': 3600, 'value': '80.81.82.83'}),
+            (
+                'arbitrary-txt',
+                {
+                    'type': 'TXT',
+                    'ttl': 3600,
+                    'value': 'v=DKIM1\\; k=rsa\\; p=blah',
+                },
+            ),
         ):
             record = Record.new(expected, name, data)
             expected.add_record(record)
@@ -273,4 +281,4 @@ class TestTinyDnsFileSource(TestCase):
         got = Zone('example.com.', ['sub'])
         self.source.populate(got)
         # we don't see one www.sub.example.com. record b/c it's in a sub
-        self.assertEqual(29, len(got.records))
+        self.assertEqual(30, len(got.records))

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -78,5 +78,8 @@ S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999
 :arbitrary-sshfp.example.com:SSHFP:1 1 000000000000000000000000000000000047b270:45
 # does not make sense to do an A this way, but it'll work
 :arbitrary-a.example.com:a:80.81.82.83
+# tinydns rdata isn't RFC 1035 presentation format (unquoted), unescaped ;
+# should get escaped rather than parsed as RFC character-strings
+:arbitrary-txt.example.com:TXT:v=DKIM1; k=rsa; p=blah
 # this should just be inored b/c the type is unknown
 :arbitrary-invalid.example.com:invalid:does not matter:99


### PR DESCRIPTION
## Summary

`rdata_text` for TXT/SPF now returns properly quoted, chunked RFC 1035 presentation-format text like every other record type, and `parse_rdata_text` correctly parses that format back into the internal value.

**Presentation-format parsing/rendering (quoting, 255-byte-per-character-string chunking, `\"`/`\\`/`\DDD` escaping) is delegated to dnspython** rather than hand-rolled. dnspython is already a hard core dependency of octodns (`pyproject.toml`, already imported directly elsewhere in the codebase), and a from-scratch tokenizer/escaper turned up real bugs a from-scratch implementation didn't need to have:

- It misparsed (raised on) valid content ending in a literal backslash before a closing quote.
- It never escaped a literal backslash or control bytes on output — for an embedded newline this produces presentation text that dnspython itself can't parse back (`SyntaxError: newline in quoted string`), so a real `octodns-bind` zone file written from such a value would be broken.
- It never decoded `\DDD` octet escapes on input (dnspython's own form for any control/non-ASCII byte), storing them as literal garbage instead.

octoDNS's own pre-existing convention of marking a literal `;` internally as `\;` (unrelated to RFC 1035, enforced by `ChunkedValueValidator`) stays as a small, separate step layered on top of dnspython's parsing/rendering, applied only at the fully-raw-content boundary.

Confirmed via direct round-trip testing against real dnspython output, including every case that was previously broken:
```
'has \; semi'       ->  '"has \; semi"'          -> 'has \; semi'      OK
'has "quote" in it' ->  '"has \"quote\" in it"'   -> OK
'a\b' (1 backslash) ->  '"a\\b"'                  -> 'a\b'             OK  (was: RrParseError)
'a\tb'               -> '"a\009b"'                -> 'a\tb'            OK  (was: silently unescaped)
'a\nb'               -> '"a\010b"'                -> 'a\nb'            OK  (was: raw newline, breaks octodns-bind)
```

- `record.rrs` output is byte-identical to before for ordinary values (no `;`/`"`/`\`/control bytes); `chunked_value()`/`chunked_values` compat shims are preserved so `octodns-route53`, `-cloudflare`, `-googlecloud`, `-constellix`, and `-hetzner` need no changes.
- One behavior change: TXT chunk boundaries near 255 bytes are now computed on the true raw content length rather than octoDNS's marker-inflated internal string, so a value with a `;` right at the boundary now splits a byte or two later than before — the more RFC-correct point.
- `ValueAllowlistFilter`/`ValueRejectlistFilter` keep matching on the raw value for TXT/SPF (str-subclass values) rather than the now-quoted `rdata_text`, so existing user configs don't break.
- `TinyDnsFileSource`'s generic `:`-line path escapes unquoted tinydns rdata directly instead of running it through dnspython's presentation-format parser, since tinydns rdata isn't presentation format (and a bare `;` there would be misread as a zone-file comment).

/cc #1447 addresses the TXT half of this issue; CAA was addressed separately in #1449 (merged)
/cc will need a companion `octodns-bind` PR to drop its now-redundant `chunked_value()` call in `ZoneFileSource._apply`, which would otherwise double-quote

## Test plan

- [x] `./script/test` - 811 passed
- [x] `./script/coverage` - 100% line + branch coverage
- [x] `./script/lint` / `./script/format --check` - clean
- [x] `rrs` -> `from_rrs` round-trip tests covering `;`, `"`, literal `\`, and control characters
- [x] Manually verified round-trips against real dnspython-generated rdata, including the full matrix above and a >255-byte chunked value