### PR TITLE
Fix OwnershipProcessor dropping changes to record types with lower-case letters

### DIFF
--- a/.changelog/4894bc8785d846b19681fd9557eb96f3.md
+++ b/.changelog/4894bc8785d846b19681fd9557eb96f3.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix OwnershipProcessor dropping changes to records whose type contains lower-case letters, e.g. octodns-route53's Route53Provider/ALIAS - #1455

--- a/octodns/processor/ownership.py
+++ b/octodns/processor/ownership.py
@@ -133,7 +133,7 @@ class OwnershipProcessor(BaseProcessor):
 
             if (
                 not self._is_ownership(record)
-                and record._type not in owned[record.name]
+                and record._type.upper() not in owned[record.name]
                 and record.name != 'octodns-meta'
             ):
                 # It's not an ownership TXT, it's not owned, and it's not

--- a/tests/test_octodns_processor_ownership.py
+++ b/tests/test_octodns_processor_ownership.py
@@ -8,7 +8,7 @@ from helpers import PlannableProvider
 
 from octodns.processor.ownership import OwnershipException, OwnershipProcessor
 from octodns.provider.plan import Plan
-from octodns.record import Delete, Record
+from octodns.record import Delete, Record, Update, ValueMixin
 from octodns.zone import DuplicateRecordException, Zone
 
 zone = Zone('unit.tests.', [])
@@ -26,6 +26,34 @@ for record in [
 ]:
     records[record.name] = record
     zone.add_record(record)
+
+
+class MixedCaseValue(str):
+    @classmethod
+    def parse_rdata_text(cls, value):
+        return value
+
+    @classmethod
+    def validate(cls, data, _type):
+        return []
+
+    @classmethod
+    def process(cls, value):
+        return MixedCaseValue(value)
+
+    @property
+    def rdata_text(self):
+        return self
+
+
+class MixedCase(ValueMixin, Record):
+    # Provider-specific types are not required to be upper case, e.g.
+    # octodns-route53's Route53Provider/ALIAS
+    _type = 'Provider/MiXeD'
+    _value_type = MixedCaseValue
+
+
+Record.register_type(MixedCase, 'Provider/MiXeD')
 
 
 class TestOwnershipProcessor(TestCase):
@@ -222,3 +250,57 @@ class TestOwnershipProcessor(TestCase):
         plan.existing.add_record(foreign_unmanaged)
         got = ownership.process_plan(plan, None, None)
         self.assertTrue(got)
+
+    def test_process_plan_mixed_case_type(self):
+        # Record names are lower cased, so the ownership TXT for a
+        # provider-specific type records that type in lower case. The plan
+        # filter has to account for that or changes to those records are
+        # silently dropped even though we own them.
+        ownership = OwnershipProcessor('ownership')
+
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            'mixed',
+            {'ttl': 30, 'type': 'Provider/MiXeD', 'value': 'before'},
+        )
+        updated = Record.new(
+            zone,
+            'mixed',
+            {'ttl': 30, 'type': 'Provider/MiXeD', 'value': 'after'},
+        )
+
+        marker = Record.new(
+            zone,
+            f'{ownership.txt_name}.provider/mixed.mixed',
+            {'ttl': 60, 'type': 'TXT', 'value': ownership.txt_value},
+            lenient=True,
+        )
+        # the marker name is lower cased on the way in
+        self.assertEqual(
+            f'{ownership.txt_name}.provider/mixed.mixed', marker.name
+        )
+
+        existing = Zone(zone.name, [])
+        desired = Zone(zone.name, [])
+        for zone_, value in ((existing, record), (desired, updated)):
+            zone_.add_record(value, lenient=True)
+            zone_.add_record(marker, lenient=True)
+
+        change = Update(record, updated)
+        plan = Plan(existing, desired, [change], True)
+
+        got = ownership.process_plan(plan, None, None)
+        self.assertTrue(got)
+        self.assertEqual([change], got.changes)
+
+        # an unowned record of the same type is still left alone
+        unowned = Record.new(
+            zone,
+            'unowned',
+            {'ttl': 30, 'type': 'Provider/MiXeD', 'value': 'before'},
+        )
+        existing = Zone(zone.name, [])
+        existing.add_record(unowned, lenient=True)
+        plan = Plan(existing, Zone(zone.name, []), [Delete(unowned)], True)
+        self.assertFalse(ownership.process_plan(plan, None, None))


### PR DESCRIPTION
Fixes #1455.

## The bug

`_decode_ownership_name` upper cases the type it reads out of the ownership TXT name. It has to: record names are lower cased on the way in, so the marker for an `A` record arrives as `_owner.a.the-a`, as the existing `test_process_source_zone` assertions show.

The plan filter then compared the record's real `_type` against that upper cased index:

```python
and record._type not in owned[record.name]
```

Core types are already upper case, so the mismatch is invisible for them. A provider-specific type containing lower-case letters never matches, and its changes are dropped from the plan with no warning even when we own the record. `octodns-route53`'s `Route53Provider/ALIAS` is one such type, which makes an apex alias unmanageable whenever `OwnershipProcessor` is enabled. The symptom is quiet: the provider logs `Updates=1` and the printed plan `Summary` says `Updates=0`.

## The fix

Normalise the comparison side too, so both sides are consistent.

I considered removing the upper casing at `_decode_ownership_name` instead and comparing raw. That does not work: the type is recovered from a lower cased record name, so raw comparison fails for every mixed-case type in the other direction. Both sides have to be normalised, not neither.

## Tests

`test_process_plan_mixed_case_type` registers a `Provider/MiXeD` record type, following the pattern in `tests/test_octodns_processor_templating.py`, and covers both directions:

- an owned record of that type keeps its change, which fails on `main` with `AssertionError: None is not true`
- an unowned record of that type is still left alone, so the fix does not widen what the processor takes over

No dependency on `octodns-route53` — the lower casing that causes this is octodns's own, so a locally registered type reproduces it.

`MixedCaseValue` also implements `rdata_text`, because `test_records_have_rdata_methods` audits every registered type and a fixture that skips it fails that test.

## Checks

- `./script/test` — 808 passed
- `./script/coverage` — 100.00%, requirement met
- `./script/lint` — clean
- `./script/format` — applied
- changelog fragment added via `./script/changelog create -t patch`
