### PR TITLE
Add uniform value-level RDATA conversion APIs

### DIFF
--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -18,7 +18,8 @@ ordering. The new RRset conversion APIs reject extra values for single-value
 records and report unregistered types with `RecordException`, while deprecated
 `Record.from_rrs()` retains its legacy first-value behavior.
 Raw TXT/SPF provider text is normalized with the explicit
-`TxtValue.normalize_raw_text()` helper, and provider migration guidance now
-distinguishes raw text from RDATA presentation text. The MRO-aware
+`TxtValue.normalize_raw_text()` helper and rendered with its inverse,
+`value.to_raw_text()`, and provider migration guidance now distinguishes raw
+text from RDATA presentation text. The MRO-aware
 `value_to_rdata_text()` and `value_from_rdata_text()` compatibility dispatchers
 are available from `octodns.record` for third-party processors and providers.

--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add uniform value-level RDATA conversion APIs

--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -5,4 +5,5 @@ Add `to_rdata_text()`/`from_rdata_text()` value conversion APIs and
 `Record.to_rrset()`/`Record.from_rrset()`/`Record.from_rrsets()` record
 conversion APIs with the grouped `Rrset` carrier. Preserve and deprecate the
 1.x `rdata_text`, `parse_rdata_text()`, `record.rrs`, `Record.from_rrs()`, and
-`Rr` compatibility APIs for removal in 2.0.
+`Rr` compatibility APIs for removal in 2.0, and rename `RrParseError` to
+`RdataParseError` while retaining the old name as a 1.x compatibility alias.

--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -7,3 +7,9 @@ conversion APIs with the grouped `Rrset` carrier. Preserve and deprecate the
 1.x `rdata_text`, `parse_rdata_text()`, `record.rrs`, `Record.from_rrs()`, and
 `Rr` compatibility APIs for removal in 2.0, and rename `RrParseError` to
 `RdataParseError` while retaining the old name as a 1.x compatibility alias.
+TXT/SPF conversion preserves ambiguous unquoted multi-token legacy raw values,
+normalizes presentation parsing failures to `RdataParseError`, and uses fixed
+255-octet chunking in the new API. The record-level chunking hooks remain
+available only for the deprecated `record.rrs` path, and lenient non-ASCII
+round-tripping is guaranteed only when every emitted UTF-8 character-string
+fits the DNS 255-octet limit.

--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -13,3 +13,7 @@ normalizes presentation parsing failures to `RdataParseError`, and uses fixed
 available only for the deprecated `record.rrs` path, and lenient non-ASCII
 round-tripping is guaranteed only when every emitted UTF-8 character-string
 fits the DNS 255-octet limit.
+`Rrset` now validates its RDATA collection and supports full equality and
+ordering. The new RRset conversion APIs reject extra values for single-value
+records and report unregistered types with `RecordException`, while deprecated
+`Record.from_rrs()` retains its legacy first-value behavior.

--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -1,4 +1,8 @@
 ---
 type: minor
 ---
-Add uniform value-level RDATA conversion APIs
+Add `to_rdata_text()`/`from_rdata_text()` value conversion APIs and
+`Record.to_rrset()`/`Record.from_rrset()`/`Record.from_rrsets()` record
+conversion APIs with the grouped `Rrset` carrier. Preserve and deprecate the
+1.x `rdata_text`, `parse_rdata_text()`, `record.rrs`, `Record.from_rrs()`, and
+`Rr` compatibility APIs for removal in 2.0.

--- a/.changelog/143c8364c9914b0f902f3c524270ee79.md
+++ b/.changelog/143c8364c9914b0f902f3c524270ee79.md
@@ -17,3 +17,8 @@ fits the DNS 255-octet limit.
 ordering. The new RRset conversion APIs reject extra values for single-value
 records and report unregistered types with `RecordException`, while deprecated
 `Record.from_rrs()` retains its legacy first-value behavior.
+Raw TXT/SPF provider text is normalized with the explicit
+`TxtValue.normalize_raw_text()` helper, and provider migration guidance now
+distinguishes raw text from RDATA presentation text. The MRO-aware
+`value_to_rdata_text()` and `value_from_rdata_text()` compatibility dispatchers
+are available from `octodns.record` for third-party processors and providers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -337,9 +337,9 @@ Processors
    * - `NameRejectlistFilter`_
      - Filter that IGNORES records that match specified naming patterns, all others will be managed
    * - `ValueAllowlistFilter`_
-     - Filter that ONLY manages records that match specified value patterns based on `rdata_text`, all others will be ignored
+     - Filter that ONLY manages records whose RDATA presentation text, as returned by ``to_rdata_text()``, matches specified value patterns; all others will be ignored
    * - `ValueRejectlistFilter`_
-     - Filter that IGNORES records that match specified value patterns based on `rdata_text`, all others will be managed
+     - Filter that IGNORES records whose RDATA presentation text, as returned by ``to_rdata_text()``, matches specified value patterns; all others will be managed
    * - `OwnershipProcessor`_
      - Processor that implements ownership in octoDNS so that it can manage only the records in a zone in sources and will ignore all others.
    * - `SpfDnsLookupProcessor`_

--- a/docs/records.rst
+++ b/docs/records.rst
@@ -130,7 +130,11 @@ Use named attributes on :py:class:`octodns.record.rr.Rrset`; do not apply the
 legacy tuple's positional access pattern to it. The singular
 :py:class:`octodns.record.rr.Rr` carrier and
 :py:meth:`octodns.record.base.Record.from_rrs` are likewise compatibility APIs
-scheduled for removal in octoDNS 2.0.
+scheduled for removal in octoDNS 2.0. The old
+:py:class:`octodns.record.rr.RrParseError` name remains as a deprecated,
+identity-preserving alias for
+:py:class:`octodns.record.rr.RdataParseError` throughout 1.x and will also be
+removed in 2.0.
 
 Advanced Record Support
 -----------------------

--- a/docs/records.rst
+++ b/docs/records.rst
@@ -54,7 +54,31 @@ TXT and SPF need an additional compatibility rule because their legacy
 tokens, it treats the original input as raw text and preserves its spaces.
 Quoted or mixed quoted/unquoted input follows DNS presentation semantics and
 its character-strings concatenate. Providers that already know they have raw
-TXT/SPF text should use ``ValueType.from_raw()`` explicitly.
+TXT/SPF text should use ``TxtValue.normalize_raw_text()`` explicitly. The
+method returns normalized internal text suitable for constructing either TXT
+or SPF records.
+
+Provider migration follows the input representation rather than a mechanical
+method rename:
+
+.. list-table:: Value parsing migration
+   :header-rows: 1
+
+   * - Existing input
+     - Replacement
+   * - Non-TXT/SPF ``ValueType.parse_rdata_text(rdata)``
+     - ``ValueType.from_rdata_text(rdata)``
+   * - Raw or unescaped TXT/SPF provider text
+     - ``TxtValue.normalize_raw_text(value)``
+   * - TXT/SPF RDATA presentation text
+     - ``TxtValue.from_rdata_text(rdata)``
+
+Generic processors and provider utilities should import
+``value_to_rdata_text()`` and ``value_from_rdata_text()`` from
+``octodns.record``. These public helpers select new or legacy value methods by
+their defining position in the value type's MRO, allowing callers to support
+third-party value types during the 1.x migration without implementing that
+dispatch themselves.
 
 New-style TXT/SPF values always render with the value-level conversion's
 255-octet chunk limit. The record-level ``CHUNK_SIZE``, ``chunked_value()``,

--- a/docs/records.rst
+++ b/docs/records.rst
@@ -72,7 +72,12 @@ one grouped :py:class:`octodns.record.rr.Rrset`. An ``Rrset`` has named
 ``name``, ``_type``, ``ttl``, and ``rdatas`` attributes. The owner name, type,
 and TTL apply to every element of ``rdatas``, and each element must be a
 Python ``str`` containing one RDATA value in presentation format. DNS class is
-not stored; octoDNS assumes the Internet (``IN``) class.
+not stored; octoDNS assumes the Internet (``IN``) class. Construction rejects
+a string or non-iterable ``rdatas`` container, an empty collection, and
+non-string elements with
+:py:class:`octodns.record.exception.RecordException`. ``Rrset`` objects
+support equality and ordering across their name, type, TTL, and ordered RDATA
+values.
 
 :py:meth:`octodns.record.base.Record.from_rrset` performs the singular inverse
 and returns one :py:class:`octodns.record.base.Record`.
@@ -82,7 +87,9 @@ ordered deterministically by owner name and type. An empty iterable returns an
 empty list. Otherwise, bulk input may contain at most one ``Rrset`` for each
 owner-name/type pair; duplicates raise
 :py:class:`octodns.record.exception.RecordException`. An ``Rrset`` with no
-RDATA values is also rejected with ``RecordException``.
+RDATA values is also rejected with ``RecordException``. Single-value record
+types, such as CNAME, require exactly one RDATA value. Unregistered record
+types likewise raise ``RecordException`` rather than leaking ``KeyError``.
 
 Both inverse methods pass ``lenient`` through record construction and attach
 ``source`` to every record they create. The deprecated compatibility entry
@@ -151,9 +158,11 @@ Use named attributes on :py:class:`octodns.record.rr.Rrset`; do not apply the
 legacy tuple's positional access pattern to it. The singular
 :py:class:`octodns.record.rr.Rr` carrier and
 :py:meth:`octodns.record.base.Record.from_rrs` are likewise compatibility APIs
-scheduled for removal in octoDNS 2.0. The old
-:py:class:`octodns.record.rr.RrParseError` name remains as a deprecated,
-identity-preserving alias for
+scheduled for removal in octoDNS 2.0. Unlike the new RRset APIs,
+``Record.from_rrs()`` retains its legacy behavior of using the first RDATA
+value for a single-value record. The old
+:py:class:`octodns.record.rr.RrParseError` name remains as an
+identity-preserving compatibility alias for
 :py:class:`octodns.record.rr.RdataParseError` throughout 1.x and will also be
 removed in 2.0.
 

--- a/docs/records.rst
+++ b/docs/records.rst
@@ -16,6 +16,122 @@ Adding new record types to octoDNS is relatively straightforward, but will
 require careful evaluation of each provider to determine whether or not it will
 be supported and the addition of code in each to handle and test the new type.
 
+Internal and RDATA formats
+--------------------------
+
+octoDNS uses two distinct text representations at its configuration/provider
+boundary:
+
+* **octoDNS internal format** is the data accepted from configuration and
+  exposed by record and value objects. Text in this format is represented by
+  Python Unicode strings and may use octoDNS-specific normalization. For
+  example, TXT and SPF values internally escape semicolons.
+* **RDATA presentation format** is the master-file-style text for the RDATA
+  portion of one DNS resource record. Its quoting, escaping, field layout, and
+  chunking follow the RFC for that record type.
+
+RDATA presentation text is not a complete master-file record: it omits the
+owner name, TTL, class, and record type. It is also not the binary octets used
+by DNS wire format. For example, ``192.0.2.1`` is the RDATA presentation text
+within the complete master-file record
+``www.example.com. 300 IN A 192.0.2.1``.
+
+Value conversion
+................
+
+Each RDATA value type provides ``to_rdata_text()`` and
+``from_rdata_text()``. ``value.to_rdata_text()`` converts an octoDNS value
+object to one Python ``str`` containing one RDATA value in presentation
+format. ``ValueType.from_rdata_text(rdata)`` accepts one such ``str`` and
+returns octoDNS internal data suitable for constructing that value type.
+
+Record conversion
+.................
+
+:py:meth:`octodns.record.base.Record.to_rrset` converts one octoDNS record to
+one grouped :py:class:`octodns.record.rr.Rrset`. An ``Rrset`` has named
+``name``, ``_type``, ``ttl``, and ``rdatas`` attributes. The owner name, type,
+and TTL apply to every element of ``rdatas``, and each element must be a
+Python ``str`` containing one RDATA value in presentation format. DNS class is
+not stored; octoDNS assumes the Internet (``IN``) class.
+
+:py:meth:`octodns.record.base.Record.from_rrset` performs the singular inverse
+and returns one :py:class:`octodns.record.base.Record`.
+:py:meth:`octodns.record.base.Record.from_rrsets` accepts an iterable of
+grouped ``Rrset`` objects and returns multiple records. The bulk result is
+ordered deterministically by owner name and type. An empty iterable returns an
+empty list. Otherwise, bulk input may contain at most one ``Rrset`` for each
+owner-name/type pair; duplicates raise
+:py:class:`octodns.record.exception.RecordException`. An ``Rrset`` with no
+RDATA values is also rejected with ``RecordException``.
+
+Both inverse methods pass ``lenient`` through record construction and attach
+``source`` to every record they create. The deprecated compatibility entry
+points propagate these arguments in the same way.
+
+A provider reading RDATA presentation text can construct records as follows::
+
+  from octodns.record import Record, Rrset
+
+  rrset = Rrset(
+      'www.example.com.',
+      'A',
+      300,
+      ['192.0.2.1', '192.0.2.2'],
+  )
+  record = Record.from_rrset(
+      zone,
+      rrset,
+      lenient=lenient,
+      source=provider,
+  )
+
+A provider writing RDATA presentation text can consume the matching grouped
+carrier::
+
+  rrset = record.to_rrset()
+  provider.write(
+      name=rrset.name,
+      record_type=rrset._type,
+      ttl=rrset.ttl,
+      rdatas=rrset.rdatas,
+  )
+
+Lenient Unicode TXT and SPF values
+++++++++++++++++++++++++++++++++++
+
+Valid TXT and SPF values use ASCII bytes and are split into chunks of at most
+255 octets. When a non-ASCII internal value is deliberately accepted with
+``lenient=True``, octoDNS preserves its historical character-based chunking
+and quoting instead. This compatibility presentation text can be consumed by
+``from_rdata_text()``, which decodes its character-string bytes as UTF-8 so
+the Unicode internal value round-trips. Arbitrary non-UTF-8 character-string
+bytes are not supported because octoDNS's internal value contract is Unicode
+text.
+
+Migrating from ``rrs``
+......................
+
+The deprecated ``record.rrs`` property remains available throughout octoDNS
+1.x, but its plain tuple deliberately has a different positional order from
+the named ``Rrset`` carrier::
+
+  # Legacy tuple: (name, ttl, type, rdatas)
+  name, ttl, record_type, rdatas = record.rrs
+
+  # New carrier: Rrset(name, _type, ttl, rdatas)
+  rrset = record.to_rrset()
+  name = rrset.name
+  record_type = rrset._type
+  ttl = rrset.ttl
+  rdatas = rrset.rdatas
+
+Use named attributes on :py:class:`octodns.record.rr.Rrset`; do not apply the
+legacy tuple's positional access pattern to it. The singular
+:py:class:`octodns.record.rr.Rr` carrier and
+:py:meth:`octodns.record.base.Record.from_rrs` are likewise compatibility APIs
+scheduled for removal in octoDNS 2.0.
+
 Advanced Record Support
 -----------------------
 

--- a/docs/records.rst
+++ b/docs/records.rst
@@ -56,7 +56,10 @@ Quoted or mixed quoted/unquoted input follows DNS presentation semantics and
 its character-strings concatenate. Providers that already know they have raw
 TXT/SPF text should use ``TxtValue.normalize_raw_text()`` explicitly. The
 method returns normalized internal text suitable for constructing either TXT
-or SPF records.
+or SPF records. In the other direction, raw-text providers should call
+``value.to_raw_text()`` on TXT/SPF value objects. This removes octoDNS's
+internal semicolon escaping without adding RDATA presentation-format quoting
+or chunking.
 
 Provider migration follows the input representation rather than a mechanical
 method rename:
@@ -72,6 +75,10 @@ method rename:
      - ``TxtValue.normalize_raw_text(value)``
    * - TXT/SPF RDATA presentation text
      - ``TxtValue.from_rdata_text(rdata)``
+
+For provider writes, use ``value.to_rdata_text()`` when the destination
+expects RDATA presentation text and ``value.to_raw_text()`` when it expects
+raw TXT/SPF text.
 
 Generic processors and provider utilities should import
 ``value_to_rdata_text()`` and ``value_from_rdata_text()`` from

--- a/docs/records.rst
+++ b/docs/records.rst
@@ -44,6 +44,25 @@ Each RDATA value type provides ``to_rdata_text()`` and
 object to one Python ``str`` containing one RDATA value in presentation
 format. ``ValueType.from_rdata_text(rdata)`` accepts one such ``str`` and
 returns octoDNS internal data suitable for constructing that value type.
+Invalid presentation text raises
+:py:class:`octodns.record.rr.RdataParseError`, including TXT/SPF syntax and
+UTF-8 decoding failures.
+
+TXT and SPF need an additional compatibility rule because their legacy
+``parse_rdata_text()`` method accepted raw internal text. When
+``from_rdata_text()`` receives multiple wholly unquoted character-string
+tokens, it treats the original input as raw text and preserves its spaces.
+Quoted or mixed quoted/unquoted input follows DNS presentation semantics and
+its character-strings concatenate. Providers that already know they have raw
+TXT/SPF text should use ``ValueType.from_raw()`` explicitly.
+
+New-style TXT/SPF values always render with the value-level conversion's
+255-octet chunk limit. The record-level ``CHUNK_SIZE``, ``chunked_value()``,
+``chunked_values``, and ``rr_values`` hooks are retained only for the
+deprecated ``record.rrs`` path through octoDNS 1.x and will be removed in 2.0.
+They do not customize ``to_rrset()`` for value types implementing the new
+conversion API. The compatibility dispatcher may still consult ``rr_values``
+when a third-party value type implements only the legacy ``rdata_text`` API.
 
 Record conversion
 .................
@@ -105,9 +124,11 @@ Valid TXT and SPF values use ASCII bytes and are split into chunks of at most
 ``lenient=True``, octoDNS preserves its historical character-based chunking
 and quoting instead. This compatibility presentation text can be consumed by
 ``from_rdata_text()``, which decodes its character-string bytes as UTF-8 so
-the Unicode internal value round-trips. Arbitrary non-UTF-8 character-string
-bytes are not supported because octoDNS's internal value contract is Unicode
-text.
+the Unicode internal value round-trips when every emitted character-string's
+UTF-8 encoding fits within the DNS 255-octet limit. Longer values can retain a
+historical character chunk whose UTF-8 encoding exceeds that limit; conforming
+RDATA parsers reject such output. Arbitrary non-UTF-8 character-string bytes
+are not supported because octoDNS's internal value contract is Unicode text.
 
 Migrating from ``rrs``
 ......................

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -7,6 +7,7 @@ from itertools import product
 from logging import getLogger
 from re import compile as re_compile
 
+from ..record.base import value_to_rrs
 from ..record.exception import ValidationError
 from .base import BaseProcessor
 
@@ -232,9 +233,9 @@ class _ValueBaseFilter(_FilterProcessor):
         for record in zone.records:
             values = []
             if hasattr(record, 'values'):
-                values = [value.rdata_text for value in record.values]
+                values = [value_to_rrs(value) for value in record.values]
             elif record.value is not None:
-                values = [record.value.rdata_text]
+                values = [value_to_rrs(record.value)]
             else:
                 self.log.warning(
                     'value for %s is NoneType, ignoring', record.fqdn

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -7,7 +7,7 @@ from itertools import product
 from logging import getLogger
 from re import compile as re_compile
 
-from ..record.base import value_to_rrs
+from ..record.base import value_to_rdata_text
 from ..record.exception import ValidationError
 from .base import BaseProcessor
 
@@ -233,9 +233,9 @@ class _ValueBaseFilter(_FilterProcessor):
         for record in zone.records:
             values = []
             if hasattr(record, 'values'):
-                values = [value_to_rrs(value) for value in record.values]
+                values = [value_to_rdata_text(value) for value in record.values]
             elif record.value is not None:
-                values = [value_to_rrs(record.value)]
+                values = [value_to_rdata_text(record.value)]
             else:
                 self.log.warning(
                     'value for %s is NoneType, ignoring', record.fqdn

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -7,7 +7,7 @@ from itertools import product
 from logging import getLogger
 from re import compile as re_compile
 
-from ..record.base import value_to_rdata_text
+from ..record import value_to_rdata_text
 from ..record.exception import ValidationError
 from .base import BaseProcessor
 

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -21,7 +21,7 @@ from .naptr import NaptrRecord, NaptrValue
 from .ns import NsRecord, NsValue
 from .openpgpkey import OpenpgpkeyRecord, OpenpgpkeyValue
 from .ptr import PtrRecord, PtrValue
-from .rr import Rr, RrParseError
+from .rr import Rr, RrParseError, Rrset
 from .spf import SpfRecord
 from .srv import SrvRecord, SrvValue
 from .sshfp import SshfpRecord, SshfpValue
@@ -71,6 +71,7 @@ Record
 RecordException
 Rr
 RrParseError
+Rrset
 SpfRecord
 SrvRecord
 SrvValue

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -6,7 +6,13 @@
 from .a import ARecord, Ipv4Address, Ipv4Value
 from .aaaa import AaaaRecord, Ipv6Address, Ipv6Value
 from .alias import AliasRecord, AliasValue
-from .base import Record, ValueMixin, ValuesMixin
+from .base import (
+    Record,
+    ValueMixin,
+    ValuesMixin,
+    value_from_rdata_text,
+    value_to_rdata_text,
+)
 from .caa import CaaRecord, CaaValue
 from .change import Change, Create, Delete, Update
 from .cname import CnameRecord, CnameValue
@@ -67,9 +73,9 @@ OpenpgpkeyRecord
 OpenpgpkeyValue
 PtrRecord
 PtrValue
+RdataParseError
 Record
 RecordException
-RdataParseError
 Rr
 RrParseError
 Rrset
@@ -90,5 +96,7 @@ UriValue
 UrlfwdRecord
 UrlfwdValue
 ValidationError
+value_from_rdata_text
+value_to_rdata_text
 ValueMixin
 ValuesMixin

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -21,7 +21,7 @@ from .naptr import NaptrRecord, NaptrValue
 from .ns import NsRecord, NsValue
 from .openpgpkey import OpenpgpkeyRecord, OpenpgpkeyValue
 from .ptr import PtrRecord, PtrValue
-from .rr import Rr, RrParseError, Rrset
+from .rr import RdataParseError, Rr, RrParseError, Rrset
 from .spf import SpfRecord
 from .srv import SrvRecord, SrvValue
 from .sshfp import SshfpRecord, SshfpValue
@@ -69,6 +69,7 @@ PtrRecord
 PtrValue
 Record
 RecordException
+RdataParseError
 Rr
 RrParseError
 Rrset

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -21,28 +21,25 @@ def unquote(s):
     return s
 
 
-class RdataValueMixin(object):
-    @classmethod
-    def parse_rdata_text(cls, rdata):
-        deprecated(
-            f'`{cls.__name__}.parse_rdata_text` is DEPRECATED. Use '
-            f'`{cls.__name__}.from_rrs()` instead. Will be removed in 2.0.',
-            stacklevel=2,
-        )
-        return cls.from_rrs(rdata)
+def _deprecated_parse_rdata_text(value_type):
+    deprecated(
+        f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. Use '
+        f'`{value_type.__name__}.from_rrs()` instead. Will be removed in 2.0.',
+        stacklevel=3,
+    )
 
-    @property
-    def rdata_text(self):
-        cls = self.__class__
-        deprecated(
-            f'`{cls.__name__}.rdata_text` is DEPRECATED. Use '
-            f'`{cls.__name__}.to_rrs()` instead. Will be removed in 2.0.',
-            stacklevel=2,
-        )
-        return self.to_rrs()
+
+def _deprecated_rdata_text(value):
+    value_type = value.__class__
+    deprecated(
+        f'`{value_type.__name__}.rdata_text` is DEPRECATED. Use '
+        f'`{value_type.__name__}.to_rrs()` instead. Will be removed in 2.0.',
+        stacklevel=3,
+    )
 
 
 def value_from_rrs(value_type, rdata):
+    '''Convert one presentation-format RDATA string to raw value data.'''
     method = getattr(value_type, 'from_rrs', None)
     if method:
         return method(rdata)
@@ -55,6 +52,7 @@ def value_from_rrs(value_type, rdata):
 
 
 def value_to_rrs(value):
+    '''Render one logical value as one presentation-format RDATA string.'''
     method = getattr(value, 'to_rrs', None)
     if method:
         return method()

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -371,11 +371,11 @@ class Record(EqualityTupleMixin):
     def from_rrs(cls, zone, rrs, lenient=False, source=None):
         '''Create records from deprecated, individual :class:`~octodns.record.rr.Rr` objects.
 
-        The flat input is grouped by owner name and type and converted through
-        :meth:`from_rrsets`. Input order is retained within each group and
-        output records are ordered deterministically by owner name and type.
-        ``lenient`` and ``source`` are passed unchanged to
-        :meth:`Record.new`.
+        The flat input is grouped by owner name and type and converted with
+        each record class's legacy ``data_from_rrs()`` implementation. Input
+        order is retained within each group and output records are ordered
+        deterministically by owner name and type. ``lenient`` and ``source``
+        are passed unchanged to :meth:`Record.new`.
 
         :param octodns.zone.Zone zone: zone containing the records
         :param collections.abc.Iterable rrs: individual
@@ -401,15 +401,16 @@ class Record(EqualityTupleMixin):
         for rr in rrs:
             grouped[(rr.name, rr._type)].append(rr)
 
-        rrsets = []
-        for rrs in grouped.values():
-            first = rrs[0]
-            rrsets.append(
-                Rrset(
-                    first.name, first._type, first.ttl, [rr.rdata for rr in rrs]
-                )
+        records = []
+        for _, grouped_rrs in sorted(grouped.items()):
+            first = grouped_rrs[0]
+            name = zone.hostname_from_fqdn(first.name)
+            record_class = cls._CLASSES[first._type]
+            data = record_class.data_from_rrs(grouped_rrs)
+            records.append(
+                Record.new(zone, name, data, lenient=lenient, source=source)
             )
-        return cls.from_rrsets(zone, rrsets, lenient=lenient, source=source)
+        return records
 
     @classmethod
     def _record_from_rrset(cls, zone, rrset, lenient=False, source=None):
@@ -418,8 +419,13 @@ class Record(EqualityTupleMixin):
                 f'Invalid Rrset {rrset.name} {rrset._type}: at least one '
                 'RDATA value is required'
             )
+        try:
+            record_class = cls._CLASSES[rrset._type]
+        except KeyError:
+            raise RecordException(
+                f'Unknown record type: "{rrset._type}"'
+            ) from None
         name = zone.hostname_from_fqdn(rrset.name)
-        record_class = cls._CLASSES[rrset._type]
         data = record_class.data_from_rrset(rrset)
         return Record.new(zone, name, data, lenient=lenient, source=source)
 
@@ -446,11 +452,11 @@ class Record(EqualityTupleMixin):
         :param object source: source assigned to the returned record
         :returns: exactly one octoDNS record
         :rtype: Record
-        :raises octodns.record.exception.RecordException: if ``rdatas`` is
-            empty
+        :raises octodns.record.exception.RecordException: if the RRset is
+            invalid, a single-value record contains multiple RDATA values, or
+            the type is not registered
         :raises octodns.record.exception.ValidationError: if the converted
             internal record data fails validation and ``lenient`` is false
-        :raises KeyError: if the RRset's type is not registered
         '''
         return cls._record_from_rrset(
             zone, rrset, lenient=lenient, source=source
@@ -474,11 +480,12 @@ class Record(EqualityTupleMixin):
         :param object source: source assigned to every returned record
         :returns: zero or more octoDNS records in owner-name/type order
         :rtype: list[Record]
-        :raises octodns.record.exception.RecordException: if an RRset has no
-            RDATA values or an owner-name/type pair occurs more than once
+        :raises octodns.record.exception.RecordException: if an RRset is
+            invalid, a single-value record contains multiple RDATA values, a
+            type is not registered, or an owner-name/type pair occurs more
+            than once
         :raises octodns.record.exception.ValidationError: if converted
             internal record data fails validation and ``lenient`` is false
-        :raises KeyError: if an RRset's type is not registered
         '''
         grouped = {}
         for rrset in rrsets:
@@ -785,6 +792,11 @@ class ValueMixin(object):
 
     @classmethod
     def data_from_rrset(cls, rrset):
+        if len(rrset.rdatas) != 1:
+            raise RecordException(
+                f'Invalid Rrset {rrset.name} {rrset._type}: exactly one '
+                'RDATA value is required for a single-value record'
+            )
         return {
             'ttl': rrset.ttl,
             'type': rrset._type,

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -21,6 +21,74 @@ def unquote(s):
     return s
 
 
+def _legacy_value_api(value_type, method):
+    replacement = 'to_rrs' if method == 'rdata_text' else 'from_rrs'
+    deprecated(
+        f'`{value_type.__name__}.{method}` is DEPRECATED. Use '
+        f'`{value_type.__name__}.{replacement}()` instead. Will be removed in 2.0.',
+        stacklevel=3,
+    )
+
+
+def _add_rdata_apis(value_type):
+    '''Add the 1.x RDATA API compatibility layer to a built-in value type.'''
+    if getattr(value_type, '_rdata_apis_added', False):
+        return
+
+    parser = value_type.parse_rdata_text
+    renderer = value_type.rdata_text
+
+    def legacy_to_rrs(self):
+        return renderer.__get__(self, value_type)
+
+    def legacy_from_rrs(cls, rdata):
+        return parser(rdata)
+
+    @classmethod
+    def parse_rdata_text(cls, rdata):
+        _legacy_value_api(cls, 'parse_rdata_text')
+        return legacy_from_rrs(cls, rdata)
+
+    @property
+    def rdata_text(self):
+        _legacy_value_api(self.__class__, 'rdata_text')
+        return legacy_to_rrs(self)
+
+    if not hasattr(value_type, 'to_rrs'):
+        value_type.to_rrs = legacy_to_rrs
+    if not hasattr(value_type, 'from_rrs'):
+        value_type.from_rrs = classmethod(legacy_from_rrs)
+    value_type.parse_rdata_text = parse_rdata_text
+    value_type.rdata_text = rdata_text
+    value_type._legacy_parse_rdata_text = parser
+    value_type._rdata_apis_added = True
+
+
+def value_from_rrs(value_type, rdata):
+    method = getattr(value_type, 'from_rrs', None)
+    if method:
+        return method(rdata)
+    deprecated(
+        f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. '
+        'Implement `from_rrs()` instead. Will be removed in 2.0.',
+        stacklevel=3,
+    )
+    return value_type.parse_rdata_text(rdata)
+
+
+def value_to_rrs(value):
+    method = getattr(value, 'to_rrs', None)
+    if method:
+        return method()
+    value_type = value.__class__
+    deprecated(
+        f'`{value_type.__name__}.rdata_text` is DEPRECATED. '
+        'Implement `to_rrs()` instead. Will be removed in 2.0.',
+        stacklevel=3,
+    )
+    return value.rdata_text
+
+
 class NameValidator(RecordValidator):
     '''
     Validates record name and FQDN shape: rejects the legacy ``@`` alias,
@@ -196,6 +264,12 @@ class Record(EqualityTupleMixin):
         # resolution so a value subclass can override its parent's
         # VALIDATORS rather than registering both
         vt = getattr(_class, '_value_type', None)
+        # Built-in value types retain their old public APIs during 1.x while
+        # exposing the uniform RDATA conversion APIs. Third-party types are
+        # deliberately left alone so the conversion helpers can warn and use
+        # their compatibility fallback.
+        if vt and vt.__module__.startswith('octodns.'):
+            _add_rdata_apis(vt)
         for validator in getattr(vt, 'VALIDATORS', ()):
             cls.register_validator(validator, types=[_type])
 
@@ -315,7 +389,13 @@ class Record(EqualityTupleMixin):
 
     @classmethod
     def parse_rdata_texts(cls, rdatas):
-        return [cls._value_type.parse_rdata_text(r) for r in rdatas]
+        # TinyDNS and other raw-format sources use this legacy entry point.
+        parser = getattr(
+            cls._value_type,
+            '_legacy_parse_rdata_text',
+            cls._value_type.parse_rdata_text,
+        )
+        return [parser(r) for r in rdatas]
 
     def __init__(self, zone, name, data, source=None, context=None):
         self.zone = zone
@@ -487,7 +567,7 @@ class ValuesMixin(object):
         # type and TTL come from the first rr
         rr = rrs[0]
         # values come from parsing the rdata portion of all rrs
-        values = [cls._value_type.parse_rdata_text(rr.rdata) for rr in rrs]
+        values = [value_from_rrs(cls._value_type, rr.rdata) for rr in rrs]
         return {'ttl': rr.ttl, 'type': rr._type, 'values': values}
 
     def __init__(self, zone, name, data, source=None, context=None):
@@ -527,7 +607,7 @@ class ValuesMixin(object):
             self.fqdn,
             self.ttl,
             self._type,
-            [v.rdata_text for v in self.rr_values],
+            [value_to_rrs(v) for v in self.rr_values],
         )
 
     def __repr__(self):
@@ -549,7 +629,7 @@ class ValueMixin(object):
         return {
             'ttl': rr.ttl,
             'type': rr._type,
-            'value': cls._value_type.parse_rdata_text(rr.rdata),
+            'value': value_from_rrs(cls._value_type, rr.rdata),
         }
 
     def __init__(self, zone, name, data, source=None, context=None):
@@ -568,7 +648,7 @@ class ValueMixin(object):
 
     @property
     def rrs(self):
-        return self.fqdn, self.ttl, self._type, [self.value.rdata_text]
+        return self.fqdn, self.ttl, self._type, [value_to_rrs(self.value)]
 
     def __repr__(self):
         klass = self.__class__.__name__

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -59,7 +59,15 @@ def _value_from_rdata_text_uses_legacy(value_type):
 
 
 def value_from_rdata_text(value_type, rdata):
-    '''Convert one presentation-format RDATA string to internal value data.'''
+    '''Convert one presentation-format RDATA string to internal value data.
+
+    Dispatch prefers ``from_rdata_text()`` while retaining compatibility with
+    third-party value types that only implement ``parse_rdata_text()``.
+
+    :param type value_type: record value type performing the conversion
+    :param str rdata: one RDATA value in presentation format
+    :returns: internal data suitable for constructing ``value_type``
+    '''
     if not _value_from_rdata_text_uses_legacy(value_type):
         return value_type.from_rdata_text(rdata)
     # Intentionally identify the octoDNS conversion path. This warning is
@@ -81,13 +89,19 @@ def _value_to_rdata_text_uses_legacy(value_type):
     )
 
 
-def value_to_rdata_text(value, legacy_value=None):
-    '''Render one logical value as one presentation-format RDATA string.'''
+def value_to_rdata_text(value):
+    '''Render one logical value as one presentation-format RDATA string.
+
+    Dispatch prefers ``to_rdata_text()`` while retaining compatibility with
+    third-party values that only implement the ``rdata_text`` property.
+
+    :param object value: one record value object
+    :returns: one RDATA value in presentation format
+    :rtype: str
+    '''
     value_type = value.__class__
     if not _value_to_rdata_text_uses_legacy(value_type):
         return value.to_rdata_text()
-    if legacy_value is None:
-        legacy_value = value
     # Intentionally identify the octoDNS conversion path. This warning is
     # about the legacy implementation on the value type, not its caller.
     deprecated(
@@ -95,7 +109,7 @@ def value_to_rdata_text(value, legacy_value=None):
         'Implement `to_rdata_text()` instead. Will be removed in 2.0.',
         stacklevel=3,
     )
-    return legacy_value.rdata_text
+    return value.rdata_text
 
 
 class NameValidator(RecordValidator):

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -28,7 +28,7 @@ def _deprecated_parse_rdata_text(value_type, replacement=None):
     deprecated(
         f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. Use '
         f'`{replacement}` instead. Will be removed in 2.0.',
-        stacklevel=3,
+        stacklevel=4,
     )
 
 
@@ -38,7 +38,7 @@ def _deprecated_rdata_text(value, replacement=None):
     deprecated(
         f'`{value_type.__name__}.rdata_text` is DEPRECATED. Use '
         f'`{replacement}` instead. Will be removed in 2.0.',
-        stacklevel=3,
+        stacklevel=4,
     )
 
 
@@ -62,6 +62,8 @@ def value_from_rdata_text(value_type, rdata):
     '''Convert one presentation-format RDATA string to internal value data.'''
     if not _value_from_rdata_text_uses_legacy(value_type):
         return value_type.from_rdata_text(rdata)
+    # Intentionally identify the octoDNS conversion path. This warning is
+    # about the legacy implementation on the value type, not its caller.
     deprecated(
         f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. '
         'Implement `from_rdata_text()` instead. Will be removed in 2.0.',
@@ -86,6 +88,8 @@ def value_to_rdata_text(value, legacy_value=None):
         return value.to_rdata_text()
     if legacy_value is None:
         legacy_value = value
+    # Intentionally identify the octoDNS conversion path. This warning is
+    # about the legacy implementation on the value type, not its caller.
     deprecated(
         f'`{value_type.__name__}.rdata_text` is DEPRECATED. '
         'Implement `to_rdata_text()` instead. Will be removed in 2.0.',

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -21,47 +21,25 @@ def unquote(s):
     return s
 
 
-def _legacy_value_api(value_type, method):
-    replacement = 'to_rrs' if method == 'rdata_text' else 'from_rrs'
-    deprecated(
-        f'`{value_type.__name__}.{method}` is DEPRECATED. Use '
-        f'`{value_type.__name__}.{replacement}()` instead. Will be removed in 2.0.',
-        stacklevel=3,
-    )
-
-
-def _add_rdata_apis(value_type):
-    '''Add the 1.x RDATA API compatibility layer to a built-in value type.'''
-    if getattr(value_type, '_rdata_apis_added', False):
-        return
-
-    parser = value_type.parse_rdata_text
-    renderer = value_type.rdata_text
-
-    def legacy_to_rrs(self):
-        return renderer.__get__(self, value_type)
-
-    def legacy_from_rrs(cls, rdata):
-        return parser(rdata)
-
+class RdataValueMixin(object):
     @classmethod
     def parse_rdata_text(cls, rdata):
-        _legacy_value_api(cls, 'parse_rdata_text')
-        return legacy_from_rrs(cls, rdata)
+        deprecated(
+            f'`{cls.__name__}.parse_rdata_text` is DEPRECATED. Use '
+            f'`{cls.__name__}.from_rrs()` instead. Will be removed in 2.0.',
+            stacklevel=2,
+        )
+        return cls.from_rrs(rdata)
 
     @property
     def rdata_text(self):
-        _legacy_value_api(self.__class__, 'rdata_text')
-        return legacy_to_rrs(self)
-
-    if not hasattr(value_type, 'to_rrs'):
-        value_type.to_rrs = legacy_to_rrs
-    if not hasattr(value_type, 'from_rrs'):
-        value_type.from_rrs = classmethod(legacy_from_rrs)
-    value_type.parse_rdata_text = parse_rdata_text
-    value_type.rdata_text = rdata_text
-    value_type._legacy_parse_rdata_text = parser
-    value_type._rdata_apis_added = True
+        cls = self.__class__
+        deprecated(
+            f'`{cls.__name__}.rdata_text` is DEPRECATED. Use '
+            f'`{cls.__name__}.to_rrs()` instead. Will be removed in 2.0.',
+            stacklevel=2,
+        )
+        return self.to_rrs()
 
 
 def value_from_rrs(value_type, rdata):
@@ -264,12 +242,6 @@ class Record(EqualityTupleMixin):
         # resolution so a value subclass can override its parent's
         # VALIDATORS rather than registering both
         vt = getattr(_class, '_value_type', None)
-        # Built-in value types retain their old public APIs during 1.x while
-        # exposing the uniform RDATA conversion APIs. Third-party types are
-        # deliberately left alone so the conversion helpers can warn and use
-        # their compatibility fallback.
-        if vt and vt.__module__.startswith('octodns.'):
-            _add_rdata_apis(vt)
         for validator in getattr(vt, 'VALIDATORS', ()):
             cls.register_validator(validator, types=[_type])
 
@@ -389,13 +361,7 @@ class Record(EqualityTupleMixin):
 
     @classmethod
     def parse_rdata_texts(cls, rdatas):
-        # TinyDNS and other raw-format sources use this legacy entry point.
-        parser = getattr(
-            cls._value_type,
-            '_legacy_parse_rdata_text',
-            cls._value_type.parse_rdata_text,
-        )
-        return [parser(r) for r in rdatas]
+        return [value_from_rrs(cls._value_type, r) for r in rdatas]
 
     def __init__(self, zone, name, data, source=None, context=None):
         self.zone = zone

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -12,6 +12,7 @@ from ..equality import EqualityTupleMixin
 from ..idna import IdnaError, idna_decode, idna_encode
 from .change import Update
 from .exception import RecordException, ValidationError
+from .rr import Rrset
 from .validator import RecordValidator, ValidationReason, ValidatorRegistry
 
 
@@ -21,48 +22,69 @@ def unquote(s):
     return s
 
 
-def _deprecated_parse_rdata_text(value_type):
+def _deprecated_parse_rdata_text(value_type, replacement=None):
+    replacement = replacement or f'{value_type.__name__}.from_rdata_text()'
     deprecated(
         f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. Use '
-        f'`{value_type.__name__}.from_rrs()` instead. Will be removed in 2.0.',
+        f'`{replacement}` instead. Will be removed in 2.0.',
         stacklevel=3,
     )
 
 
-def _deprecated_rdata_text(value):
+def _deprecated_rdata_text(value, replacement=None):
     value_type = value.__class__
+    replacement = replacement or f'{value_type.__name__}.to_rdata_text()'
     deprecated(
         f'`{value_type.__name__}.rdata_text` is DEPRECATED. Use '
-        f'`{value_type.__name__}.to_rrs()` instead. Will be removed in 2.0.',
+        f'`{replacement}` instead. Will be removed in 2.0.',
         stacklevel=3,
     )
 
 
-def value_from_rrs(value_type, rdata):
-    '''Convert one presentation-format RDATA string to raw value data.'''
-    method = getattr(value_type, 'from_rrs', None)
-    if method:
-        return method(rdata)
+def _mro_owner(value_type, name):
+    for index, owner in enumerate(value_type.__mro__):
+        if name in owner.__dict__:
+            return index
+    return None
+
+
+def value_from_rdata_text(value_type, rdata):
+    '''Convert one presentation-format RDATA string to internal value data.'''
+    new_owner = _mro_owner(value_type, 'from_rdata_text')
+    legacy_owner = _mro_owner(value_type, 'parse_rdata_text')
+    if new_owner is not None and (
+        legacy_owner is None or new_owner <= legacy_owner
+    ):
+        return value_type.from_rdata_text(rdata)
     deprecated(
         f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. '
-        'Implement `from_rrs()` instead. Will be removed in 2.0.',
+        'Implement `from_rdata_text()` instead. Will be removed in 2.0.',
         stacklevel=3,
     )
     return value_type.parse_rdata_text(rdata)
 
 
-def value_to_rrs(value):
+def _value_to_rdata_text_uses_legacy(value_type):
+    new_owner = _mro_owner(value_type, 'to_rdata_text')
+    legacy_owner = _mro_owner(value_type, 'rdata_text')
+    return new_owner is None or (
+        legacy_owner is not None and legacy_owner < new_owner
+    )
+
+
+def value_to_rdata_text(value, legacy_value=None):
     '''Render one logical value as one presentation-format RDATA string.'''
-    method = getattr(value, 'to_rrs', None)
-    if method:
-        return method()
     value_type = value.__class__
+    if not _value_to_rdata_text_uses_legacy(value_type):
+        return value.to_rdata_text()
+    if legacy_value is None:
+        legacy_value = value
     deprecated(
         f'`{value_type.__name__}.rdata_text` is DEPRECATED. '
-        'Implement `to_rrs()` instead. Will be removed in 2.0.',
+        'Implement `to_rdata_text()` instead. Will be removed in 2.0.',
         stacklevel=3,
     )
-    return value.rdata_text
+    return legacy_value.rdata_text
 
 
 class NameValidator(RecordValidator):
@@ -336,30 +358,135 @@ class Record(EqualityTupleMixin):
 
     @classmethod
     def from_rrs(cls, zone, rrs, lenient=False, source=None):
+        '''Create records from deprecated, individual :class:`~octodns.record.rr.Rr` objects.
+
+        The flat input is grouped by owner name and type and converted through
+        :meth:`from_rrsets`. Input order is retained within each group and
+        output records are ordered deterministically by owner name and type.
+        ``lenient`` and ``source`` are passed unchanged to
+        :meth:`Record.new`.
+
+        :param octodns.zone.Zone zone: zone containing the records
+        :param collections.abc.Iterable rrs: individual
+            :class:`~octodns.record.rr.Rr` objects whose ``rdata`` attributes
+            are RDATA presentation-format strings
+        :param bool lenient: allow records that fail validation
+        :param object source: source assigned to every returned record
+        :returns: zero or more octoDNS records
+        :rtype: list[Record]
+
+        .. deprecated:: 1.22.0
+           Use :meth:`from_rrsets`. ``Record.from_rrs`` will be removed in
+           2.0.
+        '''
+        deprecated(
+            '`Record.from_rrs` is DEPRECATED. Use `Record.from_rrsets()` '
+            'instead. Will be removed in 2.0.',
+            stacklevel=3,
+        )
         # group records by name & type so that multiple rdatas can be combined
         # into a single record when needed
         grouped = defaultdict(list)
         for rr in rrs:
             grouped[(rr.name, rr._type)].append(rr)
 
-        records = []
-        # walk the grouped rrs converting each one to data and then create a
-        # record with that data
-        for _, rrs in sorted(grouped.items()):
-            rr = rrs[0]
-            name = zone.hostname_from_fqdn(rr.name)
-            _class = cls._CLASSES[rr._type]
-            data = _class.data_from_rrs(rrs)
-            record = Record.new(
-                zone, name, data, lenient=lenient, source=source
+        rrsets = []
+        for rrs in grouped.values():
+            first = rrs[0]
+            rrsets.append(
+                Rrset(
+                    first.name, first._type, first.ttl, [rr.rdata for rr in rrs]
+                )
             )
-            records.append(record)
+        return cls.from_rrsets(zone, rrsets, lenient=lenient, source=source)
 
-        return records
+    @classmethod
+    def _record_from_rrset(cls, zone, rrset, lenient=False, source=None):
+        if not rrset.rdatas:
+            raise RecordException(
+                f'Invalid Rrset {rrset.name} {rrset._type}: at least one '
+                'RDATA value is required'
+            )
+        name = zone.hostname_from_fqdn(rrset.name)
+        record_class = cls._CLASSES[rrset._type]
+        data = record_class.data_from_rrset(rrset)
+        return Record.new(zone, name, data, lenient=lenient, source=source)
+
+    @classmethod
+    def from_rrset(cls, zone, rrset, lenient=False, source=None):
+        '''Create one octoDNS record from one grouped RRset.
+
+        ``rrset`` contains one owner, type, TTL, and one or more RDATA values
+        in DNS master-file presentation format. DNS class is implicitly
+        Internet (``IN``). The returned record exposes octoDNS internal-format
+        values. ``lenient`` and ``source`` are passed unchanged to
+        :meth:`Record.new`.
+
+        Provider example::
+
+            rrset = Rrset(
+                'www.example.com.', 'A', 300, ['192.0.2.1', '192.0.2.2']
+            )
+            record = Record.from_rrset(zone, rrset, source=provider)
+
+        :param octodns.zone.Zone zone: zone containing the record
+        :param octodns.record.rr.Rrset rrset: exactly one grouped RRset
+        :param bool lenient: allow a record that fails validation
+        :param object source: source assigned to the returned record
+        :returns: exactly one octoDNS record
+        :rtype: Record
+        :raises octodns.record.exception.RecordException: if ``rdatas`` is
+            empty
+        :raises octodns.record.exception.ValidationError: if the converted
+            internal record data fails validation and ``lenient`` is false
+        :raises KeyError: if the RRset's type is not registered
+        '''
+        return cls._record_from_rrset(
+            zone, rrset, lenient=lenient, source=source
+        )
+
+    @classmethod
+    def from_rrsets(cls, zone, rrsets, lenient=False, source=None):
+        '''Create records from grouped RRsets.
+
+        Each :class:`~octodns.record.rr.Rrset` contains RDATA
+        presentation-format strings and implicitly uses Internet (``IN``)
+        class. At most one RRset may occur for each owner-name/type pair.
+        Results are sorted deterministically by owner name and type. Empty
+        input returns an empty list. ``lenient`` and ``source`` are passed
+        unchanged to every :meth:`Record.new` call.
+
+        :param octodns.zone.Zone zone: zone containing the records
+        :param collections.abc.Iterable rrsets: grouped
+            :class:`~octodns.record.rr.Rrset` objects
+        :param bool lenient: allow records that fail validation
+        :param object source: source assigned to every returned record
+        :returns: zero or more octoDNS records in owner-name/type order
+        :rtype: list[Record]
+        :raises octodns.record.exception.RecordException: if an RRset has no
+            RDATA values or an owner-name/type pair occurs more than once
+        :raises octodns.record.exception.ValidationError: if converted
+            internal record data fails validation and ``lenient`` is false
+        :raises KeyError: if an RRset's type is not registered
+        '''
+        grouped = {}
+        for rrset in rrsets:
+            key = (rrset.name, rrset._type)
+            if key in grouped:
+                raise RecordException(
+                    f'Duplicate Rrset {rrset.name} {rrset._type}'
+                )
+            grouped[key] = rrset
+        return [
+            cls._record_from_rrset(
+                zone, grouped[key], lenient=lenient, source=source
+            )
+            for key in sorted(grouped)
+        ]
 
     @classmethod
     def parse_rdata_texts(cls, rdatas):
-        return [value_from_rrs(cls._value_type, r) for r in rdatas]
+        return [value_from_rdata_text(cls._value_type, r) for r in rdatas]
 
     def __init__(self, zone, name, data, source=None, context=None):
         self.zone = zone
@@ -423,6 +550,51 @@ class Record(EqualityTupleMixin):
         if self.decoded_name:
             return f'{self.decoded_name}.{self.zone.decoded_name}'
         return self.zone.decoded_name
+
+    def to_rrset(self):
+        '''Render this record as one grouped RRset.
+
+        Values exposed by this record in octoDNS internal format are converted
+        into deterministic RDATA presentation-format strings. The returned
+        :class:`~octodns.record.rr.Rrset` contains this record's fully-qualified
+        owner name, type, and TTL; DNS class is implicitly Internet (``IN``).
+
+        Provider example::
+
+            rrset = record.to_rrset()
+            provider_values = rrset.rdatas
+
+        :returns: exactly one grouped RRset
+        :rtype: octodns.record.rr.Rrset
+        '''
+        return self._to_rrset(self._rdatas())
+
+    def _to_rrset(self, rdatas):
+        return Rrset(self.fqdn, self._type, self.ttl, rdatas)
+
+    def _legacy_rdatas(self):
+        return self._rdatas()
+
+    @property
+    def rrs(self):
+        '''Return the deprecated legacy RRset tuple.
+
+        The plain tuple order remains ``(name, ttl, type, rdatas)`` and differs
+        from the named :class:`~octodns.record.rr.Rrset` constructor order.
+
+        :returns: owner name, TTL, type, and a list of RDATA presentation text
+        :rtype: tuple
+
+        .. deprecated:: 1.22.0
+           Use :meth:`to_rrset`. ``Record.rrs`` will be removed in 2.0.
+        '''
+        deprecated(
+            '`Record.rrs` is DEPRECATED. Use `Record.to_rrset()` instead. '
+            'Will be removed in 2.0.',
+            stacklevel=3,
+        )
+        rrset = self._to_rrset(self._legacy_rdatas())
+        return rrset.name, rrset.ttl, rrset._type, rrset.rdatas
 
     @property
     def ignored(self):
@@ -531,8 +703,18 @@ class ValuesMixin(object):
         # type and TTL come from the first rr
         rr = rrs[0]
         # values come from parsing the rdata portion of all rrs
-        values = [value_from_rrs(cls._value_type, rr.rdata) for rr in rrs]
+        values = [
+            value_from_rdata_text(cls._value_type, rr.rdata) for rr in rrs
+        ]
         return {'ttl': rr.ttl, 'type': rr._type, 'values': values}
+
+    @classmethod
+    def data_from_rrset(cls, rrset):
+        values = [
+            value_from_rdata_text(cls._value_type, rdata)
+            for rdata in rrset.rdatas
+        ]
+        return {'ttl': rrset.ttl, 'type': rrset._type, 'values': values}
 
     def __init__(self, zone, name, data, source=None, context=None):
         super().__init__(zone, name, data, source=source, context=context)
@@ -565,14 +747,8 @@ class ValuesMixin(object):
     def rr_values(self):
         return self.values
 
-    @property
-    def rrs(self):
-        return (
-            self.fqdn,
-            self.ttl,
-            self._type,
-            [value_to_rrs(v) for v in self.rr_values],
-        )
+    def _rdatas(self):
+        return [value_to_rdata_text(v) for v in self.rr_values]
 
     def __repr__(self):
         values = "', '".join([str(v) for v in self.values])
@@ -593,7 +769,15 @@ class ValueMixin(object):
         return {
             'ttl': rr.ttl,
             'type': rr._type,
-            'value': value_from_rrs(cls._value_type, rr.rdata),
+            'value': value_from_rdata_text(cls._value_type, rr.rdata),
+        }
+
+    @classmethod
+    def data_from_rrset(cls, rrset):
+        return {
+            'ttl': rrset.ttl,
+            'type': rrset._type,
+            'value': value_from_rdata_text(cls._value_type, rrset.rdatas[0]),
         }
 
     def __init__(self, zone, name, data, source=None, context=None):
@@ -610,9 +794,8 @@ class ValueMixin(object):
         ret['value'] = getattr(self.value, 'data', self.value)
         return ret
 
-    @property
-    def rrs(self):
-        return self.fqdn, self.ttl, self._type, [value_to_rrs(self.value)]
+    def _rdatas(self):
+        return [value_to_rdata_text(self.value)]
 
     def __repr__(self):
         klass = self.__class__.__name__

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -4,6 +4,7 @@
 
 from collections import defaultdict
 from copy import deepcopy
+from functools import cache
 from logging import getLogger
 
 from ..context import ContextDict
@@ -48,13 +49,18 @@ def _mro_owner(value_type, name):
     return None
 
 
-def value_from_rdata_text(value_type, rdata):
-    '''Convert one presentation-format RDATA string to internal value data.'''
+@cache
+def _value_from_rdata_text_uses_legacy(value_type):
     new_owner = _mro_owner(value_type, 'from_rdata_text')
     legacy_owner = _mro_owner(value_type, 'parse_rdata_text')
-    if new_owner is not None and (
-        legacy_owner is None or new_owner <= legacy_owner
-    ):
+    return new_owner is None or (
+        legacy_owner is not None and legacy_owner < new_owner
+    )
+
+
+def value_from_rdata_text(value_type, rdata):
+    '''Convert one presentation-format RDATA string to internal value data.'''
+    if not _value_from_rdata_text_uses_legacy(value_type):
         return value_type.from_rdata_text(rdata)
     deprecated(
         f'`{value_type.__name__}.parse_rdata_text` is DEPRECATED. '
@@ -64,6 +70,7 @@ def value_from_rdata_text(value_type, rdata):
     return value_type.parse_rdata_text(rdata)
 
 
+@cache
 def _value_to_rdata_text_uses_legacy(value_type):
     new_owner = _mro_owner(value_type, 'to_rdata_text')
     legacy_owner = _mro_owner(value_type, 'rdata_text')

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -5,7 +5,13 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -131,7 +137,7 @@ class CaaValueBestPracticeValidator(ValueValidator):
         return []
 
 
-class CaaValue(RdataValueMixin, EqualityTupleMixin, dict):
+class CaaValue(EqualityTupleMixin, dict):
     # https://tools.ietf.org/html/rfc8659
 
     VALIDATORS = [
@@ -209,6 +215,16 @@ class CaaValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         # RFC 8659 §4.1.1 requires value to be a quoted character-string

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -161,7 +161,14 @@ class CaaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one CAA RDATA presentation string into internal field data.
+
+        :param str value: CAA RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format CAA field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             # value may contain whitepsace
             flags, tag, value = value.split(' ', 2)
@@ -219,14 +226,19 @@ class CaaValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal CAA value as one RDATA presentation string.
+
+        :returns: CAA RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         # RFC 8659 §4.1.1 requires value to be a quoted character-string
         return f'{self.flags} {self.tag} "{self.value}"'
 

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -5,7 +5,7 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -131,7 +131,7 @@ class CaaValueBestPracticeValidator(ValueValidator):
         return []
 
 
-class CaaValue(EqualityTupleMixin, dict):
+class CaaValue(RdataValueMixin, EqualityTupleMixin, dict):
     # https://tools.ietf.org/html/rfc8659
 
     VALIDATORS = [
@@ -155,7 +155,7 @@ class CaaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             # value may contain whitepsace
             flags, tag, value = value.split(' ', 2)
@@ -210,8 +210,7 @@ class CaaValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         # RFC 8659 §4.1.1 requires value to be a quoted character-string
         return f'{self.flags} {self.tag} "{self.value}"'
 

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -12,7 +12,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -167,13 +167,13 @@ class CaaValue(EqualityTupleMixin, dict):
         :param str value: CAA RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format CAA field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             # value may contain whitepsace
             flags, tag, value = value.split(' ', 2)
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             flags = int(flags)
         except ValueError:

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -4,9 +4,11 @@
 
 import re
 
+import dns.exception
 import dns.rdata
 import dns.rdataclass
 import dns.rdatatype
+import dns.tokenizer
 from dns.rdtypes.ANY.TXT import TXT
 
 from .base import (
@@ -16,6 +18,7 @@ from .base import (
     _value_to_rdata_text_uses_legacy,
     value_to_rdata_text,
 )
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -85,13 +88,27 @@ def _legacy_chunked_value(value, value_type, chunk_size):
 
 
 class _ChunkedValuesMixin(ValuesMixin):
+    '''Legacy record-level chunking compatibility for TXT/SPF values.
+
+    ``CHUNK_SIZE``, ``chunked_value()``, ``chunked_values``, and ``rr_values``
+    are used by the deprecated ``record.rrs`` representation. New-style
+    values rendered by ``to_rrset()`` always use the value-level conversion's
+    255-octet DNS limit instead.
+
+    .. deprecated:: 1.22.0
+       These record-level chunking hooks will be removed with ``record.rrs``
+       in 2.0.
+    '''
+
     CHUNK_SIZE = 255
 
     def chunked_value(self, value):
+        '''Render one value with the legacy record-level chunk size.'''
         return _legacy_chunked_value(value, self._value_type, self.CHUNK_SIZE)
 
     @property
     def chunked_values(self):
+        '''Render all values with the legacy record-level chunk size.'''
         values = []
         for v in self.values:
             values.append(self.chunked_value(v))
@@ -99,22 +116,22 @@ class _ChunkedValuesMixin(ValuesMixin):
 
     @property
     def rr_values(self):
+        '''Return presentation-form values for the deprecated ``rrs`` API.'''
         return self.chunked_values
 
     def _rdatas(self):
-        # ``rr_values`` is retained for backwards compatibility, but consists
-        # of presentation-form values. Render from the raw values directly so
-        # that RDATA is never quoted and escaped a second time.
-        return [
-            value_to_rdata_text(value, legacy_value=rr_value)
-            for value, rr_value in zip(self.values, self.rr_values)
-        ]
+        if _value_to_rdata_text_uses_legacy(self._value_type):
+            # Legacy overrides historically receive the presentation-form
+            # objects exposed by ``rr_values``. Only evaluate those objects
+            # when the compatibility dispatch actually needs them.
+            return [value_to_rdata_text(value) for value in self.rr_values]
+        return [value_to_rdata_text(value) for value in self.values]
 
     def _legacy_rdatas(self):
         rdatas = []
-        for value, rr_value in zip(self.values, self.rr_values):
-            if _value_to_rdata_text_uses_legacy(value.__class__):
-                rdatas.append(value_to_rdata_text(value, legacy_value=rr_value))
+        for rr_value in self.rr_values:
+            if _value_to_rdata_text_uses_legacy(rr_value.__class__):
+                rdatas.append(value_to_rdata_text(rr_value))
             else:
                 rdatas.append(str(rr_value))
         return rdatas
@@ -142,16 +159,26 @@ class _ChunkedValue(str):
         Character-string bytes are decoded as UTF-8 and semicolons are escaped
         for octoDNS's TXT/SPF internal format.
 
+        Wholly unquoted input containing multiple character-string tokens is
+        treated as legacy raw text so that spaces are not silently discarded.
+
         :param str rdata: one TXT-style RDATA presentation-format value
         :returns: octoDNS internal-format text
         :rtype: str
-        :raises dns.exception.DNSException: if ``rdata`` is not valid TXT
-            RDATA presentation text
-        :raises UnicodeDecodeError: if parsed character-string bytes are not
+        :raises octodns.record.rr.RdataParseError: if ``rdata`` is not valid
+            TXT RDATA presentation text or its character-string bytes are not
             valid UTF-8
         '''
-        parsed = dns.rdata.from_text('IN', 'TXT', rdata)
-        return b''.join(parsed.strings).decode('utf-8').replace(';', '\\;')
+        try:
+            tokens = dns.tokenizer.Tokenizer(rdata).get_remaining()
+            if len(tokens) > 1 and all(
+                token.is_identifier() for token in tokens
+            ):
+                return cls.from_raw(rdata)
+            parsed = dns.rdata.from_text('IN', 'TXT', rdata)
+            return b''.join(parsed.strings).decode('utf-8').replace(';', '\\;')
+        except (dns.exception.DNSException, UnicodeDecodeError) as error:
+            raise RdataParseError() from error
 
     @classmethod
     def _schema(cls):
@@ -176,8 +203,9 @@ class _ChunkedValue(str):
 
         Valid ASCII input is chunked by octet into character strings of at
         most 255 bytes and rendered by dnspython. Lenient non-ASCII input uses
-        the legacy character-based quoting and chunking representation so it
-        remains round-trippable as UTF-8 text.
+        the legacy character-based quoting and chunking representation. That
+        compatibility output is round-trippable only when every emitted
+        character-string fits within the 255-octet DNS limit as UTF-8.
 
         :returns: one TXT-style RDATA presentation-format string
         :rtype: str

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -153,6 +153,18 @@ class _ChunkedValue(str):
         except AttributeError:
             return value
 
+    def to_raw_text(self):
+        '''Convert octoDNS internal TXT/SPF text to raw provider text.
+
+        This is the inverse of :meth:`normalize_raw_text` for valid internal
+        values. It removes octoDNS's semicolon escaping without adding RDATA
+        presentation-format quoting or chunking.
+
+        :returns: unescaped TXT/SPF text suitable for a raw-text provider
+        :rtype: str
+        '''
+        return self.replace('\\;', ';')
+
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -4,6 +4,8 @@
 
 import re
 
+import dns.rdata
+
 from .base import ValuesMixin
 from .validator import ValidationReason, ValueValidator
 
@@ -91,6 +93,18 @@ class _ChunkedValuesMixin(ValuesMixin):
     def rr_values(self):
         return self.chunked_values
 
+    @property
+    def rrs(self):
+        # ``rr_values`` is retained for backwards compatibility, but consists
+        # of presentation-form values. Render from the raw values directly so
+        # that RDATA is never quoted and escaped a second time.
+        return (
+            self.fqdn,
+            self.ttl,
+            self._type,
+            [value.to_rrs() for value in self.values],
+        )
+
 
 class _ChunkedValue(str):
     VALIDATORS = [chunked_value_validator]
@@ -101,6 +115,11 @@ class _ChunkedValue(str):
             return value.replace(';', '\\;')
         except AttributeError:
             return value
+
+    @classmethod
+    def from_rrs(cls, rdata):
+        parsed = dns.rdata.from_text('IN', 'TXT', rdata)
+        return b''.join(parsed.strings).decode('ascii').replace(';', '\\;')
 
     @classmethod
     def _schema(cls):
@@ -118,6 +137,23 @@ class _ChunkedValue(str):
     @property
     def rdata_text(self):
         return self
+
+    def to_rrs(self):
+        value = self.replace('\\;', ';')
+        chunks = [value[i : i + 255] for i in range(0, len(value), 255)] or ['']
+
+        def escape(chunk):
+            return ''.join(
+                (
+                    f'\\{ord(c):03d}'
+                    if ord(c) < 32 or ord(c) > 126
+                    else f'\\{c}' if c in ('"', '\\') else c
+                )
+                for c in chunk
+            )
+
+        rdata = ' '.join(f'"{escape(chunk)}"' for chunk in chunks)
+        return dns.rdata.from_text('IN', 'TXT', rdata).to_text()
 
     def template(self, params):
         if '{' not in self:

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -6,6 +6,7 @@ import re
 
 import dns.rdata
 
+from ..deprecation import deprecated
 from .base import ValuesMixin
 from .validator import ValidationReason, ValueValidator
 
@@ -110,11 +111,20 @@ class _ChunkedValue(str):
     VALIDATORS = [chunked_value_validator]
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_raw(cls, value):
         try:
             return value.replace(';', '\\;')
         except AttributeError:
             return value
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        deprecated(
+            f'`{cls.__name__}.parse_rdata_text` is DEPRECATED. '
+            'Use `from_rrs()` instead. Will be removed in 2.0.',
+            stacklevel=2,
+        )
+        return cls.from_raw(value)
 
     @classmethod
     def from_rrs(cls, rdata):
@@ -136,6 +146,11 @@ class _ChunkedValue(str):
 
     @property
     def rdata_text(self):
+        deprecated(
+            f'`{self.__class__.__name__}.rdata_text` is DEPRECATED. '
+            'Use `to_rrs()` instead. Will be removed in 2.0.',
+            stacklevel=2,
+        )
         return self
 
     def to_rrs(self):

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -5,9 +5,15 @@
 import re
 
 import dns.rdata
+import dns.rdataclass
+import dns.rdatatype
+from dns.rdtypes.ANY.TXT import TXT
 
-from ..deprecation import deprecated
-from .base import ValuesMixin
+from .base import (
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+)
 from .validator import ValidationReason, ValueValidator
 
 
@@ -119,11 +125,7 @@ class _ChunkedValue(str):
 
     @classmethod
     def parse_rdata_text(cls, value):
-        deprecated(
-            f'`{cls.__name__}.parse_rdata_text` is DEPRECATED. '
-            'Use `from_rrs()` instead. Will be removed in 2.0.',
-            stacklevel=2,
-        )
+        _deprecated_parse_rdata_text(cls)
         return cls.from_raw(value)
 
     @classmethod
@@ -146,29 +148,15 @@ class _ChunkedValue(str):
 
     @property
     def rdata_text(self):
-        deprecated(
-            f'`{self.__class__.__name__}.rdata_text` is DEPRECATED. '
-            'Use `to_rrs()` instead. Will be removed in 2.0.',
-            stacklevel=2,
-        )
+        _deprecated_rdata_text(self)
         return self
 
     def to_rrs(self):
-        value = self.replace('\\;', ';')
-        chunks = [value[i : i + 255] for i in range(0, len(value), 255)] or ['']
-
-        def escape(chunk):
-            return ''.join(
-                (
-                    f'\\{ord(c):03d}'
-                    if ord(c) < 32 or ord(c) > 126
-                    else f'\\{c}' if c in ('"', '\\') else c
-                )
-                for c in chunk
-            )
-
-        rdata = ' '.join(f'"{escape(chunk)}"' for chunk in chunks)
-        return dns.rdata.from_text('IN', 'TXT', rdata).to_text()
+        value = self.replace('\\;', ';').encode('ascii')
+        chunks = [value[i : i + 255] for i in range(0, len(value), 255)] or [
+            b''
+        ]
+        return TXT(dns.rdataclass.IN, dns.rdatatype.TXT, chunks).to_text()
 
     def template(self, params):
         if '{' not in self:

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -13,6 +13,8 @@ from .base import (
     ValuesMixin,
     _deprecated_parse_rdata_text,
     _deprecated_rdata_text,
+    _value_to_rdata_text_uses_legacy,
+    value_to_rdata_text,
 )
 from .validator import ValidationReason, ValueValidator
 
@@ -67,27 +69,26 @@ chunked_value_validator = ChunkedValueValidator(
 )
 
 
+def _legacy_chunked_value(value, value_type, chunk_size):
+    value = value.replace('"', '\\"')
+    chunks = []
+    i = 0
+    n = len(value)
+    while i < n:
+        c = min(chunk_size, n - i)
+        while value[i + c - 1] == '\\':
+            c -= 1
+        chunks.append(value[i : i + c])
+        i += c
+    joined = '" "'.join(chunks)
+    return value_type(f'"{joined}"')
+
+
 class _ChunkedValuesMixin(ValuesMixin):
     CHUNK_SIZE = 255
 
     def chunked_value(self, value):
-        value = value.replace('"', '\\"')
-        vs = []
-        i = 0
-        n = len(value)
-        # until we've processed the whole string
-        while i < n:
-            # start with a full chunk size
-            c = min(self.CHUNK_SIZE, n - i)
-            # make sure that we don't break on escape chars
-            while value[i + c - 1] == '\\':
-                c -= 1
-            # we have our chunk now
-            vs.append(value[i : i + c])
-            # and can step over if
-            i += c
-        vs = '" "'.join(vs)
-        return self._value_type(f'"{vs}"')
+        return _legacy_chunked_value(value, self._value_type, self.CHUNK_SIZE)
 
     @property
     def chunked_values(self):
@@ -100,17 +101,23 @@ class _ChunkedValuesMixin(ValuesMixin):
     def rr_values(self):
         return self.chunked_values
 
-    @property
-    def rrs(self):
+    def _rdatas(self):
         # ``rr_values`` is retained for backwards compatibility, but consists
         # of presentation-form values. Render from the raw values directly so
         # that RDATA is never quoted and escaped a second time.
-        return (
-            self.fqdn,
-            self.ttl,
-            self._type,
-            [value.to_rrs() for value in self.values],
-        )
+        return [
+            value_to_rdata_text(value, legacy_value=rr_value)
+            for value, rr_value in zip(self.values, self.rr_values)
+        ]
+
+    def _legacy_rdatas(self):
+        rdatas = []
+        for value, rr_value in zip(self.values, self.rr_values):
+            if _value_to_rdata_text_uses_legacy(value.__class__):
+                rdatas.append(value_to_rdata_text(value, legacy_value=rr_value))
+            else:
+                rdatas.append(str(rr_value))
+        return rdatas
 
 
 class _ChunkedValue(str):
@@ -125,13 +132,26 @@ class _ChunkedValue(str):
 
     @classmethod
     def parse_rdata_text(cls, value):
-        _deprecated_parse_rdata_text(cls)
+        _deprecated_parse_rdata_text(cls, f'{cls.__name__}.from_raw()')
         return cls.from_raw(value)
 
     @classmethod
-    def from_rrs(cls, rdata):
+    def from_rdata_text(cls, rdata):
+        '''Convert one RDATA presentation string to octoDNS internal text.
+
+        Character-string bytes are decoded as UTF-8 and semicolons are escaped
+        for octoDNS's TXT/SPF internal format.
+
+        :param str rdata: one TXT-style RDATA presentation-format value
+        :returns: octoDNS internal-format text
+        :rtype: str
+        :raises dns.exception.DNSException: if ``rdata`` is not valid TXT
+            RDATA presentation text
+        :raises UnicodeDecodeError: if parsed character-string bytes are not
+            valid UTF-8
+        '''
         parsed = dns.rdata.from_text('IN', 'TXT', rdata)
-        return b''.join(parsed.strings).decode('ascii').replace(';', '\\;')
+        return b''.join(parsed.strings).decode('utf-8').replace(';', '\\;')
 
     @classmethod
     def _schema(cls):
@@ -148,11 +168,25 @@ class _ChunkedValue(str):
 
     @property
     def rdata_text(self):
-        _deprecated_rdata_text(self)
+        _deprecated_rdata_text(self, 'str(value)')
         return self
 
-    def to_rrs(self):
-        value = self.replace('\\;', ';').encode('ascii')
+    def to_rdata_text(self):
+        '''Render this octoDNS internal value as RDATA presentation text.
+
+        Valid ASCII input is chunked by octet into character strings of at
+        most 255 bytes and rendered by dnspython. Lenient non-ASCII input uses
+        the legacy character-based quoting and chunking representation so it
+        remains round-trippable as UTF-8 text.
+
+        :returns: one TXT-style RDATA presentation-format string
+        :rtype: str
+        '''
+        raw = self.replace('\\;', ';')
+        try:
+            value = raw.encode('ascii')
+        except UnicodeEncodeError:
+            return str(_legacy_chunked_value(self, self.__class__, 255))
         chunks = [value[i : i + 255] for i in range(0, len(value), 255)] or [
             b''
         ]

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -141,7 +141,13 @@ class _ChunkedValue(str):
     VALIDATORS = [chunked_value_validator]
 
     @classmethod
-    def from_raw(cls, value):
+    def normalize_raw_text(cls, value):
+        '''Normalize unescaped TXT/SPF provider text for octoDNS records.
+
+        :param object value: raw provider value, normally a string
+        :returns: octoDNS internal text with semicolons escaped, or a
+            non-string value unchanged for legacy compatibility
+        '''
         try:
             return value.replace(';', '\\;')
         except AttributeError:
@@ -149,8 +155,10 @@ class _ChunkedValue(str):
 
     @classmethod
     def parse_rdata_text(cls, value):
-        _deprecated_parse_rdata_text(cls, f'{cls.__name__}.from_raw()')
-        return cls.from_raw(value)
+        _deprecated_parse_rdata_text(
+            cls, f'{cls.__name__}.normalize_raw_text()'
+        )
+        return cls.normalize_raw_text(value)
 
     @classmethod
     def from_rdata_text(cls, rdata):
@@ -174,7 +182,7 @@ class _ChunkedValue(str):
             if len(tokens) > 1 and all(
                 token.is_identifier() for token in tokens
             ):
-                return cls.from_raw(rdata)
+                return cls.normalize_raw_text(rdata)
             parsed = dns.rdata.from_text('IN', 'TXT', rdata)
             return b''.join(parsed.strings).decode('utf-8').replace(';', '\\;')
         except (dns.exception.DNSException, UnicodeDecodeError) as error:

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin
+from .base import RdataValueMixin, Record, ValuesMixin
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -280,7 +280,7 @@ class DsValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class DsValue(EqualityTupleMixin, dict):
+class DsValue(RdataValueMixin, EqualityTupleMixin, dict):
     # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
     log = getLogger('DsValue')
 
@@ -317,7 +317,7 @@ class DsValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             key_tag, algorithm, digest_type, digest = value.split(' ')
         except ValueError:
@@ -400,8 +400,7 @@ class DsValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return (
             f'{self.key_tag} {self.algorithm} {self.digest_type} {self.digest}'
         )

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -7,7 +7,12 @@ from logging import getLogger
 
 from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+)
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -280,7 +285,7 @@ class DsValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class DsValue(RdataValueMixin, EqualityTupleMixin, dict):
+class DsValue(EqualityTupleMixin, dict):
     # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
     log = getLogger('DsValue')
 
@@ -399,6 +404,16 @@ class DsValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return (

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -13,7 +13,7 @@ from .base import (
     _deprecated_parse_rdata_text,
     _deprecated_rdata_text,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -328,12 +328,12 @@ class DsValue(EqualityTupleMixin, dict):
         :param str value: DS RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format DS field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             key_tag, algorithm, digest_type, digest = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             key_tag = int(key_tag)
         except ValueError:

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -322,7 +322,14 @@ class DsValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one DS RDATA presentation string into internal field data.
+
+        :param str value: DS RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format DS field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             key_tag, algorithm, digest_type, digest = value.split(' ')
         except ValueError:
@@ -408,14 +415,19 @@ class DsValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal DS value as one RDATA presentation string.
+
+        :returns: DS RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return (
             f'{self.key_tag} {self.algorithm} {self.digest_type} {self.digest}'
         )

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -47,7 +47,13 @@ class _IpValue(str):
     VALIDATORS = [IpValueValidator('ip-value-rfc', sets={'legacy', 'strict'})]
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one address RDATA presentation string into internal text.
+
+        :param str value: address RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format address text
+        :rtype: str
+        '''
         return value
 
     @classmethod
@@ -70,14 +76,19 @@ class _IpValue(str):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal address as one RDATA presentation string.
+
+        :returns: address RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return self
 
     def template(self, params):

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -3,7 +3,7 @@
 #
 
 
-from .base import RdataValueMixin
+from .base import _deprecated_parse_rdata_text, _deprecated_rdata_text
 from .validator import ValidationReason, ValueValidator
 
 
@@ -43,7 +43,7 @@ class IpValueValidator(ValueValidator):
         return reasons
 
 
-class _IpValue(RdataValueMixin, str):
+class _IpValue(str):
     VALIDATORS = [IpValueValidator('ip-value-rfc', sets={'legacy', 'strict'})]
 
     @classmethod
@@ -66,6 +66,16 @@ class _IpValue(RdataValueMixin, str):
     def __new__(cls, v):
         v = str(cls._address_type(v))
         return super().__new__(cls, v)
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return self

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -3,6 +3,7 @@
 #
 
 
+from .base import RdataValueMixin
 from .validator import ValidationReason, ValueValidator
 
 
@@ -42,11 +43,11 @@ class IpValueValidator(ValueValidator):
         return reasons
 
 
-class _IpValue(str):
+class _IpValue(RdataValueMixin, str):
     VALIDATORS = [IpValueValidator('ip-value-rfc', sets={'legacy', 'strict'})]
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         return value
 
     @classmethod
@@ -66,8 +67,7 @@ class _IpValue(str):
         v = str(cls._address_type(v))
         return super().__new__(cls, v)
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -215,7 +215,14 @@ class LocValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one LOC RDATA presentation string into internal field data.
+
+        :param str value: LOC RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format LOC field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             value = value.replace('m', '')
             (
@@ -416,14 +423,19 @@ class LocValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal LOC value as one RDATA presentation string.
+
+        :returns: LOC RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f'{self.lat_degrees} {self.lat_minutes} {self.lat_seconds} {self.lat_direction} {self.long_degrees} {self.long_minutes} {self.long_seconds} {self.long_direction} {self.altitude}m {self.size}m {self.precision_horz}m {self.precision_vert}m'
 
     def template(self, params):

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -3,7 +3,13 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -134,7 +140,7 @@ class LocValueValidator(ValueValidator):
         return reasons
 
 
-class LocValue(RdataValueMixin, EqualityTupleMixin, dict):
+class LocValue(EqualityTupleMixin, dict):
     # TODO: this does not really match the RFC, but it's stuck using the details
     # of how the type was impelemented. Would be nice to rework things to match
     # while maintaining backwards compatibility.
@@ -406,6 +412,16 @@ class LocValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f'{self.lat_degrees} {self.lat_minutes} {self.lat_seconds} {self.lat_direction} {self.long_degrees} {self.long_minutes} {self.long_seconds} {self.long_direction} {self.altitude}m {self.size}m {self.precision_horz}m {self.precision_vert}m'

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -134,7 +134,7 @@ class LocValueValidator(ValueValidator):
         return reasons
 
 
-class LocValue(EqualityTupleMixin, dict):
+class LocValue(RdataValueMixin, EqualityTupleMixin, dict):
     # TODO: this does not really match the RFC, but it's stuck using the details
     # of how the type was impelemented. Would be nice to rework things to match
     # while maintaining backwards compatibility.
@@ -209,7 +209,7 @@ class LocValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             value = value.replace('m', '')
             (
@@ -407,8 +407,7 @@ class LocValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.lat_degrees} {self.lat_minutes} {self.lat_seconds} {self.lat_direction} {self.long_degrees} {self.long_minutes} {self.long_seconds} {self.long_direction} {self.altitude}m {self.size}m {self.precision_horz}m {self.precision_vert}m'
 
     def template(self, params):

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -10,7 +10,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -221,7 +221,7 @@ class LocValue(EqualityTupleMixin, dict):
         :param str value: LOC RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format LOC field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             value = value.replace('m', '')
@@ -240,7 +240,7 @@ class LocValue(EqualityTupleMixin, dict):
                 precision_vert,
             ) = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             lat_degrees = int(lat_degrees)
         except ValueError:

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -4,7 +4,13 @@
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .target import (
     _check_target_format,
@@ -155,7 +161,7 @@ class MxValueNotIpValidator(ValueValidator):
         return reasons
 
 
-class MxValue(RdataValueMixin, EqualityTupleMixin, dict):
+class MxValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         MxValueValidator('mx-value', sets={'legacy'}),
         MxValueRfcValidator('mx-value-rfc', sets={'strict'}),
@@ -250,6 +256,16 @@ class MxValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f'{self.preference} {self.exchange}'

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -206,7 +206,14 @@ class MxValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one MX RDATA presentation string into internal field data.
+
+        :param str value: MX RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format MX field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             preference, exchange = value.split(' ')
         except ValueError:
@@ -260,14 +267,19 @@ class MxValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal MX value as one RDATA presentation string.
+
+        :returns: MX RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f'{self.preference} {self.exchange}'
 
     def template(self, params):

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -11,7 +11,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .target import (
     _check_target_format,
     _check_target_not_ip,
@@ -212,12 +212,12 @@ class MxValue(EqualityTupleMixin, dict):
         :param str value: MX RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format MX field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             preference, exchange = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             preference = int(preference)
         except ValueError:

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -4,7 +4,7 @@
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import (
     _check_target_format,
@@ -155,7 +155,7 @@ class MxValueNotIpValidator(ValueValidator):
         return reasons
 
 
-class MxValue(EqualityTupleMixin, dict):
+class MxValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         MxValueValidator('mx-value', sets={'legacy'}),
         MxValueRfcValidator('mx-value-rfc', sets={'strict'}),
@@ -200,7 +200,7 @@ class MxValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             preference, exchange = value.split(' ')
         except ValueError:
@@ -251,8 +251,7 @@ class MxValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.preference} {self.exchange}'
 
     def template(self, params):

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import _check_target_trailing_dot
 from .validator import ValidationReason, ValueValidator
@@ -170,7 +170,7 @@ class NaptrValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class NaptrValue(EqualityTupleMixin, dict):
+class NaptrValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALID_FLAGS = ('S', 'A', 'U', 'P', 's', 'a', 'u', 'p')
 
     VALIDATORS = [
@@ -208,7 +208,7 @@ class NaptrValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             order, preference, flags, service, regexp, replacement = (
                 value.split(' ')
@@ -301,8 +301,7 @@ class NaptrValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         # RFC 3403 requires flags, service, and regexp to be quoted character-strings
         flags = self.flags or ''
         service = self.service or ''

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -214,7 +214,14 @@ class NaptrValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one NAPTR RDATA presentation string into internal field data.
+
+        :param str value: NAPTR RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format NAPTR field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             order, preference, flags, service, regexp, replacement = (
                 value.split(' ')
@@ -310,14 +317,19 @@ class NaptrValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal NAPTR value as one RDATA presentation string.
+
+        :returns: NAPTR RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         # RFC 3403 requires flags, service, and regexp to be quoted character-strings
         flags = self.flags or ''
         service = self.service or ''

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -10,7 +10,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .target import _check_target_trailing_dot
 from .validator import ValidationReason, ValueValidator
 
@@ -220,14 +220,14 @@ class NaptrValue(EqualityTupleMixin, dict):
         :param str value: NAPTR RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format NAPTR field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             order, preference, flags, service, regexp, replacement = (
                 value.split(' ')
             )
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             order = int(order)
             preference = int(preference)

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -3,7 +3,13 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .target import _check_target_trailing_dot
 from .validator import ValidationReason, ValueValidator
@@ -170,7 +176,7 @@ class NaptrValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class NaptrValue(RdataValueMixin, EqualityTupleMixin, dict):
+class NaptrValue(EqualityTupleMixin, dict):
     VALID_FLAGS = ('S', 'A', 'U', 'P', 's', 'a', 'u', 'p')
 
     VALIDATORS = [
@@ -300,6 +306,16 @@ class NaptrValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         # RFC 3403 requires flags, service, and regexp to be quoted character-strings

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -2,7 +2,12 @@
 #
 #
 
-from .base import RdataValueMixin, Record, ValuesMixin
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+)
 from .validator import ValidationReason, ValueValidator
 
 
@@ -18,7 +23,7 @@ class OpenpgpkeyValueValidator(ValueValidator):
         return []
 
 
-class OpenpgpkeyValue(RdataValueMixin, str):
+class OpenpgpkeyValue(str):
     '''
     OPENPGPKEY value - base64-encoded OpenPGP public key
 
@@ -44,6 +49,16 @@ class OpenpgpkeyValue(RdataValueMixin, str):
     @classmethod
     def process(cls, values):
         return [cls(v) for v in values]
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return self

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -41,7 +41,13 @@ class OpenpgpkeyValue(str):
         return {'type': 'string'}
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse OPENPGPKEY RDATA presentation text into internal text.
+
+        :param str value: OPENPGPKEY RDATA in master-file presentation format
+        :returns: whitespace-normalized octoDNS internal-format text
+        :rtype: str
+        '''
         # Strip whitespace that may appear in zone files (base64 data may be
         # split across lines)
         return value.replace(' ', '')
@@ -53,14 +59,19 @@ class OpenpgpkeyValue(str):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal OPENPGPKEY value as RDATA presentation text.
+
+        :returns: OPENPGPKEY RDATA in master-file presentation format
+        :rtype: str
+        '''
         return self
 
     def template(self, params):

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValuesMixin
+from .base import RdataValueMixin, Record, ValuesMixin
 from .validator import ValidationReason, ValueValidator
 
 
@@ -18,7 +18,7 @@ class OpenpgpkeyValueValidator(ValueValidator):
         return []
 
 
-class OpenpgpkeyValue(str):
+class OpenpgpkeyValue(RdataValueMixin, str):
     '''
     OPENPGPKEY value - base64-encoded OpenPGP public key
 
@@ -36,7 +36,7 @@ class OpenpgpkeyValue(str):
         return {'type': 'string'}
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         # Strip whitespace that may appear in zone files (base64 data may be
         # split across lines)
         return value.replace(' ', '')
@@ -45,8 +45,7 @@ class OpenpgpkeyValue(str):
     def process(cls, values):
         return [cls(v) for v in values]
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):

--- a/octodns/record/rr.py
+++ b/octodns/record/rr.py
@@ -2,6 +2,7 @@
 #
 #
 
+from ..deprecation import deprecated
 from .exception import RecordException
 
 
@@ -11,13 +12,28 @@ class RrParseError(RecordException):
 
 
 class Rr(object):
-    '''
-    Simple object intended to be used with Record.from_rrs to allow providers
-    that work with RFC formatted rdata to share centralized parsing/encoding
-    code
+    '''A deprecated carrier for one DNS resource record.
+
+    ``rdata`` is one RDATA presentation-format string. The owner ``name``,
+    record ``_type``, and ``ttl`` apply only to that value and the DNS class is
+    implicitly Internet (``IN``).
+
+    :param str name: fully-qualified owner name
+    :param str _type: DNS record type
+    :param int ttl: time to live in seconds
+    :param str rdata: one RDATA value in DNS master-file presentation format
+
+    .. deprecated:: 1.22.0
+       Use :class:`Rrset`, which groups all RDATA values for an owner and type.
+       ``Rr`` and :meth:`octodns.record.base.Record.from_rrs` will be removed
+       in 2.0.
     '''
 
     def __init__(self, name, _type, ttl, rdata):
+        deprecated(
+            '`Rr` is DEPRECATED. Use `Rrset` instead. Will be removed in 2.0.',
+            stacklevel=3,
+        )
         self.name = name
         self._type = _type
         self.ttl = ttl
@@ -25,3 +41,28 @@ class Rr(object):
 
     def __repr__(self):
         return f'Rr<{self.name}, {self._type}, {self.ttl}, {self.rdata}'
+
+
+class Rrset(object):
+    '''A grouped DNS resource-record set in presentation format.
+
+    The carrier represents one owner name, type, TTL, and an ordered list of
+    RDATA presentation-format strings. DNS class is not stored and is
+    implicitly Internet (``IN``). Unlike the deprecated :class:`Rr`, one
+    ``Rrset`` contains all values for the owner/type pair.
+
+    :param str name: fully-qualified owner name
+    :param str _type: DNS record type shared by all values
+    :param int ttl: time to live in seconds shared by all values
+    :param collections.abc.Iterable rdatas: RDATA values in DNS master-file
+        presentation format
+    '''
+
+    def __init__(self, name, _type, ttl, rdatas):
+        self.name = name
+        self._type = _type
+        self.ttl = ttl
+        self.rdatas = list(rdatas)
+
+    def __repr__(self):
+        return f'Rrset<{self.name}, {self._type}, {self.ttl}, {self.rdatas}'

--- a/octodns/record/rr.py
+++ b/octodns/record/rr.py
@@ -6,9 +6,19 @@ from ..deprecation import deprecated
 from .exception import RecordException
 
 
-class RrParseError(RecordException):
+class RdataParseError(RecordException):
+    '''Raised when RDATA presentation text cannot be parsed.
+
+    :param str message: description of the parse failure
+    '''
+
     def __init__(self, message='failed to parse string value as RR text'):
         super().__init__(message)
+
+
+# ``RrParseError`` is retained as an identity-preserving compatibility alias
+# throughout 1.x. It will be removed in 2.0.
+RrParseError = RdataParseError
 
 
 class Rr(object):

--- a/octodns/record/rr.py
+++ b/octodns/record/rr.py
@@ -3,6 +3,7 @@
 #
 
 from ..deprecation import deprecated
+from ..equality import EqualityTupleMixin
 from .exception import RecordException
 
 
@@ -12,7 +13,9 @@ class RdataParseError(RecordException):
     :param str message: description of the parse failure
     '''
 
-    def __init__(self, message='failed to parse string value as RR text'):
+    def __init__(
+        self, message='failed to parse string value as RDATA presentation text'
+    ):
         super().__init__(message)
 
 
@@ -53,26 +56,54 @@ class Rr(object):
         return f'Rr<{self.name}, {self._type}, {self.ttl}, {self.rdata}'
 
 
-class Rrset(object):
+class Rrset(EqualityTupleMixin):
     '''A grouped DNS resource-record set in presentation format.
 
     The carrier represents one owner name, type, TTL, and an ordered list of
     RDATA presentation-format strings. DNS class is not stored and is
     implicitly Internet (``IN``). Unlike the deprecated :class:`Rr`, one
-    ``Rrset`` contains all values for the owner/type pair.
+    ``Rrset`` contains all values for the owner/type pair. Equality and
+    ordering compare the name, type, TTL, and ordered RDATA values.
 
     :param str name: fully-qualified owner name
     :param str _type: DNS record type shared by all values
     :param int ttl: time to live in seconds shared by all values
     :param collections.abc.Iterable rdatas: RDATA values in DNS master-file
         presentation format
+    :raises octodns.record.exception.RecordException: if ``rdatas`` is not a
+        non-string iterable, is empty, or contains a non-string value
     '''
 
     def __init__(self, name, _type, ttl, rdatas):
         self.name = name
         self._type = _type
         self.ttl = ttl
-        self.rdatas = list(rdatas)
+        if isinstance(rdatas, str):
+            raise RecordException(
+                f'Invalid Rrset {name} {_type}: RDATA values must be a '
+                'non-string iterable of strings'
+            )
+        try:
+            self.rdatas = list(rdatas)
+        except TypeError:
+            raise RecordException(
+                f'Invalid Rrset {name} {_type}: RDATA values must be a '
+                'non-string iterable of strings'
+            ) from None
+        if not self.rdatas:
+            raise RecordException(
+                f'Invalid Rrset {name} {_type}: at least one RDATA value is '
+                'required'
+            )
+        for index, rdata in enumerate(self.rdatas):
+            if not isinstance(rdata, str):
+                raise RecordException(
+                    f'Invalid Rrset {name} {_type}: RDATA value at index '
+                    f'{index} must be a string'
+                )
+
+    def _equality_tuple(self):
+        return self.name, self._type, self.ttl, tuple(self.rdatas)
 
     def __repr__(self):
-        return f'Rrset<{self.name}, {self._type}, {self.ttl}, {self.rdatas}'
+        return f'Rrset<{self.name}, {self._type}, {self.ttl}, {self.rdatas}>'

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -6,7 +6,13 @@ import re
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .target import (
     _check_target_format,
@@ -263,7 +269,7 @@ class SrvValueNotIpValidator(ValueValidator):
         return reasons
 
 
-class SrvValue(RdataValueMixin, EqualityTupleMixin, dict):
+class SrvValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         SrvValueValidator('srv-value', sets={'legacy'}),
         SrvValueRfcValidator('srv-value-rfc', sets={'strict'}),
@@ -289,7 +295,7 @@ class SrvValue(RdataValueMixin, EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(self, value):
+    def from_rrs(cls, value):
         try:
             priority, weight, port, target = value.split(' ')
         except ValueError:
@@ -363,6 +369,16 @@ class SrvValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f"{self.priority} {self.weight} {self.port} {self.target}"

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -6,7 +6,7 @@ import re
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import (
     _check_target_format,
@@ -263,7 +263,7 @@ class SrvValueNotIpValidator(ValueValidator):
         return reasons
 
 
-class SrvValue(EqualityTupleMixin, dict):
+class SrvValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         SrvValueValidator('srv-value', sets={'legacy'}),
         SrvValueRfcValidator('srv-value-rfc', sets={'strict'}),
@@ -289,7 +289,7 @@ class SrvValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             priority, weight, port, target = value.split(' ')
         except ValueError:
@@ -364,8 +364,7 @@ class SrvValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f"{self.priority} {self.weight} {self.port} {self.target}"
 
     def template(self, params):

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -13,7 +13,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .target import (
     _check_target_format,
     _check_target_not_ip,
@@ -301,12 +301,12 @@ class SrvValue(EqualityTupleMixin, dict):
         :param str value: SRV RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format SRV field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             priority, weight, port, target = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             priority = int(priority)
         except ValueError:

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -295,7 +295,14 @@ class SrvValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one SRV RDATA presentation string into internal field data.
+
+        :param str value: SRV RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format SRV field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             priority, weight, port, target = value.split(' ')
         except ValueError:
@@ -373,14 +380,19 @@ class SrvValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal SRV value as one RDATA presentation string.
+
+        :returns: SRV RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f"{self.priority} {self.weight} {self.port} {self.target}"
 
     def template(self, params):

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -12,7 +12,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -245,12 +245,12 @@ class SshfpValue(EqualityTupleMixin, dict):
         :param str value: SSHFP RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format SSHFP field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             algorithm, fingerprint_type, fingerprint = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             algorithm = int(algorithm)
         except ValueError:

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -239,7 +239,14 @@ class SshfpValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one SSHFP RDATA presentation string into internal field data.
+
+        :param str value: SSHFP RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format SSHFP field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             algorithm, fingerprint_type, fingerprint = value.split(' ')
         except ValueError:
@@ -303,14 +310,19 @@ class SshfpValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal SSHFP value as one RDATA presentation string.
+
+        :returns: SSHFP RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f'{self.algorithm} {self.fingerprint_type} {self.fingerprint}'
 
     def template(self, params):

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -5,7 +5,13 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -206,7 +212,7 @@ class SshfpValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class SshfpValue(RdataValueMixin, EqualityTupleMixin, dict):
+class SshfpValue(EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
 
@@ -233,7 +239,7 @@ class SshfpValue(RdataValueMixin, EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(self, value):
+    def from_rrs(cls, value):
         try:
             algorithm, fingerprint_type, fingerprint = value.split(' ')
         except ValueError:
@@ -293,6 +299,16 @@ class SshfpValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f'{self.algorithm} {self.fingerprint_type} {self.fingerprint}'

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -5,7 +5,7 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -206,7 +206,7 @@ class SshfpValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class SshfpValue(EqualityTupleMixin, dict):
+class SshfpValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
 
@@ -233,7 +233,7 @@ class SshfpValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             algorithm, fingerprint_type, fingerprint = value.split(' ')
         except ValueError:
@@ -294,8 +294,7 @@ class SshfpValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.algorithm} {self.fingerprint_type} {self.fingerprint}'
 
     def template(self, params):

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -17,7 +17,7 @@ from .base import (
     unquote,
 )
 from .chunked import _ChunkedValue, chunked_value_validator
-from .rr import RrParseError
+from .rr import RdataParseError
 from .target import _check_target_format, _check_target_trailing_dot
 from .validator import ValidationReason, ValueValidator
 
@@ -299,12 +299,12 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         :param str value: RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format SVCB/HTTPS field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             svcpriority, targetname, *svcparams = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             svcpriority = int(svcpriority)
         except ValueError:
@@ -314,7 +314,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         for svcparam in svcparams:
             paramkey, *paramvalue = svcparam.split('=')
             if paramkey in params.keys():
-                raise RrParseError(f'{paramkey} is specified twice')
+                raise RdataParseError(f'{paramkey} is specified twice')
             if len(paramvalue) != 0:
                 parse_rdata_text = SUPPORTED_PARAMS.get(paramkey, {}).get(
                     'parse_rdata_text', None

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -146,7 +146,7 @@ def validate_svckey_number(paramkey, validator_id=None):
     return []
 
 
-def parse_rdata_text_svcparamvalue_list(svcparamvalue):
+def _svcparamvalue_list_from_rdata_text(svcparamvalue):
     if svcparamvalue.startswith('"'):
         svcparamvalue = svcparamvalue[1:-1]
     return svcparamvalue.split(',')
@@ -164,23 +164,23 @@ SUPPORTED_PARAMS = {
     'alpn': {
         'key_num': 1,
         'validate': validate_svcparam_alpn,
-        'parse_rdata_text': parse_rdata_text_svcparamvalue_list,
+        'from_rdata_text': _svcparamvalue_list_from_rdata_text,
     },
     'port': {'key_num': 3, 'validate': validate_svcparam_port},
     'ipv4hint': {
         'key_num': 4,
         'validate': validate_svcparam_ipv4hint,
-        'parse_rdata_text': parse_rdata_text_svcparamvalue_list,
+        'from_rdata_text': _svcparamvalue_list_from_rdata_text,
     },
     'ipv6hint': {
         'key_num': 6,
         'validate': validate_svcparam_ipv6hint,
-        'parse_rdata_text': parse_rdata_text_svcparamvalue_list,
+        'from_rdata_text': _svcparamvalue_list_from_rdata_text,
     },
     'mandatory': {
         'key_num': 0,
         'validate': validate_svcparam_mandatory,
-        'parse_rdata_text': parse_rdata_text_svcparamvalue_list,
+        'from_rdata_text': _svcparamvalue_list_from_rdata_text,
     },
     'ech': {'key_num': 5, 'validate': validate_svcparam_ech},
 }
@@ -316,16 +316,16 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
             if paramkey in params.keys():
                 raise RdataParseError(f'{paramkey} is specified twice')
             if len(paramvalue) != 0:
-                parse_rdata_text = SUPPORTED_PARAMS.get(paramkey, {}).get(
-                    'parse_rdata_text', None
+                param_parser = SUPPORTED_PARAMS.get(paramkey, {}).get(
+                    'from_rdata_text', None
                 )
-                if parse_rdata_text is None:
+                if param_parser is None:
                     v = paramvalue[0]
                     if v.startswith('"'):
                         v = v[1:-1]
                     params[paramkey] = v
                 else:
-                    params[paramkey] = parse_rdata_text(paramvalue[0])
+                    params[paramkey] = param_parser(paramvalue[0])
             else:
                 params[paramkey] = None
         return {

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -9,7 +9,13 @@ from ipaddress import AddressValueError, IPv4Address, IPv6Address
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .chunked import _ChunkedValue, chunked_value_validator
 from .rr import RrParseError
 from .target import _check_target_format, _check_target_trailing_dot
@@ -269,7 +275,7 @@ class SvcbValueValidator(ValueValidator):
         return reasons
 
 
-class _SvcbValueBase(RdataValueMixin, EqualityTupleMixin, dict):
+class _SvcbValueBase(EqualityTupleMixin, dict):
     @classmethod
     def _schema(cls):
         return {
@@ -357,6 +363,16 @@ class _SvcbValueBase(RdataValueMixin, EqualityTupleMixin, dict):
     @svcparams.setter
     def svcparams(self, value):
         self['svcparams'] = value
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         params = ''

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -9,7 +9,7 @@ from ipaddress import AddressValueError, IPv4Address, IPv6Address
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .chunked import _ChunkedValue, chunked_value_validator
 from .rr import RrParseError
 from .target import _check_target_format, _check_target_trailing_dot
@@ -269,7 +269,7 @@ class SvcbValueValidator(ValueValidator):
         return reasons
 
 
-class _SvcbValueBase(EqualityTupleMixin, dict):
+class _SvcbValueBase(RdataValueMixin, EqualityTupleMixin, dict):
     @classmethod
     def _schema(cls):
         return {
@@ -287,7 +287,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             svcpriority, targetname, *svcparams = value.split(' ')
         except ValueError:
@@ -358,8 +358,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
     def svcparams(self, value):
         self['svcparams'] = value
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         params = ''
         sorted_svcparamkeys = sorted(self.svcparams, key=svcparamkeysort)
         for svcparamkey in sorted_svcparamkeys:
@@ -396,7 +395,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         return (self.svcpriority, self.targetname, params)
 
     def __repr__(self):
-        return f"'{self.rdata_text}'"
+        return f"'{self.to_rrs()}'"
 
 
 class SvcbValueBestPracticeValidator(ValueValidator):

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -293,7 +293,14 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse SVCB/HTTPS RDATA presentation text into internal field data.
+
+        :param str value: RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format SVCB/HTTPS field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             svcpriority, targetname, *svcparams = value.split(' ')
         except ValueError:
@@ -367,14 +374,19 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal SVCB/HTTPS value as RDATA presentation text.
+
+        :returns: RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         params = ''
         sorted_svcparamkeys = sorted(self.svcparams, key=svcparamkeysort)
         for svcparamkey in sorted_svcparamkeys:
@@ -411,7 +423,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         return (self.svcpriority, self.targetname, params)
 
     def __repr__(self):
-        return f"'{self.to_rrs()}'"
+        return f"'{self.to_rdata_text()}'"
 
 
 class SvcbValueBestPracticeValidator(ValueValidator):

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -7,7 +7,7 @@ import ipaddress
 from fqdn import FQDN
 
 from ..idna import idna_encode
-from .base import RdataValueMixin
+from .base import _deprecated_parse_rdata_text, _deprecated_rdata_text
 from .validator import ValidationReason, ValueValidator
 
 
@@ -154,7 +154,7 @@ class TargetsValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class _TargetValue(RdataValueMixin, str):
+class _TargetValue(str):
     VALIDATORS = [
         TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'}),
         TargetValueNotIpValidator('target-value-not-ip', sets={'strict'}),
@@ -164,7 +164,7 @@ class _TargetValue(RdataValueMixin, str):
     ]
 
     @classmethod
-    def from_rrs(self, value):
+    def from_rrs(cls, value):
         return value
 
     @classmethod
@@ -181,6 +181,16 @@ class _TargetValue(RdataValueMixin, str):
         v = idna_encode(v)
         return super().__new__(cls, v)
 
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
+
     def to_rrs(self):
         return self
 
@@ -192,7 +202,7 @@ class _TargetValue(RdataValueMixin, str):
 
 #
 # much like _TargetValue, but geared towards multiple values
-class _TargetsValue(RdataValueMixin, str):
+class _TargetsValue(str):
     VALIDATORS = [
         TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'}),
         TargetsValueNotIpValidator('targets-value-not-ip', sets={'strict'}),
@@ -216,6 +226,16 @@ class _TargetsValue(RdataValueMixin, str):
     def __new__(cls, v):
         v = idna_encode(v)
         return super().__new__(cls, v)
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return self

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -164,7 +164,13 @@ class _TargetValue(str):
     ]
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse target RDATA presentation text into octoDNS internal text.
+
+        :param str value: target in DNS master-file presentation format
+        :returns: octoDNS internal-format target text
+        :rtype: str
+        '''
         return value
 
     @classmethod
@@ -184,14 +190,19 @@ class _TargetValue(str):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal target as one RDATA presentation string.
+
+        :returns: target in DNS master-file presentation format
+        :rtype: str
+        '''
         return self
 
     def template(self, params):
@@ -212,7 +223,13 @@ class _TargetsValue(str):
     ]
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse target RDATA presentation text into octoDNS internal text.
+
+        :param str value: target in DNS master-file presentation format
+        :returns: octoDNS internal-format target text
+        :rtype: str
+        '''
         return value
 
     @classmethod
@@ -230,14 +247,19 @@ class _TargetsValue(str):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal target as one RDATA presentation string.
+
+        :returns: target in DNS master-file presentation format
+        :rtype: str
+        '''
         return self
 
     def template(self, params):

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -7,6 +7,7 @@ import ipaddress
 from fqdn import FQDN
 
 from ..idna import idna_encode
+from .base import RdataValueMixin
 from .validator import ValidationReason, ValueValidator
 
 
@@ -153,7 +154,7 @@ class TargetsValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class _TargetValue(str):
+class _TargetValue(RdataValueMixin, str):
     VALIDATORS = [
         TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'}),
         TargetValueNotIpValidator('target-value-not-ip', sets={'strict'}),
@@ -163,7 +164,7 @@ class _TargetValue(str):
     ]
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         return value
 
     @classmethod
@@ -180,8 +181,7 @@ class _TargetValue(str):
         v = idna_encode(v)
         return super().__new__(cls, v)
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):
@@ -192,7 +192,7 @@ class _TargetValue(str):
 
 #
 # much like _TargetValue, but geared towards multiple values
-class _TargetsValue(str):
+class _TargetsValue(RdataValueMixin, str):
     VALIDATORS = [
         TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'}),
         TargetsValueNotIpValidator('targets-value-not-ip', sets={'strict'}),
@@ -202,7 +202,7 @@ class _TargetsValue(str):
     ]
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         return value
 
     @classmethod
@@ -217,8 +217,7 @@ class _TargetsValue(str):
         v = idna_encode(v)
         return super().__new__(cls, v)
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -254,7 +254,14 @@ class TlsaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one TLSA RDATA presentation string into internal field data.
+
+        :param str value: TLSA RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format TLSA field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             (
                 certificate_usage,
@@ -337,14 +344,19 @@ class TlsaValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal TLSA value as one RDATA presentation string.
+
+        :returns: TLSA RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f'{self.certificate_usage} {self.selector} {self.matching_type} {self.certificate_association_data}'
 
     def template(self, params):

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -5,7 +5,7 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -212,7 +212,7 @@ class TlsaValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class TlsaValue(EqualityTupleMixin, dict):
+class TlsaValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         TlsaValueValidator('tlsa-value', sets={'legacy'}),
         TlsaValueRfcValidator('tlsa-value-rfc', sets={'strict'}),
@@ -248,7 +248,7 @@ class TlsaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             (
                 certificate_usage,
@@ -328,8 +328,7 @@ class TlsaValue(EqualityTupleMixin, dict):
     def certificate_association_data(self, value):
         self['certificate_association_data'] = value
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.certificate_usage} {self.selector} {self.matching_type} {self.certificate_association_data}'
 
     def template(self, params):

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -5,7 +5,13 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -212,7 +218,7 @@ class TlsaValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class TlsaValue(RdataValueMixin, EqualityTupleMixin, dict):
+class TlsaValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         TlsaValueValidator('tlsa-value', sets={'legacy'}),
         TlsaValueRfcValidator('tlsa-value-rfc', sets={'strict'}),
@@ -248,7 +254,7 @@ class TlsaValue(RdataValueMixin, EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(self, value):
+    def from_rrs(cls, value):
         try:
             (
                 certificate_usage,
@@ -327,6 +333,16 @@ class TlsaValue(RdataValueMixin, EqualityTupleMixin, dict):
     @certificate_association_data.setter
     def certificate_association_data(self, value):
         self['certificate_association_data'] = value
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f'{self.certificate_usage} {self.selector} {self.matching_type} {self.certificate_association_data}'

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -12,7 +12,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -260,7 +260,7 @@ class TlsaValue(EqualityTupleMixin, dict):
         :param str value: TLSA RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format TLSA field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             (
@@ -270,7 +270,7 @@ class TlsaValue(EqualityTupleMixin, dict):
                 certificate_association_data,
             ) = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             certificate_usage = int(certificate_usage)
         except ValueError:

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -6,7 +6,13 @@ import re
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .validator import RecordValidator, ValidationReason, ValueValidator
 
@@ -132,7 +138,7 @@ class UriValueRfcValidator(ValueValidator):
         return reasons
 
 
-class UriValue(RdataValueMixin, EqualityTupleMixin, dict):
+class UriValue(EqualityTupleMixin, dict):
     VALIDATORS = [
         UriValueValidator('uri-value', sets={'legacy'}),
         UriValueRfcValidator('uri-value-rfc', sets={'strict'}),
@@ -151,7 +157,7 @@ class UriValue(RdataValueMixin, EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(self, value):
+    def from_rrs(cls, value):
         try:
             priority, weight, target = value.split(' ')
         except ValueError:
@@ -207,6 +213,16 @@ class UriValue(RdataValueMixin, EqualityTupleMixin, dict):
     @property
     def data(self):
         return self
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f'{self.priority} {self.weight} "{self.target}"'

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -157,7 +157,14 @@ class UriValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse one URI RDATA presentation string into internal field data.
+
+        :param str value: URI RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format URI field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             priority, weight, target = value.split(' ')
         except ValueError:
@@ -217,14 +224,19 @@ class UriValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal URI value as one RDATA presentation string.
+
+        :returns: URI RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f'{self.priority} {self.weight} "{self.target}"'
 
     def template(self, params):

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -6,7 +6,7 @@ import re
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import RecordValidator, ValidationReason, ValueValidator
 
@@ -132,7 +132,7 @@ class UriValueRfcValidator(ValueValidator):
         return reasons
 
 
-class UriValue(EqualityTupleMixin, dict):
+class UriValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         UriValueValidator('uri-value', sets={'legacy'}),
         UriValueRfcValidator('uri-value-rfc', sets={'strict'}),
@@ -151,7 +151,7 @@ class UriValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             priority, weight, target = value.split(' ')
         except ValueError:
@@ -208,8 +208,7 @@ class UriValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.priority} {self.weight} "{self.target}"'
 
     def template(self, params):

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -13,7 +13,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import RecordValidator, ValidationReason, ValueValidator
 
 
@@ -163,12 +163,12 @@ class UriValue(EqualityTupleMixin, dict):
         :param str value: URI RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format URI field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             priority, weight, target = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             priority = int(priority)
         except ValueError:

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -10,7 +10,7 @@ from .base import (
     _deprecated_rdata_text,
     unquote,
 )
-from .rr import RrParseError
+from .rr import RdataParseError
 from .validator import ValidationReason, ValueValidator
 
 
@@ -122,12 +122,12 @@ class UrlfwdValue(EqualityTupleMixin, dict):
         :param str value: URLFWD RDATA in DNS master-file presentation format
         :returns: octoDNS internal-format URLFWD field mapping
         :rtype: dict
-        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        :raises octodns.record.rr.RdataParseError: if ``value`` is invalid
         '''
         try:
             path, target, code, masking, query = value.split(' ')
         except ValueError:
-            raise RrParseError()
+            raise RdataParseError()
         try:
             code = int(code)
         except ValueError:

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -116,7 +116,14 @@ class UrlfwdValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(cls, value):
+    def from_rdata_text(cls, value):
+        '''Parse URLFWD RDATA presentation text into internal field data.
+
+        :param str value: URLFWD RDATA in DNS master-file presentation format
+        :returns: octoDNS internal-format URLFWD field mapping
+        :rtype: dict
+        :raises octodns.record.rr.RrParseError: if ``value`` is invalid
+        '''
         try:
             path, target, code, masking, query = value.split(' ')
         except ValueError:
@@ -201,14 +208,19 @@ class UrlfwdValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         _deprecated_parse_rdata_text(cls)
-        return cls.from_rrs(value)
+        return cls.from_rdata_text(value)
 
     @property
     def rdata_text(self):
         _deprecated_rdata_text(self)
-        return self.to_rrs()
+        return self.to_rdata_text()
 
-    def to_rrs(self):
+    def to_rdata_text(self):
+        '''Render this internal URLFWD value as RDATA presentation text.
+
+        :returns: URLFWD RDATA in DNS master-file presentation format
+        :rtype: str
+        '''
         return f'"{self.path}" "{self.target}" {self.code} {self.masking} {self.query}'
 
     def template(self, params):

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -3,7 +3,13 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import RdataValueMixin, Record, ValuesMixin, unquote
+from .base import (
+    Record,
+    ValuesMixin,
+    _deprecated_parse_rdata_text,
+    _deprecated_rdata_text,
+    unquote,
+)
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -86,7 +92,7 @@ class UrlfwdValueValidator(ValueValidator):
         return reasons
 
 
-class UrlfwdValue(RdataValueMixin, EqualityTupleMixin, dict):
+class UrlfwdValue(EqualityTupleMixin, dict):
     VALID_CODES = (301, 302)
     VALID_MASKS = (0, 1, 2)
     VALID_QUERY = (0, 1)
@@ -110,7 +116,7 @@ class UrlfwdValue(RdataValueMixin, EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def from_rrs(self, value):
+    def from_rrs(cls, value):
         try:
             path, target, code, masking, query = value.split(' ')
         except ValueError:
@@ -191,6 +197,16 @@ class UrlfwdValue(RdataValueMixin, EqualityTupleMixin, dict):
     @query.setter
     def query(self, value):
         self['query'] = value
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        _deprecated_parse_rdata_text(cls)
+        return cls.from_rrs(value)
+
+    @property
+    def rdata_text(self):
+        _deprecated_rdata_text(self)
+        return self.to_rrs()
 
     def to_rrs(self):
         return f'"{self.path}" "{self.target}" {self.code} {self.masking} {self.query}'

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import RdataValueMixin, Record, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -86,7 +86,7 @@ class UrlfwdValueValidator(ValueValidator):
         return reasons
 
 
-class UrlfwdValue(EqualityTupleMixin, dict):
+class UrlfwdValue(RdataValueMixin, EqualityTupleMixin, dict):
     VALID_CODES = (301, 302)
     VALID_MASKS = (0, 1, 2)
     VALID_QUERY = (0, 1)
@@ -110,7 +110,7 @@ class UrlfwdValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             path, target, code, masking, query = value.split(' ')
         except ValueError:
@@ -192,8 +192,7 @@ class UrlfwdValue(EqualityTupleMixin, dict):
     def query(self, value):
         self['query'] = value
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'"{self.path}" "{self.target}" {self.code} {self.masking} {self.query}'
 
     def template(self, params):

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -341,9 +341,11 @@ class TinyDnsBaseSource(BaseSource):
 
             rdatas = [l[2] for l in lines]
             if _type in ('SPF', 'TXT'):
-                # TinyDNS stores TXT/SPF values in octoDNS's raw format, not
-                # presentation-format RDATA.
-                values = [_class._value_type.from_raw(r) for r in rdatas]
+                # TinyDNS stores TXT/SPF values as raw, unescaped text rather
+                # than presentation-format RDATA.
+                values = [
+                    _class._value_type.normalize_raw_text(r) for r in rdatas
+                ]
             else:
                 values = _class.parse_rdata_texts(rdatas)
             yield _type, name, ttl, values

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -340,7 +340,13 @@ class TinyDnsBaseSource(BaseSource):
             ttl = self._ttl_for(lines, 3)
 
             rdatas = [l[2] for l in lines]
-            yield _type, name, ttl, _class.parse_rdata_texts(rdatas)
+            if _type in ('SPF', 'TXT'):
+                # TinyDNS stores TXT/SPF values in octoDNS's raw format, not
+                # presentation-format RDATA.
+                values = [_class._value_type.from_raw(r) for r in rdatas]
+            else:
+                values = _class.parse_rdata_texts(rdatas)
+            yield _type, name, ttl, values
 
     def _records_for_six(self, zone, name, lines, arpa=False):
         # 6fqdn:ip:ttl:timestamp:lo

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -240,10 +240,9 @@ class TestValueAllowListFilter(TestCase):
 
         self.assertEqual(7, len(self.zone.records))
         filtered = allows.process_source_zone(self.zone.copy(), None)
-        self.assertEqual(2, len(filtered.records))
+        self.assertEqual(1, len(filtered.records))
         self.assertEqual(
-            ['good.exact', 'good.values'],
-            sorted([r.name for r in filtered.records]),
+            ['good.exact'], sorted([r.name for r in filtered.records])
         )
 
     def test_regex(self):
@@ -317,12 +316,13 @@ class TestValueRejectListFilter(TestCase):
 
         self.assertEqual(7, len(self.zone.records))
         filtered = rejects.process_source_zone(self.zone.copy(), None)
-        self.assertEqual(5, len(filtered.records))
+        self.assertEqual(6, len(filtered.records))
         self.assertEqual(
             [
                 'bad.compare',
                 'bad.values',
                 'first.regex',
+                'good.values',
                 'no.values',
                 'second.regex',
             ],

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -16,9 +16,11 @@ from octodns.record import (
     Ipv4Value,
     MxValue,
     NsValue,
+    RdataParseError,
     Record,
     RecordException,
     Rr,
+    RrParseError,
     Rrset,
     SrvValue,
     TxtRecord,
@@ -760,6 +762,17 @@ class TestRecord(TestCase):
         self.assertTrue(aaaa <= aaaa)
 
     def test_rr(self):
+        self.assertIs(RdataParseError, RrParseError)
+        self.assertEqual(
+            'failed to parse string value as RR text', str(RdataParseError())
+        )
+        self.assertEqual(
+            'failed to parse string value as RR text', str(RrParseError())
+        )
+        self.assertEqual(
+            'custom message', str(RdataParseError('custom message'))
+        )
+
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter('always')
             expected_line = currentframe().f_lineno + 1

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -5,6 +5,7 @@
 import warnings
 from inspect import currentframe
 from unittest import TestCase
+from unittest.mock import patch
 
 from octodns.idna import idna_encode
 from octodns.record import (
@@ -28,6 +29,7 @@ from octodns.record import (
     ValidationError,
     ValuesMixin,
 )
+from octodns.record import base as record_base
 from octodns.record.base import unquote
 from octodns.yaml import ContextDict
 from octodns.zone import Zone
@@ -212,6 +214,69 @@ class TestRecord(TestCase):
             [],
             [warning for warning in caught if 'Value.' in str(warning.message)],
         )
+
+    def test_value_rdata_mro_dispatch_caching(self):
+        class LegacyValue(Ipv4Value):
+            @classmethod
+            def parse_rdata_text(cls, value):
+                return '192.0.2.2'
+
+            @property
+            def rdata_text(self):
+                return '192.0.2.3'
+
+        class NewValue(Ipv4Value):
+            pass
+
+        parse_uses_legacy = record_base._value_from_rdata_text_uses_legacy
+        render_uses_legacy = record_base._value_to_rdata_text_uses_legacy
+        parse_uses_legacy.cache_clear()
+        render_uses_legacy.cache_clear()
+        try:
+            with patch.object(
+                record_base, '_mro_owner', wraps=record_base._mro_owner
+            ) as mro_owner:
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter('always')
+                    for _ in range(2):
+                        self.assertEqual(
+                            '192.0.2.2',
+                            record_base.value_from_rdata_text(
+                                LegacyValue, '192.0.2.1'
+                            ),
+                        )
+                        self.assertEqual(
+                            '192.0.2.3',
+                            record_base.value_to_rdata_text(
+                                LegacyValue('192.0.2.1')
+                            ),
+                        )
+
+                self.assertEqual(4, mro_owner.call_count)
+                self.assertEqual(
+                    [
+                        '`LegacyValue.parse_rdata_text` is DEPRECATED. '
+                        'Implement `from_rdata_text()` instead. Will be '
+                        'removed in 2.0.',
+                        '`LegacyValue.rdata_text` is DEPRECATED. Implement '
+                        '`to_rdata_text()` instead. Will be removed in 2.0.',
+                    ]
+                    * 2,
+                    [str(warning.message) for warning in caught],
+                )
+
+                self.assertEqual(
+                    '192.0.2.1',
+                    record_base.value_from_rdata_text(NewValue, '192.0.2.1'),
+                )
+                self.assertEqual(
+                    '192.0.2.1',
+                    record_base.value_to_rdata_text(NewValue('192.0.2.1')),
+                )
+                self.assertEqual(8, mro_owner.call_count)
+        finally:
+            parse_uses_legacy.cache_clear()
+            render_uses_legacy.cache_clear()
 
     def test_registration(self):
         with self.assertRaises(RecordException) as ctx:

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -66,14 +66,17 @@ class TestRecord(TestCase):
                 )[0].data,
             )
         self.assertEqual(
-            2,
-            len(
-                [
-                    warning
-                    for warning in caught
-                    if 'LegacyValue' in str(warning.message)
-                ]
-            ),
+            [
+                '`LegacyValue.rdata_text` is DEPRECATED. Implement '
+                '`to_rrs()` instead. Will be removed in 2.0.',
+                '`LegacyValue.parse_rdata_text` is DEPRECATED. Implement '
+                '`from_rrs()` instead. Will be removed in 2.0.',
+            ],
+            [
+                str(warning.message)
+                for warning in caught
+                if 'LegacyValue' in str(warning.message)
+            ],
         )
 
     def test_registration(self):
@@ -661,19 +664,38 @@ class TestRecord(TestCase):
                         value_type.from_rrs(rdata),
                         value_type.parse_rdata_text(rdata),
                     )
-            self.assertEqual(2, len(caught), _type)
-            _, _, _, rdatas = record.rrs
+            value_type_name = value_type.__name__
             self.assertEqual(
-                record.data,
-                Record.from_rrs(
+                [
+                    f'`{value_type_name}.rdata_text` is DEPRECATED. Use '
+                    f'`{value_type_name}.to_rrs()` instead. Will be removed in 2.0.',
+                    f'`{value_type_name}.parse_rdata_text` is DEPRECATED. Use '
+                    f'`{value_type_name}.from_rrs()` instead. Will be removed in 2.0.',
+                ],
+                [str(warning.message) for warning in caught],
+                _type,
+            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                _, _, _, rdatas = record.rrs
+                round_trip = Record.from_rrs(
                     self.zone,
                     [
                         Rr(record.fqdn, _type, record.ttl, rdata)
                         for rdata in rdatas
                     ],
-                )[0].data,
+                )[0]
+            self.assertEqual(
+                [],
+                [
+                    warning
+                    for warning in caught
+                    if '.rdata_text' in str(warning.message)
+                    or '.parse_rdata_text' in str(warning.message)
+                ],
                 _type,
             )
+            self.assertEqual(record.data, round_trip.data, _type)
 
     def test_unquote(self):
         s = 'Hello "\'"World!'

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -3,6 +3,7 @@
 #
 
 import warnings
+from inspect import currentframe
 from unittest import TestCase
 
 from octodns.idna import idna_encode
@@ -12,11 +13,13 @@ from octodns.record import (
     CnameRecord,
     Create,
     Delete,
+    Ipv4Value,
     MxValue,
     NsValue,
     Record,
     RecordException,
     Rr,
+    Rrset,
     SrvValue,
     TxtRecord,
     Update,
@@ -68,15 +71,144 @@ class TestRecord(TestCase):
         self.assertEqual(
             [
                 '`LegacyValue.rdata_text` is DEPRECATED. Implement '
-                '`to_rrs()` instead. Will be removed in 2.0.',
+                '`to_rdata_text()` instead. Will be removed in 2.0.',
                 '`LegacyValue.parse_rdata_text` is DEPRECATED. Implement '
-                '`from_rrs()` instead. Will be removed in 2.0.',
+                '`from_rdata_text()` instead. Will be removed in 2.0.',
             ],
             [
                 str(warning.message)
                 for warning in caught
                 if 'LegacyValue' in str(warning.message)
             ],
+        )
+
+    def test_value_rdata_mro_dispatch(self):
+        class ParseOnlyValue(Ipv4Value):
+            @classmethod
+            def parse_rdata_text(cls, value):
+                return '192.0.2.2'
+
+        class ParseOnlyRecord(ValuesMixin, Record):
+            _type = 'PARSEONLY'
+            _value_type = ParseOnlyValue
+
+        class RenderOnlyValue(Ipv4Value):
+            @property
+            def rdata_text(self):
+                return '192.0.2.3'
+
+        class RenderOnlyRecord(ValuesMixin, Record):
+            _type = 'RENDERONLY'
+            _value_type = RenderOnlyValue
+
+        class IntermediateValue(Ipv4Value):
+            @classmethod
+            def parse_rdata_text(cls, value):
+                return '192.0.2.4'
+
+        class InheritedValue(IntermediateValue):
+            pass
+
+        class InheritedRecord(ValuesMixin, Record):
+            _type = 'INHERITEDOLD'
+            _value_type = InheritedValue
+
+        class BothValue(Ipv4Value):
+            @classmethod
+            def parse_rdata_text(cls, value):
+                return '192.0.2.5'
+
+            @classmethod
+            def from_rdata_text(cls, value):
+                return '192.0.2.6'
+
+            @property
+            def rdata_text(self):
+                return '192.0.2.7'
+
+            def to_rdata_text(self):
+                return '192.0.2.8'
+
+        class BothRecord(ValuesMixin, Record):
+            _type = 'BOTHAPIS'
+            _value_type = BothValue
+
+        class ExplicitNewValue(IntermediateValue):
+            @classmethod
+            def from_rdata_text(cls, value):
+                return '192.0.2.9'
+
+        class ExplicitNewRecord(ValuesMixin, Record):
+            _type = 'EXPLICITNEW'
+            _value_type = ExplicitNewValue
+
+        for record_class in (
+            ParseOnlyRecord,
+            RenderOnlyRecord,
+            InheritedRecord,
+            BothRecord,
+            ExplicitNewRecord,
+        ):
+            Record.register_type(record_class)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            record = Record.from_rrset(
+                self.zone,
+                Rrset('parse.unit.tests.', 'PARSEONLY', 30, ['192.0.2.1']),
+            )
+        self.assertEqual(['192.0.2.2'], record.values)
+        self.assertEqual(
+            '`ParseOnlyValue.parse_rdata_text` is DEPRECATED. Implement '
+            '`from_rdata_text()` instead. Will be removed in 2.0.',
+            str(caught[0].message),
+        )
+
+        record = RenderOnlyRecord(
+            self.zone, 'render', {'ttl': 30, 'values': ['192.0.2.1']}
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            rrset = record.to_rrset()
+        self.assertEqual(['192.0.2.3'], rrset.rdatas)
+        self.assertEqual(
+            '`RenderOnlyValue.rdata_text` is DEPRECATED. Implement '
+            '`to_rdata_text()` instead. Will be removed in 2.0.',
+            str(caught[0].message),
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            record = Record.from_rrset(
+                self.zone,
+                Rrset(
+                    'inherited.unit.tests.', 'INHERITEDOLD', 30, ['192.0.2.1']
+                ),
+            )
+        self.assertEqual(['192.0.2.4'], record.values)
+        self.assertEqual(
+            '`InheritedValue.parse_rdata_text` is DEPRECATED. Implement '
+            '`from_rdata_text()` instead. Will be removed in 2.0.',
+            str(caught[0].message),
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            both = Record.from_rrset(
+                self.zone,
+                Rrset('both.unit.tests.', 'BOTHAPIS', 30, ['192.0.2.1']),
+            )
+            both_rrset = both.to_rrset()
+            explicit = Record.from_rrset(
+                self.zone,
+                Rrset('new.unit.tests.', 'EXPLICITNEW', 30, ['192.0.2.1']),
+            )
+        self.assertEqual(['192.0.2.6'], both.values)
+        self.assertEqual(['192.0.2.8'], both_rrset.rdatas)
+        self.assertEqual(['192.0.2.9'], explicit.values)
+        self.assertEqual(
+            [],
+            [warning for warning in caught if 'Value.' in str(warning.message)],
         )
 
     def test_registration(self):
@@ -230,6 +362,101 @@ class TestRecord(TestCase):
         self.assertEqual('target.unit.tests.', record.value)
         # make sure there's nothing extra
         self.assertEqual(5, len(records))
+
+        # The record-class compatibility helpers remain available even though
+        # Record.from_rrs now delegates through grouped Rrsets.
+        self.assertEqual(
+            {'ttl': 42, 'type': 'A', 'values': ['1.2.3.4', '2.3.4.5']},
+            ARecord.data_from_rrs((rrs[0], rrs[3])),
+        )
+        self.assertEqual(
+            {'ttl': 46, 'type': 'CNAME', 'value': 'target.unit.tests.'},
+            CnameRecord.data_from_rrs((rrs[4],)),
+        )
+
+    def test_rrset_conversion(self):
+        zone = Zone('unit.tests.', [])
+        source = object()
+        rrsets = (
+            Rrset('www.unit.tests.', 'AAAA', 45, ['fc00::3']),
+            Rrset('unit.tests.', 'A', 42, ['2.3.4.5', '1.2.3.4', '1.2.3.4']),
+            Rrset('www.unit.tests.', 'A', 44, ['3.4.5.6']),
+        )
+
+        records = Record.from_rrsets(zone, rrsets, source=source)
+        self.assertEqual(
+            [('', 'A'), ('www', 'A'), ('www', 'AAAA')],
+            [(record.name, record._type) for record in records],
+        )
+        self.assertEqual(['1.2.3.4', '1.2.3.4', '2.3.4.5'], records[0].values)
+        self.assertTrue(all(record.source is source for record in records))
+
+        rrset = records[0].to_rrset()
+        self.assertEqual('unit.tests.', rrset.name)
+        self.assertEqual('A', rrset._type)
+        self.assertEqual(42, rrset.ttl)
+        self.assertEqual(['1.2.3.4', '1.2.3.4', '2.3.4.5'], rrset.rdatas)
+        self.assertEqual(records[0].data, Record.from_rrset(zone, rrset).data)
+
+        self.assertEqual([], Record.from_rrsets(zone, []))
+        with self.assertRaises(RecordException) as ctx:
+            Record.from_rrset(zone, Rrset('unit.tests.', 'A', 42, []))
+        self.assertEqual(
+            'Invalid Rrset unit.tests. A: at least one RDATA value is required',
+            str(ctx.exception),
+        )
+        with self.assertRaises(RecordException) as ctx:
+            Record.from_rrsets(
+                zone,
+                (
+                    Rrset('unit.tests.', 'A', 42, ['1.2.3.4']),
+                    Rrset('unit.tests.', 'A', 43, ['2.3.4.5']),
+                ),
+            )
+        self.assertEqual('Duplicate Rrset unit.tests. A', str(ctx.exception))
+
+    def test_rrset_lenient_and_legacy_conversion(self):
+        zone = Zone('unit.tests.', [])
+        source = object()
+        rrset = Rrset('bad.unit.tests.', 'CNAME', 42, ['not a valid target'])
+        record = Record.from_rrset(zone, rrset, lenient=True, source=source)
+        self.assertEqual('not a valid target', record.value)
+        self.assertIs(source, record.source)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            legacy = [
+                Rr('unit.tests.', 'A', 42, '2.3.4.5'),
+                Rr('unit.tests.', 'A', 99, '1.2.3.4'),
+            ]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            records = Record.from_rrs(
+                zone, iter(legacy), lenient=True, source=source
+            )
+        self.assertEqual(
+            [
+                '`Record.from_rrs` is DEPRECATED. Use '
+                '`Record.from_rrsets()` instead. Will be removed in 2.0.'
+            ],
+            [
+                str(warning.message)
+                for warning in caught
+                if 'Record.from_rrs' in str(warning.message)
+            ],
+        )
+        self.assertEqual(42, records[0].ttl)
+        self.assertEqual(['1.2.3.4', '2.3.4.5'], records[0].values)
+        self.assertIs(source, records[0].source)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual([], Record.from_rrs(zone, ()))
+        self.assertEqual(
+            '`Record.from_rrs` is DEPRECATED. Use `Record.from_rrsets()` '
+            'instead. Will be removed in 2.0.',
+            str(caught[0].message),
+        )
 
     def test_parse_rdata_texts(self):
         self.assertEqual(['2.3.4.5'], ARecord.parse_rdata_texts(['2.3.4.5']))
@@ -533,8 +760,30 @@ class TestRecord(TestCase):
         self.assertTrue(aaaa <= aaaa)
 
     def test_rr(self):
-        # nothing much to test, just make sure that things don't blow up
-        Rr('name', 'type', 42, 'Hello World!').__repr__()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            expected_line = currentframe().f_lineno + 1
+            rr = Rr('name', 'type', 42, 'Hello World!')
+        self.assertEqual(
+            '`Rr` is DEPRECATED. Use `Rrset` instead. Will be removed in 2.0.',
+            str(caught[0].message),
+        )
+        self.assertEqual(__file__, caught[0].filename)
+        self.assertEqual(expected_line, caught[0].lineno)
+        self.assertEqual('name', rr.name)
+        self.assertEqual('type', rr._type)
+        self.assertEqual(42, rr.ttl)
+        self.assertEqual('Hello World!', rr.rdata)
+        self.assertEqual('Rr<name, type, 42, Hello World!', rr.__repr__())
+
+        rrset = Rrset('name', 'type', 42, iter(('one', 'two')))
+        self.assertEqual('name', rrset.name)
+        self.assertEqual('type', rrset._type)
+        self.assertEqual(42, rrset.ttl)
+        self.assertEqual(['one', 'two'], rrset.rdatas)
+        self.assertEqual(
+            "Rrset<name, type, 42, ['one', 'two']", rrset.__repr__()
+        )
 
         zone = Zone('unit.tests.', [])
         record = Record.new(
@@ -542,8 +791,15 @@ class TestRecord(TestCase):
             'a',
             {'ttl': 42, 'type': 'A', 'values': ['1.2.3.4', '2.3.4.5']},
         )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual(
+                ('a.unit.tests.', 42, 'A', ['1.2.3.4', '2.3.4.5']), record.rrs
+            )
         self.assertEqual(
-            ('a.unit.tests.', 42, 'A', ['1.2.3.4', '2.3.4.5']), record.rrs
+            '`Record.rrs` is DEPRECATED. Use `Record.to_rrset()` instead. '
+            'Will be removed in 2.0.',
+            str(caught[0].message),
         )
 
         record = Record.new(
@@ -638,13 +894,97 @@ class TestRecord(TestCase):
                 'query': 0,
             },
         }
+        second_values = {
+            'A': '192.0.2.2',
+            'AAAA': '2001:db8::2',
+            'CAA': {'flags': 0, 'tag': 'iodef', 'value': 'other.example'},
+            'DS': {
+                'key_tag': 2,
+                'algorithm': 2,
+                'digest_type': 3,
+                'digest': 'EF01',
+            },
+            'HTTPS': {
+                'svcpriority': 2,
+                'targetname': 'other.unit.tests.',
+                'svcparams': {'port': 8443},
+            },
+            'LOC': {
+                'lat_degrees': 31,
+                'lat_minutes': 58,
+                'lat_seconds': 53.1,
+                'lat_direction': 'S',
+                'long_degrees': 115,
+                'long_minutes': 49,
+                'long_seconds': 11.7,
+                'long_direction': 'E',
+                'altitude': 20,
+                'size': 10,
+                'precision_horz': 10,
+                'precision_vert': 2,
+            },
+            'MX': {'preference': 20, 'exchange': 'mx2.unit.tests.'},
+            'NAPTR': {
+                'order': 2,
+                'preference': 2,
+                'flags': 'U',
+                'service': 'E2U+sip',
+                'regexp': '!^.*$!sip:other@example.com!',
+                'replacement': '.',
+            },
+            'NS': 'ns2.unit.tests.',
+            'OPENPGPKEY': 'def456',
+            'PTR': 'other.unit.tests.',
+            'SPF': 'v=spf1 include:other.unit.tests. \\;all',
+            'SRV': {
+                'priority': 2,
+                'weight': 2,
+                'port': 443,
+                'target': 'other.unit.tests.',
+            },
+            'SSHFP': {
+                'algorithm': 2,
+                'fingerprint_type': 2,
+                'fingerprint': 'B' * 64,
+            },
+            'SVCB': {
+                'svcpriority': 2,
+                'targetname': 'other.unit.tests.',
+                'svcparams': {'port': 8443},
+            },
+            'TLSA': {
+                'certificate_usage': 2,
+                'selector': 1,
+                'matching_type': 1,
+                'certificate_association_data': 'EF01',
+            },
+            'TXT': 'another \\;value',
+            'URI': {
+                'priority': 2,
+                'weight': 2,
+                'target': 'https://other.unit.tests/',
+            },
+            'URLFWD': {
+                'path': '/other',
+                'target': 'https://other.unit.tests/',
+                'code': 302,
+                'masking': 0,
+                'query': 0,
+            },
+        }
         names = {'ALIAS': '', 'SRV': '_srv._tcp', 'URI': '_uri._tcp'}
         for _type, value in values.items():
+            data = {'ttl': 30, 'type': _type}
+            if _type in second_values:
+                data['values'] = [value, second_values[_type]]
+            else:
+                data['value'] = value
             record = Record.new(
-                self.zone,
-                names.get(_type, _type.lower()),
-                {'ttl': 30, 'type': _type, 'value': value},
+                self.zone, names.get(_type, _type.lower()), data
             )
+            if _type in second_values:
+                self.assertEqual(2, len(record.values), _type)
+                self.assertNotEqual(record.values[0], record.values[1], _type)
             value_type = record._value_type
             value_obj = (
                 record.values[0] if hasattr(record, 'values') else record.value
@@ -658,43 +998,32 @@ class TestRecord(TestCase):
                         value_type.parse_rdata_text(value_obj),
                     )
                 else:
-                    rdata = value_obj.to_rrs()
+                    rdata = value_obj.to_rdata_text()
                     self.assertEqual(rdata, value_obj.rdata_text)
                     self.assertEqual(
-                        value_type.from_rrs(rdata),
+                        value_type.from_rdata_text(rdata),
                         value_type.parse_rdata_text(rdata),
                     )
             value_type_name = value_type.__name__
+            if _type in ('SPF', 'TXT'):
+                replacements = ('str(value)', f'{value_type_name}.from_raw()')
+            else:
+                replacements = (
+                    f'{value_type_name}.to_rdata_text()',
+                    f'{value_type_name}.from_rdata_text()',
+                )
             self.assertEqual(
                 [
                     f'`{value_type_name}.rdata_text` is DEPRECATED. Use '
-                    f'`{value_type_name}.to_rrs()` instead. Will be removed in 2.0.',
+                    f'`{replacements[0]}` instead. Will be removed in 2.0.',
                     f'`{value_type_name}.parse_rdata_text` is DEPRECATED. Use '
-                    f'`{value_type_name}.from_rrs()` instead. Will be removed in 2.0.',
+                    f'`{replacements[1]}` instead. Will be removed in 2.0.',
                 ],
                 [str(warning.message) for warning in caught],
                 _type,
             )
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter('always')
-                _, _, _, rdatas = record.rrs
-                round_trip = Record.from_rrs(
-                    self.zone,
-                    [
-                        Rr(record.fqdn, _type, record.ttl, rdata)
-                        for rdata in rdatas
-                    ],
-                )[0]
-            self.assertEqual(
-                [],
-                [
-                    warning
-                    for warning in caught
-                    if '.rdata_text' in str(warning.message)
-                    or '.parse_rdata_text' in str(warning.message)
-                ],
-                _type,
-            )
+            rrset = record.to_rrset()
+            round_trip = Record.from_rrset(self.zone, rrset)
             self.assertEqual(record.data, round_trip.data, _type)
 
     def test_unquote(self):
@@ -1111,14 +1440,14 @@ class TestRecordValidation(TestCase):
             if not value_type.__module__.startswith('octodns.'):
                 continue
 
-            attr = 'from_rrs'
+            attr = 'from_rdata_text'
             method = getattr(value_type, attr)
             self.assertTrue(method, f'{_type}, {cls} has {attr}')
             self.assertTrue(
                 callable(method), f'{_type}, {cls} {attr} is callable'
             )
 
-            attr = 'to_rrs'
+            attr = 'to_rdata_text'
             method = getattr(value_type, attr)
             self.assertTrue(method, f'{_type}, {cls} has {attr}')
             self.assertTrue(

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -23,13 +23,29 @@ from octodns.record import (
     ValidationError,
     ValuesMixin,
 )
-from octodns.record.base import unquote
+from octodns.record.base import unquote, value_from_rrs, value_to_rrs
 from octodns.yaml import ContextDict
 from octodns.zone import Zone
 
 
 class TestRecord(TestCase):
     zone = Zone('unit.tests.', [])
+
+    def test_legacy_value_rr_api_fallback(self):
+        class LegacyValue(str):
+            @classmethod
+            def parse_rdata_text(cls, value):
+                return value.upper()
+
+            @property
+            def rdata_text(self):
+                return self.lower()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual('VALUE', value_from_rrs(LegacyValue, 'value'))
+            self.assertEqual('value', value_to_rrs(LegacyValue('VALUE')))
+        self.assertEqual(2, len(caught))
 
     def test_registration(self):
         with self.assertRaises(RecordException) as ctx:
@@ -918,6 +934,23 @@ class TestRecordValidation(TestCase):
 
             value_type = getattr(cls, '_value_type')
             self.assertTrue(value_type, f'{_type}, {cls} has _value_type')
+
+            if not value_type.__module__.startswith('octodns.'):
+                continue
+
+            attr = 'from_rrs'
+            method = getattr(value_type, attr)
+            self.assertTrue(method, f'{_type}, {cls} has {attr}')
+            self.assertTrue(
+                callable(method), f'{_type}, {cls} {attr} is callable'
+            )
+
+            attr = 'to_rrs'
+            method = getattr(value_type, attr)
+            self.assertTrue(method, f'{_type}, {cls} has {attr}')
+            self.assertTrue(
+                callable(method), f'{_type}, {cls} {attr} is callable'
+            )
 
             attr = 'parse_rdata_text'
             method = getattr(value_type, attr)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -30,6 +30,7 @@ from octodns.record import (
     ValuesMixin,
 )
 from octodns.record import base as record_base
+from octodns.record import value_from_rdata_text, value_to_rdata_text
 from octodns.record.base import unquote
 from octodns.yaml import ContextDict
 from octodns.zone import Zone
@@ -234,12 +235,16 @@ class TestRecord(TestCase):
         parse_uses_legacy.cache_clear()
         render_uses_legacy.cache_clear()
         try:
+            self.assertIs(
+                record_base.value_from_rdata_text, value_from_rdata_text
+            )
+            self.assertIs(record_base.value_to_rdata_text, value_to_rdata_text)
             with patch.object(
                 record_base, '_mro_owner', wraps=record_base._mro_owner
             ) as mro_owner:
                 with warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter('always')
-                    for legacy_value in (None, LegacyValue('192.0.2.4')):
+                    for _ in range(2):
                         self.assertEqual(
                             '192.0.2.2',
                             record_base.value_from_rdata_text(
@@ -249,8 +254,7 @@ class TestRecord(TestCase):
                         self.assertEqual(
                             '192.0.2.3',
                             record_base.value_to_rdata_text(
-                                LegacyValue('192.0.2.1'),
-                                legacy_value=legacy_value,
+                                LegacyValue('192.0.2.1')
                             ),
                         )
 
@@ -1162,7 +1166,10 @@ class TestRecord(TestCase):
                     )
             value_type_name = value_type.__name__
             if _type in ('SPF', 'TXT'):
-                replacements = ('str(value)', f'{value_type_name}.from_raw()')
+                replacements = (
+                    'str(value)',
+                    f'{value_type_name}.normalize_raw_text()',
+                )
             else:
                 replacements = (
                     f'{value_type_name}.to_rdata_text()',

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -167,6 +167,7 @@ class TestRecord(TestCase):
             '`from_rdata_text()` instead. Will be removed in 2.0.',
             str(caught[0].message),
         )
+        self.assertTrue(caught[0].filename.endswith('/octodns/record/base.py'))
 
         record = RenderOnlyRecord(
             self.zone, 'render', {'ttl': 30, 'values': ['192.0.2.1']}
@@ -238,7 +239,7 @@ class TestRecord(TestCase):
             ) as mro_owner:
                 with warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter('always')
-                    for _ in range(2):
+                    for legacy_value in (None, LegacyValue('192.0.2.4')):
                         self.assertEqual(
                             '192.0.2.2',
                             record_base.value_from_rdata_text(
@@ -248,7 +249,8 @@ class TestRecord(TestCase):
                         self.assertEqual(
                             '192.0.2.3',
                             record_base.value_to_rdata_text(
-                                LegacyValue('192.0.2.1')
+                                LegacyValue('192.0.2.1'),
+                                legacy_value=legacy_value,
                             ),
                         )
 

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -23,7 +23,7 @@ from octodns.record import (
     ValidationError,
     ValuesMixin,
 )
-from octodns.record.base import unquote, value_from_rrs, value_to_rrs
+from octodns.record.base import unquote
 from octodns.yaml import ContextDict
 from octodns.zone import Zone
 
@@ -34,6 +34,10 @@ class TestRecord(TestCase):
     def test_legacy_value_rr_api_fallback(self):
         class LegacyValue(str):
             @classmethod
+            def process(cls, values):
+                return [cls(value) for value in values]
+
+            @classmethod
             def parse_rdata_text(cls, value):
                 return value.upper()
 
@@ -41,11 +45,36 @@ class TestRecord(TestCase):
             def rdata_text(self):
                 return self.lower()
 
+        class LegacyRecord(ValuesMixin, Record):
+            _type = 'LEGACYRR'
+            _value_type = LegacyValue
+
+        Record.register_type(LegacyRecord)
+        record = LegacyRecord(
+            self.zone, 'legacy', {'ttl': 30, 'values': ['VALUE']}
+        )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter('always')
-            self.assertEqual('VALUE', value_from_rrs(LegacyValue, 'value'))
-            self.assertEqual('value', value_to_rrs(LegacyValue('VALUE')))
-        self.assertEqual(2, len(caught))
+            self.assertEqual(
+                ('legacy.unit.tests.', 30, 'LEGACYRR', ['value']), record.rrs
+            )
+            self.assertEqual(
+                record.data,
+                Record.from_rrs(
+                    self.zone,
+                    [Rr('legacy.unit.tests.', 'LEGACYRR', 30, 'value')],
+                )[0].data,
+            )
+        self.assertEqual(
+            2,
+            len(
+                [
+                    warning
+                    for warning in caught
+                    if 'LegacyValue' in str(warning.message)
+                ]
+            ),
+        )
 
     def test_registration(self):
         with self.assertRaises(RecordException) as ctx:
@@ -523,6 +552,128 @@ class TestRecord(TestCase):
             ('cname.unit.tests.', 43, 'CNAME', ['target.unit.tests.']),
             record.rrs,
         )
+
+    def test_rrs_round_trip_all_core_types(self):
+        values = {
+            'A': '192.0.2.1',
+            'AAAA': '2001:db8::1',
+            'ALIAS': 'target.unit.tests.',
+            'CAA': {'flags': 0, 'tag': 'issue', 'value': 'ca.example'},
+            'CNAME': 'target.unit.tests.',
+            'DNAME': 'target.unit.tests.',
+            'DS': {
+                'key_tag': 1,
+                'algorithm': 2,
+                'digest_type': 3,
+                'digest': 'ABCD',
+            },
+            'HTTPS': {
+                'svcpriority': 1,
+                'targetname': 'target.unit.tests.',
+                'svcparams': {'port': 443},
+            },
+            'LOC': {
+                'lat_degrees': 31,
+                'lat_minutes': 58,
+                'lat_seconds': 52.1,
+                'lat_direction': 'S',
+                'long_degrees': 115,
+                'long_minutes': 49,
+                'long_seconds': 11.7,
+                'long_direction': 'E',
+                'altitude': 20,
+                'size': 10,
+                'precision_horz': 10,
+                'precision_vert': 2,
+            },
+            'MX': {'preference': 10, 'exchange': 'mx.unit.tests.'},
+            'NAPTR': {
+                'order': 1,
+                'preference': 2,
+                'flags': 'U',
+                'service': 'E2U+sip',
+                'regexp': '!^.*$!sip:info@example.com!',
+                'replacement': '.',
+            },
+            'NS': 'ns.unit.tests.',
+            'OPENPGPKEY': 'abc123',
+            'PTR': 'target.unit.tests.',
+            'SPF': 'v=spf1 \\;all',
+            'SRV': {
+                'priority': 1,
+                'weight': 2,
+                'port': 443,
+                'target': 'target.unit.tests.',
+            },
+            'SSHFP': {
+                'algorithm': 1,
+                'fingerprint_type': 2,
+                'fingerprint': 'A' * 64,
+            },
+            'SVCB': {
+                'svcpriority': 1,
+                'targetname': 'target.unit.tests.',
+                'svcparams': {'port': 443},
+            },
+            'TLSA': {
+                'certificate_usage': 1,
+                'selector': 1,
+                'matching_type': 1,
+                'certificate_association_data': 'ABCD',
+            },
+            'TXT': 'value \\;with semicolon',
+            'URI': {
+                'priority': 1,
+                'weight': 2,
+                'target': 'https://target.unit.tests/',
+            },
+            'URLFWD': {
+                'path': '/',
+                'target': 'https://target.unit.tests/',
+                'code': 301,
+                'masking': 0,
+                'query': 0,
+            },
+        }
+        names = {'ALIAS': '', 'SRV': '_srv._tcp', 'URI': '_uri._tcp'}
+        for _type, value in values.items():
+            record = Record.new(
+                self.zone,
+                names.get(_type, _type.lower()),
+                {'ttl': 30, 'type': _type, 'value': value},
+            )
+            value_type = record._value_type
+            value_obj = (
+                record.values[0] if hasattr(record, 'values') else record.value
+            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                if _type in ('SPF', 'TXT'):
+                    self.assertEqual(value_obj, value_obj.rdata_text)
+                    self.assertEqual(
+                        value_obj.replace(';', '\\;'),
+                        value_type.parse_rdata_text(value_obj),
+                    )
+                else:
+                    rdata = value_obj.to_rrs()
+                    self.assertEqual(rdata, value_obj.rdata_text)
+                    self.assertEqual(
+                        value_type.from_rrs(rdata),
+                        value_type.parse_rdata_text(rdata),
+                    )
+            self.assertEqual(2, len(caught), _type)
+            _, _, _, rdatas = record.rrs
+            self.assertEqual(
+                record.data,
+                Record.from_rrs(
+                    self.zone,
+                    [
+                        Rr(record.fqdn, _type, record.ttl, rdata)
+                        for rdata in rdatas
+                    ],
+                )[0].data,
+                _type,
+            )
 
     def test_unquote(self):
         s = 'Hello "\'"World!'

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -432,8 +432,8 @@ class TestRecord(TestCase):
         # make sure there's nothing extra
         self.assertEqual(5, len(records))
 
-        # The record-class compatibility helpers remain available even though
-        # Record.from_rrs now delegates through grouped Rrsets.
+        # The record-class compatibility helpers remain available and
+        # Record.from_rrs uses them directly.
         self.assertEqual(
             {'ttl': 42, 'type': 'A', 'values': ['1.2.3.4', '2.3.4.5']},
             ARecord.data_from_rrs((rrs[0], rrs[3])),
@@ -468,8 +468,21 @@ class TestRecord(TestCase):
         self.assertEqual(records[0].data, Record.from_rrset(zone, rrset).data)
 
         self.assertEqual([], Record.from_rrsets(zone, []))
+
         with self.assertRaises(RecordException) as ctx:
-            Record.from_rrset(zone, Rrset('unit.tests.', 'A', 42, []))
+            Rrset('unit.tests.', 'A', 42, [])
+        self.assertEqual(
+            'Invalid Rrset unit.tests. A: at least one RDATA value is required',
+            str(ctx.exception),
+        )
+
+        class EmptyRrset:
+            name = 'unit.tests.'
+            _type = 'A'
+            rdatas = []
+
+        with self.assertRaises(RecordException) as ctx:
+            Record.from_rrset(zone, EmptyRrset())
         self.assertEqual(
             'Invalid Rrset unit.tests. A: at least one RDATA value is required',
             str(ctx.exception),
@@ -483,6 +496,34 @@ class TestRecord(TestCase):
                 ),
             )
         self.assertEqual('Duplicate Rrset unit.tests. A', str(ctx.exception))
+
+        cname = Rrset(
+            'cname.unit.tests.',
+            'CNAME',
+            42,
+            ['one.unit.tests.', 'two.unit.tests.'],
+        )
+        expected = (
+            'Invalid Rrset cname.unit.tests. CNAME: exactly one RDATA value '
+            'is required for a single-value record'
+        )
+        with self.assertRaises(RecordException) as ctx:
+            Record.from_rrset(zone, cname)
+        self.assertEqual(expected, str(ctx.exception))
+        with self.assertRaises(RecordException) as ctx:
+            Record.from_rrsets(zone, [cname])
+        self.assertEqual(expected, str(ctx.exception))
+
+        unknown = Rrset('unknown.unit.tests.', 'UNKNOWN', 42, ['value'])
+        for convert in (
+            lambda: Record.from_rrset(zone, unknown),
+            lambda: Record.from_rrsets(zone, [unknown]),
+        ):
+            with self.assertRaises(RecordException) as ctx:
+                convert()
+            self.assertEqual(
+                'Unknown record type: "UNKNOWN"', str(ctx.exception)
+            )
 
     def test_rrset_lenient_and_legacy_conversion(self):
         zone = Zone('unit.tests.', [])
@@ -516,6 +557,18 @@ class TestRecord(TestCase):
         )
         self.assertEqual(42, records[0].ttl)
         self.assertEqual(['1.2.3.4', '2.3.4.5'], records[0].values)
+        self.assertIs(source, records[0].source)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            legacy = [
+                Rr('cname.unit.tests.', 'CNAME', 42, 'one.unit.tests.'),
+                Rr('cname.unit.tests.', 'CNAME', 99, 'two.unit.tests.'),
+            ]
+            records = Record.from_rrs(zone, legacy, source=source)
+        self.assertEqual(1, len(records))
+        self.assertEqual(42, records[0].ttl)
+        self.assertEqual('one.unit.tests.', records[0].value)
         self.assertIs(source, records[0].source)
 
         with warnings.catch_warnings(record=True) as caught:
@@ -831,10 +884,12 @@ class TestRecord(TestCase):
     def test_rr(self):
         self.assertIs(RdataParseError, RrParseError)
         self.assertEqual(
-            'failed to parse string value as RR text', str(RdataParseError())
+            'failed to parse string value as RDATA presentation text',
+            str(RdataParseError()),
         )
         self.assertEqual(
-            'failed to parse string value as RR text', str(RrParseError())
+            'failed to parse string value as RDATA presentation text',
+            str(RrParseError()),
         )
         self.assertEqual(
             'custom message', str(RdataParseError('custom message'))
@@ -862,8 +917,29 @@ class TestRecord(TestCase):
         self.assertEqual(42, rrset.ttl)
         self.assertEqual(['one', 'two'], rrset.rdatas)
         self.assertEqual(
-            "Rrset<name, type, 42, ['one', 'two']", rrset.__repr__()
+            "Rrset<name, type, 42, ['one', 'two']>", rrset.__repr__()
         )
+
+        same = Rrset('name', 'type', 42, ('one', 'two'))
+        later = Rrset('name', 'type', 43, ('one', 'two'))
+        self.assertEqual(rrset, same)
+        self.assertNotEqual(rrset, later)
+        self.assertEqual([rrset, later], sorted((later, rrset)))
+        same.rdatas.append('three')
+        self.assertNotEqual(rrset, same)
+
+        invalid_rdatas = (
+            ('value', 'RDATA values must be a non-string iterable of strings'),
+            (None, 'RDATA values must be a non-string iterable of strings'),
+            (['value', 42], 'RDATA value at index 1 must be a string'),
+        )
+        for rdatas, message in invalid_rdatas:
+            with self.subTest(rdatas=rdatas):
+                with self.assertRaises(RecordException) as ctx:
+                    Rrset('name', 'type', 42, rdatas)
+                self.assertEqual(
+                    f'Invalid Rrset name type: {message}', str(ctx.exception)
+                )
 
         zone = Zone('unit.tests.', [])
         record = Record.new(

--- a/tests/test_octodns_record_caa.py
+++ b/tests/test_octodns_record_caa.py
@@ -84,14 +84,16 @@ class TestRecordCaa(TestCase):
 
     def test_caa_value_rdata_text(self):
         value = CaaValue({'flags': 0, 'tag': 'issue', 'value': 'ca.example'})
-        self.assertEqual('0 issue "ca.example"', value.to_rrs())
-        self.assertEqual(dict(value), CaaValue.from_rrs(value.to_rrs()))
+        self.assertEqual('0 issue "ca.example"', value.to_rdata_text())
+        self.assertEqual(
+            dict(value), CaaValue.from_rdata_text(value.to_rdata_text())
+        )
 
         with catch_warnings(record=True) as caught:
             simplefilter('always')
-            self.assertEqual(value.to_rrs(), value.rdata_text)
+            self.assertEqual(value.to_rdata_text(), value.rdata_text)
             self.assertEqual(
-                dict(value), CaaValue.parse_rdata_text(value.to_rrs())
+                dict(value), CaaValue.parse_rdata_text(value.to_rdata_text())
             )
         self.assertEqual(2, len(caught))
 

--- a/tests/test_octodns_record_caa.py
+++ b/tests/test_octodns_record_caa.py
@@ -3,6 +3,7 @@
 #
 
 from unittest import TestCase
+from warnings import catch_warnings, simplefilter
 
 from helpers import SimpleProvider
 
@@ -82,6 +83,18 @@ class TestRecordCaa(TestCase):
         a.__repr__()
 
     def test_caa_value_rdata_text(self):
+        value = CaaValue({'flags': 0, 'tag': 'issue', 'value': 'ca.example'})
+        self.assertEqual('0 issue "ca.example"', value.to_rrs())
+        self.assertEqual(dict(value), CaaValue.from_rrs(value.to_rrs()))
+
+        with catch_warnings(record=True) as caught:
+            simplefilter('always')
+            self.assertEqual(value.to_rrs(), value.rdata_text)
+            self.assertEqual(
+                dict(value), CaaValue.parse_rdata_text(value.to_rrs())
+            )
+        self.assertEqual(2, len(caught))
+
         # empty string won't parse
         with self.assertRaises(RrParseError):
             CaaValue.parse_rdata_text('')

--- a/tests/test_octodns_record_caa.py
+++ b/tests/test_octodns_record_caa.py
@@ -15,7 +15,7 @@ from octodns.record.caa import (
     CaaValueRfcValidator,
 )
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.zone import Zone
 
 
@@ -98,15 +98,15 @@ class TestRecordCaa(TestCase):
         self.assertEqual(2, len(caught))
 
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             CaaValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             CaaValue.parse_rdata_text('nope')
 
         # 2nd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             CaaValue.parse_rdata_text('0 tag')
 
         # flags not an int, will parse

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -78,7 +78,7 @@ class TestRecordChunked(TestCase):
             warnings.simplefilter('always')
             self.assertEqual(str(value), value.rdata_text)
             self.assertEqual(
-                TxtValue.from_raw('Hello; World'),
+                TxtValue.normalize_raw_text('Hello; World'),
                 TxtValue.parse_rdata_text('Hello; World'),
             )
         self.assertEqual(
@@ -86,7 +86,8 @@ class TestRecordChunked(TestCase):
                 '`TxtValue.rdata_text` is DEPRECATED. Use `str(value)` '
                 'instead. Will be removed in 2.0.',
                 '`TxtValue.parse_rdata_text` is DEPRECATED. Use '
-                '`TxtValue.from_raw()` instead. Will be removed in 2.0.',
+                '`TxtValue.normalize_raw_text()` instead. Will be removed in '
+                '2.0.',
             ],
             [str(warning.message) for warning in caught],
         )

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -4,6 +4,8 @@
 
 from unittest import TestCase
 
+import dns.rdata
+
 from octodns.record.base import _process_value_validators
 from octodns.record.chunked import _ChunkedValue, _ChunkedValuesMixin
 from octodns.record.spf import SpfRecord
@@ -53,8 +55,17 @@ class TestRecordChunked(TestCase):
             rdata = TxtValue(value).to_rrs()
             self.assertEqual(value, TxtValue.from_rrs(rdata))
 
-        record = TxtValue('a "quote"')
-        self.assertEqual('"a \\"quote\\""', record.to_rrs())
+        value = TxtValue('a' * 256)
+        rdata = value.to_rrs()
+        self.assertEqual(
+            [255, 1],
+            [len(s) for s in dns.rdata.from_text('IN', 'TXT', rdata).strings],
+        )
+
+        zone = Zone('unit.tests.', [])
+        record = SpfRecord(zone, 'spf', {'ttl': 42, 'value': 'a "quote"'})
+        self.assertEqual('"a \\"quote\\""', record.rrs[3][0])
+        self.assertEqual('a "quote"', _ChunkedValue.from_rrs(record.rrs[3][0]))
 
 
 class TestChunkedValue(TestCase):

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -2,10 +2,13 @@
 #
 #
 
+import warnings
 from unittest import TestCase
 
 import dns.rdata
 
+from octodns.processor.filter import ValueAllowlistFilter
+from octodns.record import Record
 from octodns.record.base import _process_value_validators
 from octodns.record.chunked import _ChunkedValue, _ChunkedValuesMixin
 from octodns.record.spf import SpfRecord
@@ -52,11 +55,11 @@ class TestRecordChunked(TestCase):
             '\x01control',
             'a' * 256,
         ):
-            rdata = TxtValue(value).to_rrs()
-            self.assertEqual(value, TxtValue.from_rrs(rdata))
+            rdata = TxtValue(value).to_rdata_text()
+            self.assertEqual(value, TxtValue.from_rdata_text(rdata))
 
         value = TxtValue('a' * 256)
-        rdata = value.to_rrs()
+        rdata = value.to_rdata_text()
         self.assertEqual(
             [255, 1],
             [len(s) for s in dns.rdata.from_text('IN', 'TXT', rdata).strings],
@@ -64,8 +67,143 @@ class TestRecordChunked(TestCase):
 
         zone = Zone('unit.tests.', [])
         record = SpfRecord(zone, 'spf', {'ttl': 42, 'value': 'a "quote"'})
-        self.assertEqual('"a \\"quote\\""', record.rrs[3][0])
-        self.assertEqual('a "quote"', _ChunkedValue.from_rrs(record.rrs[3][0]))
+        rdata = record.to_rrset().rdatas[0]
+        self.assertEqual('"a \\"quote\\""', rdata)
+        self.assertEqual('a "quote"', _ChunkedValue.from_rdata_text(rdata))
+
+    def test_chunked_legacy_migration_guidance(self):
+        value = TxtValue('Hello \\; World')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual(str(value), value.rdata_text)
+            self.assertEqual(
+                TxtValue.from_raw('Hello; World'),
+                TxtValue.parse_rdata_text('Hello; World'),
+            )
+        self.assertEqual(
+            [
+                '`TxtValue.rdata_text` is DEPRECATED. Use `str(value)` '
+                'instead. Will be removed in 2.0.',
+                '`TxtValue.parse_rdata_text` is DEPRECATED. Use '
+                '`TxtValue.from_raw()` instead. Will be removed in 2.0.',
+            ],
+            [str(warning.message) for warning in caught],
+        )
+
+    def test_chunked_record_rrs_preserves_legacy_rendering(self):
+        record = SpfRecord(
+            Zone('unit.tests.', []),
+            'spf',
+            {'ttl': 42, 'value': 'semi\\; quote " slash \\ middle'},
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            legacy = record.rrs
+        self.assertEqual(
+            (
+                'spf.unit.tests.',
+                42,
+                'SPF',
+                ['"semi\\; quote \\" slash \\ middle"'],
+            ),
+            legacy,
+        )
+        self.assertEqual(
+            '`Record.rrs` is DEPRECATED. Use `Record.to_rrset()` instead. '
+            'Will be removed in 2.0.',
+            str(caught[0].message),
+        )
+
+        rdata = record.to_rrset().rdatas[0]
+        self.assertNotEqual(legacy[3][0], rdata)
+        parsed = dns.rdata.from_text('IN', 'TXT', rdata)
+        self.assertEqual(
+            b'semi; quote " slash \\ middle', b''.join(parsed.strings)
+        )
+
+    def test_chunked_legacy_override_uses_historical_receiver(self):
+        class LegacyChunkedValue(_ChunkedValue):
+            receivers = []
+
+            @property
+            def rdata_text(self):
+                self.receivers.append(str(self))
+                return f'legacy:{self}'
+
+        class LegacyChunkedRecord(_ChunkedValuesMixin, Record):
+            _type = 'LEGACYCHUNKED'
+            _value_type = LegacyChunkedValue
+
+        Record.register_type(LegacyChunkedRecord)
+        record = LegacyChunkedRecord(
+            Zone('unit.tests.', []), 'legacy', {'ttl': 42, 'value': 'a "quote"'}
+        )
+        expected = 'legacy:"a \\"quote\\""'
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual([expected], record.to_rrset().rdatas)
+        self.assertEqual(
+            [
+                '`LegacyChunkedValue.rdata_text` is DEPRECATED. Implement '
+                '`to_rdata_text()` instead. Will be removed in 2.0.'
+            ],
+            [str(warning.message) for warning in caught],
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual(
+                ('legacy.unit.tests.', 42, 'LEGACYCHUNKED', [expected]),
+                record.rrs,
+            )
+        self.assertEqual(
+            [
+                '`Record.rrs` is DEPRECATED. Use `Record.to_rrset()` instead. '
+                'Will be removed in 2.0.',
+                '`LegacyChunkedValue.rdata_text` is DEPRECATED. Implement '
+                '`to_rdata_text()` instead. Will be removed in 2.0.',
+            ],
+            [str(warning.message) for warning in caught],
+        )
+        self.assertEqual(
+            ['"a \\"quote\\""', '"a \\"quote\\""'], LegacyChunkedValue.receivers
+        )
+
+    def test_lenient_unicode_presentation_round_trip(self):
+        for _type in ('SPF', 'TXT'):
+            zone = Zone('unit.tests.', [])
+            record = Record.new(
+                zone,
+                _type.lower(),
+                {'ttl': 42, 'type': _type, 'value': 'Déjà \\; vu'},
+                lenient=True,
+            )
+            rrset = record.to_rrset()
+            self.assertEqual(['"Déjà \\; vu"'], rrset.rdatas)
+            self.assertEqual(
+                record.data, Record.from_rrset(zone, rrset, lenient=True).data
+            )
+
+            zone.add_record(record)
+            filtered = ValueAllowlistFilter(
+                'unicode', ('"Déjà \\; vu"',)
+            ).process_source_zone(zone.copy(), None)
+            self.assertEqual([record], list(filtered.records))
+
+            ascii_record = Record.new(
+                Zone('unit.tests.', []),
+                'ascii',
+                {'ttl': 42, 'type': _type, 'value': 'a' * 256},
+            )
+            rdata = ascii_record.to_rrset().rdatas[0]
+            self.assertEqual(
+                [255, 1],
+                [
+                    len(chunk)
+                    for chunk in dns.rdata.from_text('IN', 'TXT', rdata).strings
+                ],
+            )
 
 
 class TestChunkedValue(TestCase):

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -39,6 +39,22 @@ class TestRecordChunked(TestCase):
         zone = Zone('unit.tests.', [])
         a = SpfRecord(zone, 'a', {'ttl': 42, 'value': 'some.target.'})
         self.assertEqual('some.target.', a.values[0].rdata_text)
+        self.assertEqual(a.chunked_values, a.rr_values)
+
+    def test_chunked_value_rrs(self):
+        for value in (
+            '',
+            'some text',
+            'a\\;b',
+            'a "quote" and \\ backslash',
+            '\x01control',
+            'a' * 256,
+        ):
+            rdata = TxtValue(value).to_rrs()
+            self.assertEqual(value, TxtValue.from_rrs(rdata))
+
+        record = TxtValue('a "quote"')
+        self.assertEqual('"a \\"quote\\""', record.to_rrs())
 
 
 class TestChunkedValue(TestCase):

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -5,10 +5,11 @@
 import warnings
 from unittest import TestCase
 
+import dns.exception
 import dns.rdata
 
 from octodns.processor.filter import ValueAllowlistFilter
-from octodns.record import Record
+from octodns.record import RdataParseError, Record, TxtRecord
 from octodns.record.base import _process_value_validators
 from octodns.record.chunked import _ChunkedValue, _ChunkedValuesMixin
 from octodns.record.spf import SpfRecord
@@ -89,6 +90,33 @@ class TestRecordChunked(TestCase):
             ],
             [str(warning.message) for warning in caught],
         )
+        self.assertEqual([__file__, __file__], [w.filename for w in caught])
+
+    def test_chunked_from_rdata_text_unquoted_compatibility(self):
+        for value_type in (TxtValue, _ChunkedValue):
+            self.assertEqual(
+                'v=spf1 include:_spf.example.com ~all',
+                value_type.from_rdata_text(
+                    'v=spf1 include:_spf.example.com ~all'
+                ),
+            )
+            self.assertEqual('single', value_type.from_rdata_text('single'))
+            self.assertEqual(
+                'foo bar', value_type.from_rdata_text('foo\\032bar')
+            )
+            self.assertEqual('foobar', value_type.from_rdata_text('"foo" bar'))
+
+    def test_chunked_from_rdata_text_parse_errors(self):
+        for value_type in (TxtValue, _ChunkedValue):
+            with self.assertRaises(RdataParseError) as ctx:
+                value_type.from_rdata_text('"unterminated')
+            self.assertIsInstance(
+                ctx.exception.__cause__, dns.exception.SyntaxError
+            )
+
+            with self.assertRaises(RdataParseError) as ctx:
+                value_type.from_rdata_text('"\\255"')
+            self.assertIsInstance(ctx.exception.__cause__, UnicodeDecodeError)
 
     def test_chunked_record_rrs_preserves_legacy_rendering(self):
         record = SpfRecord(
@@ -120,6 +148,50 @@ class TestRecordChunked(TestCase):
         self.assertEqual(
             b'semi; quote " slash \\ middle', b''.join(parsed.strings)
         )
+
+    def test_chunked_new_api_uses_fixed_chunking(self):
+        class SmallChunkTxtRecord(TxtRecord):
+            CHUNK_SIZE = 8
+
+        record = SmallChunkTxtRecord(
+            Zone('unit.tests.', []), 'small', {'ttl': 42, 'value': 'a' * 30}
+        )
+
+        self.assertEqual(
+            ['"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'], record.to_rrset().rdatas
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(
+                ['"aaaaaaaa" "aaaaaaaa" "aaaaaaaa" "aaaaaa"'], record.rrs[3]
+            )
+
+    def test_chunked_new_api_does_not_evaluate_rr_values(self):
+        class NewChunkedRecord(TxtRecord):
+            @property
+            def rr_values(self):
+                raise AssertionError('rr_values should not be evaluated')
+
+        record = NewChunkedRecord(
+            Zone('unit.tests.', []),
+            'new',
+            {'ttl': 42, 'values': ['one', 'two']},
+        )
+        self.assertEqual(['"one"', '"two"'], record.to_rrset().rdatas)
+
+    def test_chunked_legacy_rrs_preserves_rr_values_cardinality(self):
+        class LegacyRrValuesRecord(TxtRecord):
+            @property
+            def rr_values(self):
+                return [TxtValue('one'), TxtValue('two'), TxtValue('three')]
+
+        record = LegacyRrValuesRecord(
+            Zone('unit.tests.', []), 'legacy', {'ttl': 42, 'value': 'ignored'}
+        )
+        self.assertEqual(['"ignored"'], record.to_rrset().rdatas)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(['one', 'two', 'three'], record.rrs[3])
 
     def test_chunked_legacy_override_uses_historical_receiver(self):
         class LegacyChunkedValue(_ChunkedValue):
@@ -204,6 +276,17 @@ class TestRecordChunked(TestCase):
                     for chunk in dns.rdata.from_text('IN', 'TXT', rdata).strings
                 ],
             )
+
+    def test_lenient_unicode_oversized_character_string(self):
+        value = TxtValue('é' * 300)
+        rdata = value.to_rdata_text()
+        self.assertEqual([255, 45], [len(v) for v in rdata[1:-1].split('" "')])
+
+        with self.assertRaises(RdataParseError) as ctx:
+            TxtValue.from_rdata_text(rdata)
+        self.assertIsInstance(
+            ctx.exception.__cause__, dns.exception.SyntaxError
+        )
 
 
 class TestChunkedValue(TestCase):

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -93,6 +93,16 @@ class TestRecordChunked(TestCase):
         )
         self.assertEqual([__file__, __file__], [w.filename for w in caught])
 
+    def test_chunked_raw_text_conversion(self):
+        raw = 'v=DKIM1;k=rsa;s=email'
+        for value_type in (TxtValue, _ChunkedValue):
+            normalized = value_type.normalize_raw_text(raw)
+            self.assertEqual('v=DKIM1\\;k=rsa\\;s=email', normalized)
+            self.assertEqual(raw, value_type(normalized).to_raw_text())
+            self.assertEqual(
+                'ordinary text', value_type('ordinary text').to_raw_text()
+            )
+
     def test_chunked_from_rdata_text_unquoted_compatibility(self):
         for value_type in (TxtValue, _ChunkedValue):
             self.assertEqual(

--- a/tests/test_octodns_record_ds.py
+++ b/tests/test_octodns_record_ds.py
@@ -13,7 +13,7 @@ from octodns.record.ds import (
     DsValueRfcValidator,
 )
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.zone import Zone
 
 
@@ -105,23 +105,23 @@ class TestRecordDs(TestCase):
             self.assertTrue(a < b)
 
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             DsValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             DsValue.parse_rdata_text('nope')
 
         # 2nd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             DsValue.parse_rdata_text('0 1')
 
         # 3rd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             DsValue.parse_rdata_text('0 1 2')
 
         # 5th word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             DsValue.parse_rdata_text('0 1 2 key blah')
 
         # things ints, will parse

--- a/tests/test_octodns_record_loc.py
+++ b/tests/test_octodns_record_loc.py
@@ -9,7 +9,7 @@ from helpers import SimpleProvider
 from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.loc import LocRecord, LocValue
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.zone import Zone
 
 
@@ -116,7 +116,7 @@ class TestRecordLoc(TestCase):
         # only the exact correct number of words is allowed
         for i in tuple(range(0, 12)) + (13,):
             s = ''.join(['word'] * i)
-            with self.assertRaises(RrParseError):
+            with self.assertRaises(RdataParseError):
                 LocValue.parse_rdata_text(s)
 
         # type conversions are best effort

--- a/tests/test_octodns_record_mx.py
+++ b/tests/test_octodns_record_mx.py
@@ -16,7 +16,7 @@ from octodns.record.mx import (
     MxValueNotIpValidator,
     MxValueRfcValidator,
 )
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.zone import Zone
 
 
@@ -76,15 +76,15 @@ class TestRecordMx(TestCase):
 
     def test_mx_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             MxValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             MxValue.parse_rdata_text('nope')
 
         # 3rd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             MxValue.parse_rdata_text('10 mx.unit.tests. another')
 
         # preference not an int

--- a/tests/test_octodns_record_naptr.py
+++ b/tests/test_octodns_record_naptr.py
@@ -14,7 +14,7 @@ from octodns.record.naptr import (
     NaptrValueBestPracticeValidator,
     NaptrValueRfcValidator,
 )
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.zone import Zone
 
 
@@ -322,7 +322,7 @@ class TestRecordNaptr(TestCase):
             'one two three four five',
             'one two three four five six seven',
         ):
-            with self.assertRaises(RrParseError):
+            with self.assertRaises(RdataParseError):
                 NaptrValue.parse_rdata_text(v)
 
         # we don't care if the types of things are correct when parsing rr text

--- a/tests/test_octodns_record_srv.py
+++ b/tests/test_octodns_record_srv.py
@@ -9,7 +9,7 @@ from helpers import SimpleProvider
 from octodns.processor.templating import Templating
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.record.srv import (
     SrvNameRfcValidator,
     SrvRecord,
@@ -90,23 +90,23 @@ class TestRecordSrv(TestCase):
 
     def test_srv_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SrvValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SrvValue.parse_rdata_text('nope')
 
         # 2nd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SrvValue.parse_rdata_text('1 2')
 
         # 3rd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SrvValue.parse_rdata_text('1 2 3')
 
         # 5th word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SrvValue.parse_rdata_text('1 2 3 4 5')
 
         # priority weight and port not ints

--- a/tests/test_octodns_record_sshfp.py
+++ b/tests/test_octodns_record_sshfp.py
@@ -8,7 +8,7 @@ from helpers import SimpleProvider
 
 from octodns.record.base import Record
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.record.sshfp import (
     SshfpRecord,
     SshfpValue,
@@ -91,15 +91,15 @@ class TestRecordSshfp(TestCase):
 
     def test_sshfp_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SshfpValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SshfpValue.parse_rdata_text('nope')
 
         # 3rd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SshfpValue.parse_rdata_text('0 1 00479b27 another')
 
         # algorithm and fingerprint_type not ints

--- a/tests/test_octodns_record_svcb.py
+++ b/tests/test_octodns_record_svcb.py
@@ -10,7 +10,7 @@ from octodns.processor.templating import Templating
 from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.https import HttpsValue
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.record.svcb import (
     SvcbRecord,
     SvcbValue,
@@ -109,15 +109,15 @@ class TestRecordSvcb(TestCase):
 
     def test_svcb_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SvcbValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SvcbValue.parse_rdata_text('nope')
 
         # Double keys are not allowed
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             SvcbValue.parse_rdata_text('1 foo.example.com port=8080 port=8084')
 
         # priority not int

--- a/tests/test_octodns_record_tlsa.py
+++ b/tests/test_octodns_record_tlsa.py
@@ -8,7 +8,7 @@ from helpers import SimpleProvider
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.record.tlsa import (
     TlsaRecord,
     TlsaValue,
@@ -124,23 +124,23 @@ class TestRecordTlsa(TestCase):
 
     def test_tsla_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             TlsaValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             TlsaValue.parse_rdata_text('nope')
 
         # 2nd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             TlsaValue.parse_rdata_text('1 2')
 
         # 3rd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             TlsaValue.parse_rdata_text('1 2 3')
 
         # 5th word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             TlsaValue.parse_rdata_text('1 2 3 abcd another')
 
         # non-ints

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -4,6 +4,8 @@
 
 from unittest import TestCase
 
+import dns.rdata
+
 from octodns.record import Record, Rr
 from octodns.record.exception import ValidationError
 from octodns.record.txt import TxtRecord
@@ -174,6 +176,15 @@ class TestRecordTxt(TestCase):
         self.assertEqual(('txt.unit.tests.', 42, 'TXT'), record.rrs[:3])
         self.assertEqual('"before"', record.rrs[3][0])
         self.assertEqual('"z after"', record.rrs[3][2])
+        middle = dns.rdata.from_text('IN', 'TXT', record.rrs[3][1])
+        self.assertEqual(
+            [255, len(record.values[1].replace('\\;', ';')) - 255],
+            [len(chunk) for chunk in middle.strings],
+        )
+        self.assertEqual(
+            record.values[1].replace('\\;', ';'),
+            b''.join(middle.strings).decode('ascii'),
+        )
         self.assertEqual(
             record.data,
             Record.from_rrs(

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -4,7 +4,7 @@
 
 from unittest import TestCase
 
-from octodns.record import Record
+from octodns.record import Record, Rr
 from octodns.record.exception import ValidationError
 from octodns.record.txt import TxtRecord
 from octodns.zone import Zone
@@ -171,10 +171,16 @@ class TestRecordTxt(TestCase):
                 ],
             },
         )
-        vals = [
-            '"before"',
-            '"v=DKIM1\\; h=sha256\\; k=rsa\\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH" '
-            '"2s9a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB"',
-            '"z after"',
-        ]
-        self.assertEqual(('txt.unit.tests.', 42, 'TXT', vals), record.rrs)
+        self.assertEqual(('txt.unit.tests.', 42, 'TXT'), record.rrs[:3])
+        self.assertEqual('"before"', record.rrs[3][0])
+        self.assertEqual('"z after"', record.rrs[3][2])
+        self.assertEqual(
+            record.data,
+            Record.from_rrs(
+                zone,
+                [
+                    Rr(record.fqdn, record._type, record.ttl, r)
+                    for r in record.rrs[3]
+                ],
+            )[0].data,
+        )

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 import dns.rdata
 
-from octodns.record import Record, Rr
+from octodns.record import Record
 from octodns.record.exception import ValidationError
 from octodns.record.txt import TxtRecord
 from octodns.zone import Zone
@@ -154,10 +154,7 @@ class TestRecordTxt(TestCase):
             'txt',
             {'ttl': 42, 'type': 'TXT', 'values': ['short 1', 'short 2']},
         )
-        self.assertEqual(
-            ('txt.unit.tests.', 42, 'TXT', ['"short 1"', '"short 2"']),
-            record.rrs,
-        )
+        self.assertEqual(['"short 1"', '"short 2"'], record.to_rrset().rdatas)
 
         # long chunked text
         record = Record.new(
@@ -173,10 +170,13 @@ class TestRecordTxt(TestCase):
                 ],
             },
         )
-        self.assertEqual(('txt.unit.tests.', 42, 'TXT'), record.rrs[:3])
-        self.assertEqual('"before"', record.rrs[3][0])
-        self.assertEqual('"z after"', record.rrs[3][2])
-        middle = dns.rdata.from_text('IN', 'TXT', record.rrs[3][1])
+        rrset = record.to_rrset()
+        self.assertEqual(
+            ('txt.unit.tests.', 42, 'TXT'), (rrset.name, rrset.ttl, rrset._type)
+        )
+        self.assertEqual('"before"', rrset.rdatas[0])
+        self.assertEqual('"z after"', rrset.rdatas[2])
+        middle = dns.rdata.from_text('IN', 'TXT', rrset.rdatas[1])
         self.assertEqual(
             [255, len(record.values[1].replace('\\;', ';')) - 255],
             [len(chunk) for chunk in middle.strings],
@@ -185,13 +185,4 @@ class TestRecordTxt(TestCase):
             record.values[1].replace('\\;', ';'),
             b''.join(middle.strings).decode('ascii'),
         )
-        self.assertEqual(
-            record.data,
-            Record.from_rrs(
-                zone,
-                [
-                    Rr(record.fqdn, record._type, record.ttl, r)
-                    for r in record.rrs[3]
-                ],
-            )[0].data,
-        )
+        self.assertEqual(record.data, Record.from_rrset(zone, rrset).data)

--- a/tests/test_octodns_record_uri.py
+++ b/tests/test_octodns_record_uri.py
@@ -8,7 +8,7 @@ from helpers import SimpleProvider
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.record.uri import (
     UriNameRfcValidator,
     UriRecord,
@@ -86,19 +86,19 @@ class TestRecordUri(TestCase):
 
     def test_uri_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UriValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UriValue.parse_rdata_text('nope')
 
         # 2nd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UriValue.parse_rdata_text('1 2')
 
         # 4th word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UriValue.parse_rdata_text('1 2 3 4')
 
         # priority and weight not ints

--- a/tests/test_octodns_record_urlfwd.py
+++ b/tests/test_octodns_record_urlfwd.py
@@ -8,7 +8,7 @@ from helpers import SimpleProvider
 
 from octodns.record import Record
 from octodns.record.exception import ValidationError
-from octodns.record.rr import RrParseError
+from octodns.record.rr import RdataParseError
 from octodns.record.urlfwd import UrlfwdRecord, UrlfwdValue
 from octodns.zone import Zone
 
@@ -393,27 +393,27 @@ class TestRecordUrlfwd(TestCase):
 
     def test_urlfwd_value_rdata_text(self):
         # empty string won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UrlfwdValue.parse_rdata_text('')
 
         # single word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UrlfwdValue.parse_rdata_text('nope')
 
         # 2nd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UrlfwdValue.parse_rdata_text('1 2')
 
         # 3rd word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UrlfwdValue.parse_rdata_text('1 2 3')
 
         # 4th word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UrlfwdValue.parse_rdata_text('1 2 3 4')
 
         # 6th word won't parse
-        with self.assertRaises(RrParseError):
+        with self.assertRaises(RdataParseError):
             UrlfwdValue.parse_rdata_text('1 2 3 4 5 6')
 
         # code, masking, and query not ints

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -50,18 +50,33 @@ class TestTinyDnsFileSource(TestCase):
         )
 
     def test_colon_txt_raw_value(self):
-        zone = Zone('example.com.', [])
-        records = list(
-            self.source._records_for_colon(
-                zone,
-                'txt.example.com.',
-                [['txt.example.com.', 'TXT', 'value; with semicolon', '30']],
+        for _type in ('SPF', 'TXT'):
+            zone = Zone('example.com.', [])
+            records = list(
+                self.source._records_for_colon(
+                    zone,
+                    f'{_type.lower()}.example.com.',
+                    [
+                        [
+                            f'{_type.lower()}.example.com.',
+                            _type,
+                            'value; with semicolon',
+                            '30',
+                        ]
+                    ],
+                )
             )
-        )
-        self.assertEqual(
-            [('TXT', 'txt.example.com.', 30, ['value\\; with semicolon'])],
-            records,
-        )
+            self.assertEqual(
+                [
+                    (
+                        _type,
+                        f'{_type.lower()}.example.com.',
+                        30,
+                        ['value\\; with semicolon'],
+                    )
+                ],
+                records,
+            )
 
     def test_populate_normal(self):
         got = Zone('example.com.', [])

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -14,6 +14,55 @@ from octodns.zone import Zone
 class TestTinyDnsFileSource(TestCase):
     source = TinyDnsFileSource('test', './tests/zones/tinydns')
 
+    def test_colon_presentation_rdata(self):
+        zone = Zone('example.com.', [])
+        records = list(
+            self.source._records_for_colon(
+                zone,
+                '_srv._tcp.example.com.',
+                [
+                    [
+                        '_srv._tcp.example.com.',
+                        'SRV',
+                        '1 2 443 target.example.com.',
+                        '30',
+                    ]
+                ],
+            )
+        )
+        self.assertEqual(
+            [
+                (
+                    'SRV',
+                    '_srv._tcp.example.com.',
+                    30,
+                    [
+                        {
+                            'priority': 1,
+                            'weight': 2,
+                            'port': 443,
+                            'target': 'target.example.com.',
+                        }
+                    ],
+                )
+            ],
+            records,
+        )
+
+    def test_colon_txt_raw_value(self):
+        zone = Zone('example.com.', [])
+        records = list(
+            self.source._records_for_colon(
+                zone,
+                'txt.example.com.',
+                [['txt.example.com.', 'TXT', 'value; with semicolon', '30']],
+            )
+        )
+        self.assertEqual(
+            [('TXT', 'txt.example.com.', 30, ['value\\; with semicolon'])],
+            records,
+        )
+
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)


### PR DESCRIPTION
Introduce value-level `to_rrs()` and `from_rrs()` APIs with 1.x deprecated compatibility methods.

Adds strict TXT/SPF presentation conversion, third-party legacy fallbacks, and record/filter migration.

Tests: `./script/test`, `./script/coverage`, `./script/lint`

/cc #1447 Implement the planned RDATA conversion API rework