### PR TITLE
Add uniform value-level RR conversion APIs

### DIFF
--- a/.changelog/a0e3957ab7d6443a9005fabf5ce91b29.md
+++ b/.changelog/a0e3957ab7d6443a9005fabf5ce91b29.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add uniform value-level RR conversion APIs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -337,9 +337,9 @@ Processors
    * - `NameRejectlistFilter`_
      - Filter that IGNORES records that match specified naming patterns, all others will be managed
    * - `ValueAllowlistFilter`_
-     - Filter that ONLY manages records that match specified value patterns based on `rdata_text`, all others will be ignored
+     - Filter that ONLY manages records that match specified value patterns based on presentation-format RDATA from `to_rrs()`, all others will be ignored
    * - `ValueRejectlistFilter`_
-     - Filter that IGNORES records that match specified value patterns based on `rdata_text`, all others will be managed
+     - Filter that IGNORES records that match specified value patterns based on presentation-format RDATA from `to_rrs()`, all others will be managed
    * - `OwnershipProcessor`_
      - Processor that implements ownership in octoDNS so that it can manage only the records in a zone in sources and will ignore all others.
    * - `SpfDnsLookupProcessor`_

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -7,6 +7,7 @@ from itertools import product
 from logging import getLogger
 from re import compile as re_compile
 
+from ..record.base import _value_to_rrs
 from ..record.exception import ValidationError
 from .base import BaseProcessor
 
@@ -232,9 +233,9 @@ class _ValueBaseFilter(_FilterProcessor):
         for record in zone.records:
             values = []
             if hasattr(record, 'values'):
-                values = [value.rdata_text for value in record.values]
+                values = [_value_to_rrs(value) for value in record.values]
             elif record.value is not None:
-                values = [record.value.rdata_text]
+                values = [_value_to_rrs(record.value)]
             else:
                 self.log.warning(
                     'value for %s is NoneType, ignoring', record.fqdn

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -315,7 +315,7 @@ class Record(EqualityTupleMixin):
 
     @classmethod
     def parse_rdata_texts(cls, rdatas):
-        return [cls._value_type.parse_rdata_text(r) for r in rdatas]
+        return [_value_from_rrs(cls._value_type, r) for r in rdatas]
 
     def __init__(self, zone, name, data, source=None, context=None):
         self.zone = zone
@@ -479,6 +479,56 @@ def _process_value_validators(value_type, values, _type, disabled=None):
     )
 
 
+class RrValueMixin:
+    @property
+    def rdata_text(self):
+        name = self.__class__.__name__
+        deprecated(
+            f'`{name}.rdata_text` is DEPRECATED. Use `{name}.to_rrs()` '
+            'instead. Will be removed in 2.0.',
+            stacklevel=3,
+        )
+        return self.to_rrs()
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        name = cls.__name__
+        deprecated(
+            f'`{name}.parse_rdata_text` is DEPRECATED. Use '
+            f'`{name}.from_rrs()` instead. Will be removed in 2.0.',
+            stacklevel=3,
+        )
+        return cls.from_rrs(value)
+
+
+def _value_to_rrs(value):
+    method = getattr(value, 'to_rrs', None)
+    if callable(method):
+        return method()
+
+    name = value.__class__.__name__
+    deprecated(
+        f'`{name}.rdata_text` is DEPRECATED. Third-party value types must '
+        f'implement `{name}.to_rrs()`. Will be removed in 2.0.',
+        stacklevel=3,
+    )
+    return value.rdata_text
+
+
+def _value_from_rrs(value_type, rdata):
+    method = getattr(value_type, 'from_rrs', None)
+    if callable(method):
+        return method(rdata)
+
+    name = value_type.__name__
+    deprecated(
+        f'`{name}.parse_rdata_text` is DEPRECATED. Third-party value types '
+        f'must implement `{name}.from_rrs()`. Will be removed in 2.0.',
+        stacklevel=3,
+    )
+    return value_type.parse_rdata_text(rdata)
+
+
 class ValuesMixin(object):
     VALIDATORS = [ValuesTypeValidator()]
 
@@ -487,7 +537,7 @@ class ValuesMixin(object):
         # type and TTL come from the first rr
         rr = rrs[0]
         # values come from parsing the rdata portion of all rrs
-        values = [cls._value_type.parse_rdata_text(rr.rdata) for rr in rrs]
+        values = [_value_from_rrs(cls._value_type, rr.rdata) for rr in rrs]
         return {'ttl': rr.ttl, 'type': rr._type, 'values': values}
 
     def __init__(self, zone, name, data, source=None, context=None):
