### PR TITLE
Version 1.21.1 bump & changelog update

### DIFF
--- a/.changelog/4894bc8785d846b19681fd9557eb96f3.md
+++ b/.changelog/4894bc8785d846b19681fd9557eb96f3.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix OwnershipProcessor dropping changes to records whose type contains lower-case letters, e.g. octodns-route53's Route53Provider/ALIAS - #1455

--- a/.changelog/738bd92f908d4622bdb69f5b45195fac.md
+++ b/.changelog/738bd92f908d4622bdb69f5b45195fac.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix script/ tooling to work correctly in git worktrees

--- a/.changelog/8609e000ae4949e898462db3d76112b0.md
+++ b/.changelog/8609e000ae4949e898462db3d76112b0.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix Sphinx docs build warnings and add a CI job to catch future regressions

--- a/.changelog/99a48a5437164368846360c57759b8d0.md
+++ b/.changelog/99a48a5437164368846360c57759b8d0.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Modernize packaging: move build metadata from setup.py into pyproject.toml's [project] table, remove setup.py

--- a/.changelog/c5ca474fdffc45f0bac3bf2515963ab6.md
+++ b/.changelog/c5ca474fdffc45f0bac3bf2515963ab6.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix CaaValue.rdata_text to quote the value field per RFC 8659, matching NAPTR/URI - #1447

--- a/.changelog/dc67c65124e74bdc97704d4661adfb41.md
+++ b/.changelog/dc67c65124e74bdc97704d4661adfb41.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix cibuild-module to recognize PEP 621 (pyproject.toml [project] table) provider modules, not just setup.py and poetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.21.1 - 2026-08-01
+
+Patch:
+* Fix OwnershipProcessor dropping changes to records whose type contains lower-case letters, e.g. octodns-route53's Route53Provider/ALIAS - #1455 - [#1456](https://github.com/octodns/octodns/pull/1456)
+* Fix CaaValue.rdata_text to quote the value field per RFC 8659, matching NAPTR/URI - #1447 - [#1449](https://github.com/octodns/octodns/pull/1449)
+
 ## 1.21.0 - 2026-07-08
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.21.0'
+__version__ = __VERSION__ = '1.21.1'


### PR DESCRIPTION
## 1.21.1 - 2026-08-01

Patch:
* Fix OwnershipProcessor dropping changes to records whose type contains lower-case letters, e.g. octodns-route53's Route53Provider/ALIAS - #1455 - [#1456](https://github.com/octodns/octodns/pull/1456)
* Fix CaaValue.rdata_text to quote the value field per RFC 8659, matching NAPTR/URI - #1447 - [#1449](https://github.com/octodns/octodns/pull/1449)

