### PR TITLE
Fix Sphinx docs build warnings

### DIFF
--- a/.changelog/8609e000ae4949e898462db3d76112b0.md
+++ b/.changelog/8609e000ae4949e898462db3d76112b0.md
@@ -1,4 +1,4 @@
 ---
-type: patch
+type: none
 ---
 Fix Sphinx docs build warnings and add a CI job to catch future regressions

--- a/.changelog/8609e000ae4949e898462db3d76112b0.md
+++ b/.changelog/8609e000ae4949e898462db3d76112b0.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix Sphinx docs build warnings and add a CI job to catch future regressions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,3 +66,20 @@ jobs:
       - name: CI package build
         run: |
           ./script/cibuild-package
+  docs:
+    needs: config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          # Most recent release from https://devguide.python.org/versions/#versions
+          python-version: ${{ fromJson(needs.config.outputs.json).python_version_current }}
+          architecture: x64
+      - name: Bootstrap
+        run: |
+          ./script/bootstrap
+      - name: Generate docs
+        run: |
+          ./script/generate-docs

--- a/docs/api/validators.rst
+++ b/docs/api/validators.rst
@@ -33,4 +33,3 @@ by set name (e.g. ``legacy``, ``strict``, ``best-practice``).
    octodns.zone.mail
    octodns.zone.ns
    octodns.zone.srv
-   octodns.zone.subzone

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -212,42 +212,42 @@ bridge validators with ``sets=None`` — always active and cannot be disabled.
 
 Validators active in both ``legacy`` and ``strict``:
 
-+------------------------+------------------------------------------+
-| id                     | description                              |
-+========================+==========================================+
-| ``name-rfc``           | Record name format (RFC 1035/2181)       |
-+------------------------+------------------------------------------+
-| ``ttl-rfc``            | TTL range (positive integer)             |
-+------------------------+------------------------------------------+
-| ``healthcheck``        | octoDNS healthcheck config fields        |
-+------------------------+------------------------------------------+
-| ``cname-root-rfc``     | CNAME must not be at zone root           |
-+------------------------+------------------------------------------+
-| ``alias-root``         | ALIAS must not be at zone root           |
-+------------------------+------------------------------------------+
-| ``ip-value-rfc``       | A / AAAA value format                    |
-+------------------------+------------------------------------------+
-| ``target-value-rfc``   | CNAME/ALIAS/DNAME/PTR target format      |
-+------------------------+------------------------------------------+
-| ``targets-value-rfc``  | NS targets format                        |
-+------------------------+------------------------------------------+
-| ``loc-value-rfc``      | LOC rdata format (RFC 1876)              |
-+------------------------+------------------------------------------+
-| ``chunked-value-rfc``  | TXT/SPF chunk encoding                   |
-+------------------------+------------------------------------------+
-| ``svcb-value-rfc``     | SVCB rdata format (RFC 9460)             |
-+------------------------+------------------------------------------+
-| ``https-value-rfc``    | HTTPS rdata format (RFC 9460)            |
-+------------------------+------------------------------------------+
-| ``openpgpkey-value-rfc``| OPENPGPKEY rdata format (RFC 7929)      |
-+------------------------+------------------------------------------+
-| ``dynamic``            | Dynamic routing config (pools and rules) |
-+------------------------+------------------------------------------+
-| ``urlfwd-value``       | URLFWD rdata format                      |
-+------------------------+------------------------------------------+
-| ``cname-coexistence``  | CNAME and ALIAS cannot coexist with      |
-|                        | other records                            |
-+------------------------+------------------------------------------+
++--------------------------+------------------------------------------+
+| id                       | description                              |
++==========================+==========================================+
+| ``name-rfc``             | Record name format (RFC 1035/2181)       |
++--------------------------+------------------------------------------+
+| ``ttl-rfc``              | TTL range (positive integer)             |
++--------------------------+------------------------------------------+
+| ``healthcheck``          | octoDNS healthcheck config fields        |
++--------------------------+------------------------------------------+
+| ``cname-root-rfc``       | CNAME must not be at zone root           |
++--------------------------+------------------------------------------+
+| ``alias-root``           | ALIAS must not be at zone root           |
++--------------------------+------------------------------------------+
+| ``ip-value-rfc``         | A / AAAA value format                    |
++--------------------------+------------------------------------------+
+| ``target-value-rfc``     | CNAME/ALIAS/DNAME/PTR target format      |
++--------------------------+------------------------------------------+
+| ``targets-value-rfc``    | NS targets format                        |
++--------------------------+------------------------------------------+
+| ``loc-value-rfc``        | LOC rdata format (RFC 1876)              |
++--------------------------+------------------------------------------+
+| ``chunked-value-rfc``    | TXT/SPF chunk encoding                   |
++--------------------------+------------------------------------------+
+| ``svcb-value-rfc``       | SVCB rdata format (RFC 9460)             |
++--------------------------+------------------------------------------+
+| ``https-value-rfc``      | HTTPS rdata format (RFC 9460)            |
++--------------------------+------------------------------------------+
+| ``openpgpkey-value-rfc`` | OPENPGPKEY rdata format (RFC 7929)       |
++--------------------------+------------------------------------------+
+| ``dynamic``              | Dynamic routing config (pools and rules) |
++--------------------------+------------------------------------------+
+| ``urlfwd-value``         | URLFWD rdata format                      |
++--------------------------+------------------------------------------+
+| ``cname-coexistence``    | CNAME and ALIAS cannot coexist with      |
+|                          | other records                            |
++--------------------------+------------------------------------------+
 
 Validators active in ``legacy`` only (will be superseded in ``strict``):
 