@@ -527,7 +577,7 @@ class ValuesMixin(object):
             self.fqdn,
             self.ttl,
             self._type,
-            [v.rdata_text for v in self.rr_values],
+            [_value_to_rrs(v) for v in self.rr_values],
         )
 
     def __repr__(self):
@@ -549,7 +599,7 @@ class ValueMixin(object):
         return {
             'ttl': rr.ttl,
             'type': rr._type,
-            'value': cls._value_type.parse_rdata_text(rr.rdata),
+            'value': _value_from_rrs(cls._value_type, rr.rdata),
         }
 
     def __init__(self, zone, name, data, source=None, context=None):
@@ -568,7 +618,7 @@ class ValueMixin(object):
 
     @property
     def rrs(self):
-        return self.fqdn, self.ttl, self._type, [self.value.rdata_text]
+        return self.fqdn, self.ttl, self._type, [_value_to_rrs(self.value)]
 
     def __repr__(self):
         klass = self.__class__.__name__

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -5,7 +5,7 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -131,7 +131,7 @@ class CaaValueBestPracticeValidator(ValueValidator):
         return []
 
 
-class CaaValue(EqualityTupleMixin, dict):
+class CaaValue(RrValueMixin, EqualityTupleMixin, dict):
     # https://tools.ietf.org/html/rfc8659
 
     VALIDATORS = [
@@ -155,7 +155,7 @@ class CaaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             # value may contain whitepsace
             flags, tag, value = value.split(' ', 2)
@@ -210,8 +210,7 @@ class CaaValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         # RFC 8659 §4.1.1 requires value to be a quoted character-string
         return f'{self.flags} {self.tag} "{self.value}"'
 

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -4,7 +4,12 @@
 
 import re
 
-from .base import ValuesMixin
+import dns.rdata
+import dns.rdataclass
+import dns.rdatatype
+
+from ..deprecation import deprecated
+from .base import ValuesMixin, _value_to_rrs
 from .validator import ValidationReason, ValueValidator
 
 
@@ -91,16 +96,40 @@ class _ChunkedValuesMixin(ValuesMixin):
     def rr_values(self):
         return self.chunked_values
 
+    @property
+    def rrs(self):
+        return (
+            self.fqdn,
+            self.ttl,
+            self._type,
+            [_value_to_rrs(v) for v in self.values],
+        )
+
 
 class _ChunkedValue(str):
     VALIDATORS = [chunked_value_validator]
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_raw(cls, value):
         try:
             return value.replace(';', '\\;')
         except AttributeError:
             return value
+
+    @classmethod
+    def from_rrs(cls, value):
+        rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.TXT, value)
+        raw = b''.join(rdata.strings).decode('ascii')
+        return raw.replace(';', '\\;')
+
+    @classmethod
+    def parse_rdata_text(cls, value):
+        deprecated(
+            f'`{cls.__name__}.parse_rdata_text` is DEPRECATED. Use '
+            f'`{cls.__name__}.from_rrs()` instead. Will be removed in 2.0.',
+            stacklevel=3,
+        )
+        return cls.from_raw(value)
 
     @classmethod
     def _schema(cls):
@@ -115,8 +144,36 @@ class _ChunkedValue(str):
             ret.append(cls(v.replace('" "', '')))
         return ret
 
+    def to_rrs(self):
+        raw = self.replace('\\;', ';').encode('ascii')
+        chunks = [raw[i : i + 255] for i in range(0, len(raw), 255)]
+        if not chunks:
+            chunks = [b'']
+
+        rendered = []
+        for chunk in chunks:
+            escaped = ''
+            for octet in chunk:
+                if octet in (34, 92):
+                    escaped += f'\\{chr(octet)}'
+                elif octet < 32 or octet >= 127:
+                    escaped += f'\\{octet:03d}'
+                else:
+                    escaped += chr(octet)
+            rendered.append(f'"{escaped}"')
+        value = ' '.join(rendered)
+        return dns.rdata.from_text(
+            dns.rdataclass.IN, dns.rdatatype.TXT, value
+        ).to_text()
+
     @property
     def rdata_text(self):
+        deprecated(
+            f'`{self.__class__.__name__}.rdata_text` is DEPRECATED. Use '
+            f'`{self.__class__.__name__}.to_rrs()` instead. Will be removed '
+            'in 2.0.',
+            stacklevel=3,
+        )
         return self
 
     def template(self, params):

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin
+from .base import Record, RrValueMixin, ValuesMixin
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -280,7 +280,7 @@ class DsValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class DsValue(EqualityTupleMixin, dict):
+class DsValue(RrValueMixin, EqualityTupleMixin, dict):
     # https://www.rfc-editor.org/rfc/rfc4034.html#section-5.1
     log = getLogger('DsValue')
 
@@ -317,7 +317,7 @@ class DsValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             key_tag, algorithm, digest_type, digest = value.split(' ')
         except ValueError:
@@ -400,8 +400,7 @@ class DsValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return (
             f'{self.key_tag} {self.algorithm} {self.digest_type} {self.digest}'
         )

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -2,7 +2,7 @@
 #
 #
 
-
+from .base import RrValueMixin
 from .validator import ValidationReason, ValueValidator
 
 
@@ -42,11 +42,11 @@ class IpValueValidator(ValueValidator):
         return reasons
 
 
-class _IpValue(str):
+class _IpValue(RrValueMixin, str):
     VALIDATORS = [IpValueValidator('ip-value-rfc', sets={'legacy', 'strict'})]
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         return value
 
     @classmethod
@@ -66,8 +66,7 @@ class _IpValue(str):
         v = str(cls._address_type(v))
         return super().__new__(cls, v)
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -134,7 +134,7 @@ class LocValueValidator(ValueValidator):
         return reasons
 
 
-class LocValue(EqualityTupleMixin, dict):
+class LocValue(RrValueMixin, EqualityTupleMixin, dict):
     # TODO: this does not really match the RFC, but it's stuck using the details
     # of how the type was impelemented. Would be nice to rework things to match
     # while maintaining backwards compatibility.