@@ -376,6 +376,7 @@ Validators active in ``best-practice`` only:
 +---------------------------------------+-----------------------------------------------+
 | ``cname-target-resolvable-in-zone``   | In-zone CNAME targets must be resolvable      |
 +---------------------------------------+-----------------------------------------------+
+
 Validators active in ``best-practice`` only that check the entire zone:
 
 +----------------------------------+-----------------------------------------------+

--- a/octodns/zone/validator.py
+++ b/octodns/zone/validator.py
@@ -7,7 +7,11 @@ from logging import getLogger
 from ..record.validator import ValidationReason
 from .exception import ZoneException
 
-__all__ = ['ValidationReason', 'ZoneValidator', 'ZoneValidatorRegistry']
+# back-compat re-export, ValidationReason lived here before moving to
+# octodns.record.validator. No __all__ here (on purpose) so autodoc documents
+# it once, at its new home, rather than duplicating it on this module's page
+# too.
+ValidationReason
 
 
 class ZoneValidatorRegistry:

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -12,6 +12,6 @@ if [ -z "$BUILDER" ]; then
 fi
 
 build="_build/${BUILDER}"
-rm -rf "$build" api/records/ api/processors/
+rm -rf "$build" api/cmds/ api/helpers/ api/processors/ api/providers/ api/records/ api/secrets/ api/sources/ api/validators/
 
 sphinx-build --builder "$BUILDER" --conf-dir . --fail-on-warning "$@" "." "$build"


### PR DESCRIPTION
## Summary

`./script/generate-docs` (which passes `--fail-on-warning`) currently fails with 55
warnings against the pinned Sphinx 9.1.0 / docutils 0.22.4 toolchain. Nothing in CI
actually runs the docs build, so this regression went unnoticed on `main`.

- **51x** `more than one target found for cross-reference 'ValidationReason'` — the
  back-compat re-export in `octodns/zone/validator.py` was listed in `__all__`, which made
  autodoc document `ValidationReason` a second time on that module's page (its `__module__`
  skip-check only applies when a module has no `__all__`). Dropped `__all__` and switched
  to a bare-name re-export (same idiom already used in `octodns/zone/__init__.py`) so the
  class is documented once, at its real home (`octodns.record.validator`).
  `from octodns.zone.validator import ValidationReason` and `import *` both keep working.
- **2x** `[autosummary] failed to import octodns.zone.subzone` — that module was deleted in
  #1427 (`e464aac2`) but the docs listing in `docs/api/validators.rst` was never updated.
  Removed the stale entry.
- **1x** `Inline literal start-string without end-string` — a table row in
  `docs/configuration.rst` (`openpgpkey-value-rfc`) overflowed its column, clipping the
  closing double-backtick. Widened the column.
- **1x** `Blank line required after table` — missing blank line after a table in the same
  file. Added it.
- Extended `script/generate-docs`'s cleanup to remove all 8 gitignored generated API stub
  dirs (it previously only cleaned 2 of them), so a deleted module can't leave a stale
  generated `.rst` behind and mask exactly the kind of drift in the `subzone` case above.
- Added a `docs` job to `.github/workflows/main.yml` that bootstraps and runs
  `./script/generate-docs` on PRs, so a future docs regression fails the build instead of
  going unnoticed.

/cc #1427 removed `octodns/zone/subzone.py`, leaving the stale docs entry this PR cleans up

## Test plan

- [x] `./script/generate-docs` → `build succeeded.` with zero warnings
- [x] Confirmed `ValidationReason` back-compat import and `import *` still work
- [x] Confirmed `ValidationReason` renders on the `octodns.record.validator` docs page and
      no longer has a duplicate entry on `octodns.zone.validator`'s page
- [x] Confirmed the fixed table renders correctly in `configuration.html`
- [x] `./script/lint`, `./script/format --check`, `./script/test`, `./script/coverage` all
      pass (100% coverage maintained)