@@ -209,7 +209,7 @@ class LocValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             value = value.replace('m', '')
             (
@@ -407,8 +407,7 @@ class LocValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.lat_degrees} {self.lat_minutes} {self.lat_seconds} {self.lat_direction} {self.long_degrees} {self.long_minutes} {self.long_seconds} {self.long_direction} {self.altitude}m {self.size}m {self.precision_horz}m {self.precision_vert}m'
 
     def template(self, params):

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -4,7 +4,7 @@
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import (
     _check_target_format,
@@ -155,7 +155,7 @@ class MxValueNotIpValidator(ValueValidator):
         return reasons
 
 
-class MxValue(EqualityTupleMixin, dict):
+class MxValue(RrValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         MxValueValidator('mx-value', sets={'legacy'}),
         MxValueRfcValidator('mx-value-rfc', sets={'strict'}),
@@ -200,7 +200,7 @@ class MxValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             preference, exchange = value.split(' ')
         except ValueError:
@@ -251,8 +251,7 @@ class MxValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.preference} {self.exchange}'
 
     def template(self, params):

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import _check_target_trailing_dot
 from .validator import ValidationReason, ValueValidator
@@ -170,7 +170,7 @@ class NaptrValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class NaptrValue(EqualityTupleMixin, dict):
+class NaptrValue(RrValueMixin, EqualityTupleMixin, dict):
     VALID_FLAGS = ('S', 'A', 'U', 'P', 's', 'a', 'u', 'p')
 
     VALIDATORS = [
@@ -208,7 +208,7 @@ class NaptrValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             order, preference, flags, service, regexp, replacement = (
                 value.split(' ')
@@ -301,8 +301,7 @@ class NaptrValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         # RFC 3403 requires flags, service, and regexp to be quoted character-strings
         flags = self.flags or ''
         service = self.service or ''

--- a/octodns/record/openpgpkey.py
+++ b/octodns/record/openpgpkey.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValuesMixin
+from .base import Record, RrValueMixin, ValuesMixin
 from .validator import ValidationReason, ValueValidator
 
 
@@ -18,7 +18,7 @@ class OpenpgpkeyValueValidator(ValueValidator):
         return []
 
 
-class OpenpgpkeyValue(str):
+class OpenpgpkeyValue(RrValueMixin, str):
     '''
     OPENPGPKEY value - base64-encoded OpenPGP public key
 
@@ -36,7 +36,7 @@ class OpenpgpkeyValue(str):
         return {'type': 'string'}
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         # Strip whitespace that may appear in zone files (base64 data may be
         # split across lines)
         return value.replace(' ', '')
@@ -45,8 +45,7 @@ class OpenpgpkeyValue(str):
     def process(cls, values):
         return [cls(v) for v in values]
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -6,7 +6,7 @@ import re
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .target import (
     _check_target_format,
@@ -263,7 +263,7 @@ class SrvValueNotIpValidator(ValueValidator):
         return reasons
 
 
-class SrvValue(EqualityTupleMixin, dict):
+class SrvValue(RrValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         SrvValueValidator('srv-value', sets={'legacy'}),
         SrvValueRfcValidator('srv-value-rfc', sets={'strict'}),
@@ -289,7 +289,7 @@ class SrvValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             priority, weight, port, target = value.split(' ')
         except ValueError:
@@ -364,8 +364,7 @@ class SrvValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f"{self.priority} {self.weight} {self.port} {self.target}"
 
     def template(self, params):

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -5,7 +5,7 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -206,7 +206,7 @@ class SshfpValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class SshfpValue(EqualityTupleMixin, dict):
+class SshfpValue(RrValueMixin, EqualityTupleMixin, dict):
     VALID_ALGORITHMS = (1, 2, 3, 4)
     VALID_FINGERPRINT_TYPES = (1, 2)
 
@@ -233,7 +233,7 @@ class SshfpValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             algorithm, fingerprint_type, fingerprint = value.split(' ')
         except ValueError:
@@ -294,8 +294,7 @@ class SshfpValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.algorithm} {self.fingerprint_type} {self.fingerprint}'
 
     def template(self, params):

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -9,7 +9,7 @@ from ipaddress import AddressValueError, IPv4Address, IPv6Address
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .chunked import _ChunkedValue, chunked_value_validator
 from .rr import RrParseError
 from .target import _check_target_format, _check_target_trailing_dot
@@ -269,7 +269,7 @@ class SvcbValueValidator(ValueValidator):
         return reasons
 
 
-class _SvcbValueBase(EqualityTupleMixin, dict):
+class _SvcbValueBase(RrValueMixin, EqualityTupleMixin, dict):
     @classmethod
     def _schema(cls):
         return {
@@ -287,7 +287,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         try:
             svcpriority, targetname, *svcparams = value.split(' ')
         except ValueError:
@@ -358,8 +358,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
     def svcparams(self, value):
         self['svcparams'] = value
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         params = ''
         sorted_svcparamkeys = sorted(self.svcparams, key=svcparamkeysort)
         for svcparamkey in sorted_svcparamkeys:
@@ -396,7 +395,7 @@ class _SvcbValueBase(EqualityTupleMixin, dict):
         return (self.svcpriority, self.targetname, params)
 
     def __repr__(self):
-        return f"'{self.rdata_text}'"
+        return f"'{self.to_rrs()}'"
 
 
 class SvcbValueBestPracticeValidator(ValueValidator):

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -7,6 +7,7 @@ import ipaddress
 from fqdn import FQDN
 
 from ..idna import idna_encode
+from .base import RrValueMixin
 from .validator import ValidationReason, ValueValidator
 
 
@@ -153,7 +154,7 @@ class TargetsValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class _TargetValue(str):
+class _TargetValue(RrValueMixin, str):
     VALIDATORS = [
         TargetValueValidator('target-value-rfc', sets={'legacy', 'strict'}),
         TargetValueNotIpValidator('target-value-not-ip', sets={'strict'}),
@@ -163,7 +164,7 @@ class _TargetValue(str):
     ]
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         return value
 
     @classmethod
@@ -180,8 +181,7 @@ class _TargetValue(str):
         v = idna_encode(v)
         return super().__new__(cls, v)
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):
@@ -192,7 +192,7 @@ class _TargetValue(str):
 
 #
 # much like _TargetValue, but geared towards multiple values
-class _TargetsValue(str):
+class _TargetsValue(RrValueMixin, str):
     VALIDATORS = [
         TargetsValueValidator('targets-value-rfc', sets={'legacy', 'strict'}),
         TargetsValueNotIpValidator('targets-value-not-ip', sets={'strict'}),
@@ -202,7 +202,7 @@ class _TargetsValue(str):
     ]
 
     @classmethod
-    def parse_rdata_text(cls, value):
+    def from_rrs(cls, value):
         return value
 
     @classmethod
@@ -217,8 +217,7 @@ class _TargetsValue(str):
         v = idna_encode(v)
         return super().__new__(cls, v)
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return self
 
     def template(self, params):

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -5,7 +5,7 @@
 import re
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -212,7 +212,7 @@ class TlsaValueBestPracticeValidator(ValueValidator):
         return reasons
 
 
-class TlsaValue(EqualityTupleMixin, dict):
+class TlsaValue(RrValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         TlsaValueValidator('tlsa-value', sets={'legacy'}),
         TlsaValueRfcValidator('tlsa-value-rfc', sets={'strict'}),
@@ -248,7 +248,7 @@ class TlsaValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             (
                 certificate_usage,
@@ -328,8 +328,7 @@ class TlsaValue(EqualityTupleMixin, dict):
     def certificate_association_data(self, value):
         self['certificate_association_data'] = value
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.certificate_usage} {self.selector} {self.matching_type} {self.certificate_association_data}'
 
     def template(self, params):

--- a/octodns/record/uri.py
+++ b/octodns/record/uri.py
@@ -6,7 +6,7 @@ import re
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import RecordValidator, ValidationReason, ValueValidator
 
@@ -132,7 +132,7 @@ class UriValueRfcValidator(ValueValidator):
         return reasons
 
 
-class UriValue(EqualityTupleMixin, dict):
+class UriValue(RrValueMixin, EqualityTupleMixin, dict):
     VALIDATORS = [
         UriValueValidator('uri-value', sets={'legacy'}),
         UriValueRfcValidator('uri-value-rfc', sets={'strict'}),
@@ -151,7 +151,7 @@ class UriValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             priority, weight, target = value.split(' ')
         except ValueError:
@@ -208,8 +208,7 @@ class UriValue(EqualityTupleMixin, dict):
     def data(self):
         return self
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'{self.priority} {self.weight} "{self.target}"'
 
     def template(self, params):

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, RrValueMixin, ValuesMixin, unquote
 from .rr import RrParseError
 from .validator import ValidationReason, ValueValidator
 
@@ -86,7 +86,7 @@ class UrlfwdValueValidator(ValueValidator):
         return reasons
 
 
-class UrlfwdValue(EqualityTupleMixin, dict):
+class UrlfwdValue(RrValueMixin, EqualityTupleMixin, dict):
     VALID_CODES = (301, 302)
     VALID_MASKS = (0, 1, 2)
     VALID_QUERY = (0, 1)
@@ -110,7 +110,7 @@ class UrlfwdValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
-    def parse_rdata_text(self, value):
+    def from_rrs(self, value):
         try:
             path, target, code, masking, query = value.split(' ')
         except ValueError:
@@ -192,8 +192,7 @@ class UrlfwdValue(EqualityTupleMixin, dict):
     def query(self, value):
         self['query'] = value
 
-    @property
-    def rdata_text(self):
+    def to_rrs(self):
         return f'"{self.path}" "{self.target}" {self.code} {self.masking} {self.query}'
 
     def template(self, params):

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -340,7 +340,11 @@ class TinyDnsBaseSource(BaseSource):
             ttl = self._ttl_for(lines, 3)
 
             rdatas = [l[2] for l in lines]
-            yield _type, name, ttl, _class.parse_rdata_texts(rdatas)
+            if _type in ('SPF', 'TXT'):
+                values = [_class._value_type.from_raw(r) for r in rdatas]
+            else:
+                values = _class.parse_rdata_texts(rdatas)
+            yield _type, name, ttl, values
 
     def _records_for_six(self, zone, name, lines, arpa=False):
         # 6fqdn:ip:ttl:timestamp:lo

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -236,7 +236,9 @@ class TestValueAllowListFilter(TestCase):
     zone.add_record(empty_val)
 
     def test_exact(self):
-        allows = ValueAllowlistFilter('exact', ('matches.example.com.',))
+        allows = ValueAllowlistFilter(
+            'exact', ('matches.example.com.', '"matches.example.com."')
+        )
 
         self.assertEqual(7, len(self.zone.records))
         filtered = allows.process_source_zone(self.zone.copy(), None)
@@ -313,7 +315,9 @@ class TestValueRejectListFilter(TestCase):
     zone.add_record(empty_val)
 
     def test_exact(self):
-        rejects = ValueRejectlistFilter('exact', ('matches.example.com.',))
+        rejects = ValueRejectlistFilter(
+            'exact', ('matches.example.com.', '"matches.example.com."')
+        )
 
         self.assertEqual(7, len(self.zone.records))
         filtered = rejects.process_source_zone(self.zone.copy(), None)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -21,6 +21,7 @@ from octodns.record import (
     TxtRecord,
     Update,
     ValidationError,
+    ValueMixin,
     ValuesMixin,
 )
 from octodns.record.base import unquote
@@ -930,6 +931,288 @@ class TestRecordValidation(TestCase):
             method = getattr(value_type, attr)
             self.assertTrue(method, f'{_type}, {cls} has {attr}')
             # this one is a @property so not callable
+
+            if cls.__module__.startswith('octodns.record.'):
+                for attr in ('to_rrs', 'from_rrs'):
+                    method = getattr(value_type, attr)
+                    self.assertTrue(method, f'{_type}, {cls} has {attr}')
+                    self.assertTrue(
+                        callable(method), f'{_type}, {cls} {attr} is callable'
+                    )
+
+    def test_value_rrs_deprecations(self):
+        value_type = ARecord._value_type
+        value = value_type('1.2.3.4')
+        with self.assertWarnsRegex(
+            DeprecationWarning, 'Ipv4Value.rdata_text.*Ipv4Value.to_rrs'
+        ):
+            self.assertEqual('1.2.3.4', value.rdata_text)
+        with self.assertWarnsRegex(
+            DeprecationWarning, 'Ipv4Value.parse_rdata_text.*Ipv4Value.from_rrs'
+        ):
+            self.assertEqual('1.2.3.4', value_type.parse_rdata_text('1.2.3.4'))
+
+    def test_legacy_value_rrs_fallback(self):
+        class LegacyValue(str):
+            @classmethod
+            def process(cls, values):
+                if not isinstance(values, (list, tuple)):
+                    return cls(values)
+                return [cls(value) for value in values]
+
+            @classmethod
+            def parse_rdata_text(cls, value):
+                return value.upper()
+
+            @property
+            def rdata_text(self):
+                return self.lower()
+
+        class LegacyRecord(ValuesMixin, Record):
+            _type = 'LEGACY'
+            _value_type = LegacyValue
+
+        record = LegacyRecord(
+            self.zone, 'legacy', {'ttl': 42, 'values': ['VALUE']}
+        )
+        with self.assertWarnsRegex(
+            DeprecationWarning, 'LegacyValue.rdata_text.*LegacyValue.to_rrs'
+        ):
+            self.assertEqual(
+                ('legacy.unit.tests.', 42, 'LEGACY', ['value']), record.rrs
+            )
+
+        rr = Rr('legacy.unit.tests.', 'LEGACY', 42, 'value')
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            'LegacyValue.parse_rdata_text.*LegacyValue.from_rrs',
+        ):
+            self.assertEqual(
+                {'ttl': 42, 'type': 'LEGACY', 'values': ['VALUE']},
+                LegacyRecord.data_from_rrs([rr]),
+            )
+
+        class LegacySingleRecord(ValueMixin, Record):
+            _type = 'LEGACY-SINGLE'
+            _value_type = LegacyValue
+
+        record = LegacySingleRecord(
+            self.zone, 'legacy-single', {'ttl': 42, 'value': 'VALUE'}
+        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(['value'], record.rrs[3])
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                'VALUE', LegacySingleRecord.data_from_rrs([rr])['value']
+            )
+
+    def test_new_value_attribute_errors_are_not_legacy_fallbacks(self):
+        class BrokenValue(str):
+            @classmethod
+            def process(cls, values):
+                return [cls(value) for value in values]
+
+            @classmethod
+            def from_rrs(cls, value):
+                raise AttributeError('from_rrs failed')
+
+            def to_rrs(self):
+                raise AttributeError('to_rrs failed')
+
+        class BrokenRecord(ValuesMixin, Record):
+            _type = 'BROKEN'
+            _value_type = BrokenValue
+
+        record = BrokenRecord(
+            self.zone, 'broken', {'ttl': 42, 'values': ['value']}
+        )
+        with self.assertRaisesRegex(AttributeError, 'to_rrs failed'):
+            record.rrs
+        rr = Rr('broken.unit.tests.', 'BROKEN', 42, 'value')
+        with self.assertRaisesRegex(AttributeError, 'from_rrs failed'):
+            BrokenRecord.data_from_rrs([rr])
+
+    def test_normal_rrs_paths_do_not_warn(self):
+        record = TxtRecord(
+            self.zone, 'txt', {'ttl': 42, 'value': 'hello world'}
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            fqdn, ttl, _type, rdatas = record.rrs
+            rrs = [Rr(fqdn, _type, ttl, rdata) for rdata in rdatas]
+            reparsed = TxtRecord.data_from_rrs(rrs)
+        self.assertEqual([], caught)
+        self.assertEqual(
+            {'ttl': 42, 'type': 'TXT', 'values': ['hello world']}, reparsed
+        )
+
+    def test_all_registered_types_round_trip_rrs(self):
+        values = {
+            'A': ('a', '1.2.3.4'),
+            'AAAA': ('aaaa', '2001:db8::1'),
+            'ALIAS': ('', 'target.unit.tests.'),
+            'CAA': (
+                'caa',
+                {'flags': 0, 'tag': 'issue', 'value': 'ca.unit.tests'},
+            ),
+            'CNAME': ('cname', 'target.unit.tests.'),
+            'DNAME': ('dname', 'target.unit.tests.'),
+            'DS': (
+                'ds',
+                {
+                    'key_tag': 12345,
+                    'algorithm': 8,
+                    'digest_type': 2,
+                    'digest': 'abcdef',
+                },
+            ),
+            'HTTPS': (
+                'https',
+                {
+                    'svcpriority': 1,
+                    'targetname': 'target.unit.tests.',
+                    'svcparams': {'alpn': ['h2'], 'port': '443'},
+                },
+            ),
+            'LOC': (
+                'loc',
+                {
+                    'lat_degrees': 37,
+                    'lat_minutes': 47,
+                    'lat_seconds': 0.0,
+                    'lat_direction': 'N',
+                    'long_degrees': 122,
+                    'long_minutes': 24,
+                    'long_seconds': 0.0,
+                    'long_direction': 'W',
+                    'altitude': 10.0,
+                    'size': 1.0,
+                    'precision_horz': 10000.0,
+                    'precision_vert': 10.0,
+                },
+            ),
+            'MX': ('mx', {'preference': 10, 'exchange': 'mail.unit.tests.'}),
+            'NAPTR': (
+                'naptr',
+                {
+                    'order': 10,
+                    'preference': 20,
+                    'flags': 'S',
+                    'service': 'SIP+D2U',
+                    'regexp': '',
+                    'replacement': '_sip._udp.unit.tests.',
+                },
+            ),
+            'NS': ('ns', 'ns1.unit.tests.'),
+            'OPENPGPKEY': ('openpgpkey', 'YWJjZA=='),
+            'PTR': ('ptr', 'target.unit.tests.'),
+            'SPF': ('spf', 'v=spf1 -all'),
+            'SRV': (
+                '_sip._tcp',
+                {
+                    'priority': 10,
+                    'weight': 20,
+                    'port': 5060,
+                    'target': 'sip.unit.tests.',
+                },
+            ),
+            'SSHFP': (
+                'sshfp',
+                {
+                    'algorithm': 1,
+                    'fingerprint_type': 2,
+                    'fingerprint': 'abcdef',
+                },
+            ),
+            'SVCB': (
+                'svcb',
+                {
+                    'svcpriority': 1,
+                    'targetname': 'target.unit.tests.',
+                    'svcparams': {'alpn': ['h2'], 'port': '443'},
+                },
+            ),
+            'TLSA': (
+                '_443._tcp',
+                {
+                    'certificate_usage': 3,
+                    'selector': 1,
+                    'matching_type': 1,
+                    'certificate_association_data': 'abcdef',
+                },
+            ),
+            'TXT': ('txt', 'hello\\; world'),
+            'URI': (
+                '_sip._tcp',
+                {
+                    'priority': 10,
+                    'weight': 20,
+                    'target': 'https://unit.tests/path',
+                },
+            ),
+            'URLFWD': (
+                'urlfwd',
+                {
+                    'path': '/',
+                    'target': 'https://unit.tests/',
+                    'code': 301,
+                    'masking': 0,
+                    'query': 0,
+                },
+            ),
+        }
+        core_types = {
+            _type
+            for _type, cls in Record.registered_types().items()
+            if cls.__module__.startswith('octodns.record.')
+        }
+        self.assertEqual(core_types, set(values))
+
+        for _type, (name, value) in values.items():
+            record = Record.new(
+                self.zone,
+                name,
+                {'ttl': 42, 'type': _type, 'value': value},
+                lenient=True,
+            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                fqdn, ttl, rr_type, rdatas = record.rrs
+                rrs = [Rr(fqdn, rr_type, ttl, rdata) for rdata in rdatas]
+                reparsed = Record.from_rrs(self.zone, rrs, lenient=True)[0]
+            value_warnings = [
+                warning
+                for warning in caught
+                if '.rdata_text' in str(warning.message)
+                or '.parse_rdata_text' in str(warning.message)
+            ]
+            self.assertEqual([], value_warnings, _type)
+            self.assertEqual(record.data, reparsed.data, _type)
+
+            record_values = getattr(
+                record, 'values', [getattr(record, 'value', None)]
+            )
+            for record_value in record_values:
+                value_type = record_value.__class__
+                with self.assertWarnsRegex(
+                    DeprecationWarning,
+                    f'{value_type.__name__}.rdata_text.*to_rrs',
+                ):
+                    legacy_rdata = record_value.rdata_text
+                if _type in ('SPF', 'TXT'):
+                    self.assertEqual(record_value, legacy_rdata, _type)
+                    legacy_input = str(record_value).replace('\\;', ';')
+                    expected = value_type.from_raw(legacy_input)
+                else:
+                    self.assertEqual(record_value.to_rrs(), legacy_rdata, _type)
+                    legacy_input = record_value.to_rrs()
+                    expected = value_type.from_rrs(legacy_input)
+                with self.assertWarnsRegex(
+                    DeprecationWarning,
+                    f'{value_type.__name__}.parse_rdata_text.*from_rrs',
+                ):
+                    actual = value_type.parse_rdata_text(legacy_input)
+                self.assertEqual(expected, actual, _type)
 
 
 class TestValidators(TestCase):

--- a/tests/test_octodns_record_chunked.py
+++ b/tests/test_octodns_record_chunked.py
@@ -39,6 +39,44 @@ class TestRecordChunked(TestCase):
         zone = Zone('unit.tests.', [])
         a = SpfRecord(zone, 'a', {'ttl': 42, 'value': 'some.target.'})
         self.assertEqual('some.target.', a.values[0].rdata_text)
+        self.assertEqual(a.chunked_values, a.rr_values)
+
+    def test_rrs_conversion(self):
+        values = (
+            ('hello world', '"hello world"'),
+            ('say "hello"', '"say \\"hello\\""'),
+            ('a\\path', '"a\\\\path"'),
+            ('one\\; two', '"one; two"'),
+            ('one\x01two', '"one\\001two"'),
+            ('', '""'),
+        )
+        for raw, rdata in values:
+            value = _ChunkedValue(raw)
+            self.assertEqual(rdata, value.to_rrs())
+            self.assertEqual(raw, _ChunkedValue.from_rrs(rdata))
+
+        self.assertEqual(
+            'onetwo\\;three', _ChunkedValue.from_rrs('"one" "two;three"')
+        )
+
+        for length in (254, 255):
+            raw = 'a' * length
+            self.assertEqual(f'"{raw}"', _ChunkedValue(raw).to_rrs())
+        raw = 'a' * 256
+        self.assertEqual(f'"{"a" * 255}" "a"', _ChunkedValue(raw).to_rrs())
+
+    def test_legacy_rrs_conversion(self):
+        value = _ChunkedValue('one\\; two')
+        with self.assertWarnsRegex(
+            DeprecationWarning, '_ChunkedValue.rdata_text.*to_rrs'
+        ):
+            self.assertEqual(value, value.rdata_text)
+        with self.assertWarnsRegex(
+            DeprecationWarning, '_ChunkedValue.parse_rdata_text.*from_rrs'
+        ):
+            self.assertEqual(
+                'one\\; two', _ChunkedValue.parse_rdata_text('one; two')
+            )
 
 
 class TestChunkedValue(TestCase):

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -173,8 +173,8 @@ class TestRecordTxt(TestCase):
         )
         vals = [
             '"before"',
-            '"v=DKIM1\\; h=sha256\\; k=rsa\\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH" '
-            '"2s9a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB"',
+            '"v=DKIM1; h=sha256; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH2s9" '
+            '"a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB"',
             '"z after"',
         ]
         self.assertEqual(('txt.unit.tests.', 42, 'TXT', vals), record.rrs)

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -14,6 +14,19 @@ from octodns.zone import Zone
 class TestTinyDnsFileSource(TestCase):
     source = TinyDnsFileSource('test', './tests/zones/tinydns')
 
+    def test_arbitrary_chunked_values_are_raw(self):
+        zone = Zone('example.com.', [])
+        for _type in ('SPF', 'TXT'):
+            lines = [('raw.example.com', _type, 'raw; value', '42')]
+            self.assertEqual(
+                [(_type, 'raw.example.com', 42, ['raw\\; value'])],
+                list(
+                    self.source._records_for_colon(
+                        zone, 'raw.example.com', lines
+                    )
+                ),
+            )
+
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)


### PR DESCRIPTION
## Summary

- add to_rrs/from_rrs across all core RDATA value types while preserving deprecated 1.x APIs
- use strict dnspython presentation conversion for TXT/SPF and retain explicit raw TinyDNS handling
- preserve third-party legacy fallbacks and migrate internal RR conversion/filter callers
- add all-record round-trip, deprecation, compatibility, and TXT edge-case coverage

## Validation

- ./script/test (815 passed)
- ./script/coverage (100% statements and branches)
- ./script/lint
- representative Route53, Bind, and Cloudflare functional suites

/cc Fixes #1447